### PR TITLE
feat: add cyclic screen casting toggle for Niri

### DIFF
--- a/modules/bar/UtilButtons.qml
+++ b/modules/bar/UtilButtons.qml
@@ -177,10 +177,18 @@ Item {
                     if (isCasting) {
                         // Stop casting to the monitor
                         Quickshell.execDetached(["niri", "msg", "action", "clear-dynamic-cast-target"])
+
+                        // Send notification with "video off" icon
+                        Quickshell.execDetached(["notify-send", "-i", "camera-video-off", "Screen Casting", "Casting stopped"])
+
                         isCasting = false
                     } else {
                         // Start casting to HDMI-A-1
                         Quickshell.execDetached(["niri", "msg", "action", "set-dynamic-cast-monitor", "HDMI-A-1"])
+
+                        // Send notification with "display" icon
+                        Quickshell.execDetached(["notify-send", "-i", "video-display", "Screen Casting", "Casting started on HDMI-A-1"])
+
                         isCasting = true
                     }
                 }


### PR DESCRIPTION
### This pull request introduces a new functionality to the UtilButtons module, allowing users to quickly toggle screen casting to a specific monitor (HDMI-A-1) via the top bar.

### **Changes:**

- Replaced the placeholder screen record logic with a functional cyclic toggle button.
- Implemented niri msg action set-dynamic-cast-monitor HDMI-A-1 for activation and clear-dynamic-cast-target for deactivation.
- Added a local isCasting property to ensure the toggle works independently of Pipewire link states.

### **UI/UX Improvements:**

- Visual Feedback: The button uses the visibility icon. When active, the icon becomes filled and turns red (using the theme's colError).
- Activity Indicator: Added a pulsating red dot in the upper-right corner of the button when casting is active, mirroring the existing microphone usage indicator for design consistency.
- Toggle Logic: Simple one-click activation and deactivation.

but it's work only with HDMI-A-1, beacause it is my ouput, you need edit You need to change the output parameter somehow. I don't know how to implement this, plus I created this feature by vaibecoding. use gemeni 