### PR TITLE
fix(colors): fix fish autosuggestion contrast in dark/light mode

### DIFF
--- a/scripts/colors/generate_colors_material.py
+++ b/scripts/colors/generate_colors_material.py
@@ -302,9 +302,12 @@ if args.termscheme is not None:
             term_colors[color] = material_colors.get("onSurface", "#e0e0e0")
             continue
         
-        # Bright background (term8): Slightly brighter than term0
+        # term8: autosuggestion color — needs contrast against term0
         if color == "term8":
-            term_colors[color] = get_interpolated_surface(min(1.0, user_bg_brightness + 0.15))
+            if darkmode:
+                term_colors[color] = material_colors.get("outline", get_interpolated_surface(min(1.0, user_bg_brightness + 0.45)))
+            else:
+                term_colors[color] = material_colors.get("outline_variant", material_colors.get("outlineVariant", get_interpolated_surface(max(0.0, user_bg_brightness - 0.45))))
             continue
             
         if color == "term7":


### PR DESCRIPTION
## Summary

`term8` — the terminal palette color fish uses for autosuggestions — was set to a surface color only 0.15 steps above the background in both dark and light mode, giving it near-zero contrast. This replaces that with Material You `outline`/`outlineVariant` tokens that are designed to be readable against their respective surface backgrounds.

## Motivation

In dark mode the autosuggestion text was nearly invisible (dark color on dark background). In light mode it was washed out (light color on light background). The root cause was `term8` being derived purely from `get_interpolated_surface(user_bg_brightness + 0.15)` regardless of mode — a 0.15 surface jump is far too small to produce legible contrast in either direction.

before 
<img width="211" height="194" alt="image" src="https://github.com/user-attachments/assets/205cf8a4-26d3-4f5b-a7c6-d3eec9564c80" />

after 
<img width="211" height="211" alt="image" src="https://github.com/user-attachments/assets/e0f738b2-9702-49d8-bd7c-76b1ba8a7bcf" />


## Testing

Steps to verify this works:

1. Apply a wallpaper in **dark mode** (`switchwall.sh --mode dark <image>`) and open a fish shell — type a partial command and confirm the autosuggestion is visibly readable
2. Switch to **light mode** (`switchwall.sh --mode light <image>`) and repeat — confirm the autosuggestion is visibly darker than the background and readable
3. Check both a warm-hued and cool-hued wallpaper to confirm the `outline`/`outlineVariant` tokens harmonize correctly with the accent

## Checklist

- [x] Tested on Niri (or Hyprland if applicable)
- [x] Tested both ii and waffle families for UI changes
- [x] Tested material, aurora, and inir styles for ii changes
- [x] No hardcoded values (colors, fonts, durations use design tokens)
- [x] Config changes synced in Config.qml and defaults/config.json
- [x] Config access uses optional chaining: Config.options?.section?.option ?? default
- [x] IPC functions have explicit return types (: void, : string, etc.)
- [x] Shell restarted after changes: qs kill -c ii; qs -c ii
- [x] Logs checked for errors: qs log -c ii | tail -50
- [x] Lazy-loaded components tested (Settings, overlays)
- [x] No console errors or warnings

## Related

Closes #
Fixes #