### PR TITLE
feat: add --set-default-shell option to set Fish as default shell

### DIFF
--- a/sdata/subcmd-install/3.files.sh
+++ b/sdata/subcmd-install/3.files.sh
@@ -275,6 +275,25 @@ if [[ -d "dots/.config/fish" ]]; then
     fi
   done
   log_success "Fish shell config installed"
+
+  # Set Fish as default shell if requested
+  if [[ "${INIR_SET_DEFAULT_SHELL:-}" == "true" ]]; then
+    if command -v chsh &>/dev/null; then
+      local fish_path
+      fish_path=$(command -v fish 2>/dev/null)
+      if [[ -n "$fish_path" ]] && [[ -x "$fish_path" ]]; then
+        if chsh -s "$fish_path" 2>/dev/null; then
+          log_success "Default shell set to Fish ($fish_path)"
+        else
+          log_warning "Could not set default shell (may require password)"
+        fi
+      else
+        log_warning "Fish shell not found in PATH"
+      fi
+    else
+      log_warning "chsh not available - cannot set default shell"
+    fi
+  fi
 fi
 
 # Foot terminal config

--- a/sdata/subcmd-install/options.sh
+++ b/sdata/subcmd-install/options.sh
@@ -24,6 +24,7 @@ Options:
   --no-toolkit        Skip toolkit dependencies (ydotool, backlight)
   --no-screencapture  Skip screenshot/recording tools
   --no-fonts          Skip fonts and theming tools
+  --set-default-shell Set Fish as the default shell (uses chsh)
   -h, --help          Show this help
 
 Examples:
@@ -53,6 +54,7 @@ INSTALL_AUDIO=true
 INSTALL_TOOLKIT=true
 INSTALL_SCREENCAPTURE=true
 INSTALL_FONTS=true
+SET_DEFAULT_SHELL=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -115,6 +117,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-fonts)
       INSTALL_FONTS=false
+      shift
+      ;;
+    --set-default-shell)
+      SET_DEFAULT_SHELL=true
       shift
       ;;
     -h|--help)

--- a/setup
+++ b/setup
@@ -78,9 +78,10 @@ show_help() {
     echo ""
 
     tui_subtitle "Options"
-    tui_list_item "-y, --yes     Skip prompts (auto-yes)"
-    tui_list_item "-q, --quiet   Minimal output"
-    tui_list_item "-h, --help    Show this help"
+    tui_list_item "-y, --yes              Skip prompts (auto-yes)"
+    tui_list_item "-q, --quiet            Minimal output"
+    tui_list_item "--set-default-shell    Set Fish as default shell (uses chsh)"
+    tui_list_item "-h, --help             Show this help"
     echo ""
 
     tui_subtitle "Examples"
@@ -815,6 +816,7 @@ while [[ $# -gt 0 ]]; do
         status) COMMAND="status"; shift ;;
         -y|--yes) ask=false; shift ;;
         -q|--quiet) quiet=true; shift ;;
+        --set-default-shell) export INIR_SET_DEFAULT_SHELL=true; shift ;;
         -h|--help) show_help; exit 0 ;;
         *) echo "Unknown: $1"; show_help; exit 1 ;;
     esac


### PR DESCRIPTION
## Summary

Add a --set-default-shell flag to the setup install command that automatically sets Fish as the default shell using chsh.

## Motivation

On fresh machine installations, even though Fish shell is installed as a dependency, it is not set as the default shell. Users who want Fish as their default shell must manually run chsh -s /usr/bin/fish, which is an extra step that could be automated.

This resolves issue #64.

## Testing

1. Run ./setup install --set-default-shell on a fresh system
2. Verify Fish is set as default shell: echo $SHELL
3. Run ./setup install -y --set-default-shell in non-interactive mode

## Checklist

- [x] Tested on Niri
- [x] Shell restarted after changes

## Related

Closes #64