### PR TITLE
fix: fixed width size android quick panel

### DIFF
--- a/modules/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/modules/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -22,7 +22,7 @@ AbstractQuickPanel {
     property real spacing: 6
     property real padding: 6
     readonly property real baseCellWidth: {
-        const availableWidth = root.width - (root.padding * 2) - (root.spacing * (root.columns - 1))
+        const availableWidth = root.width - (root.padding * 2) - (root.spacing * root.columns)
         return availableWidth / root.columns
     }
     readonly property real baseCellHeight: 56


### PR DESCRIPTION
<img width="441" height="438" alt="изображение" src="https://github.com/user-attachments/assets/9a785018-9667-46d4-a457-54572b6e80ac" />

fixed

<img width="440" height="382" alt="изображение" src="https://github.com/user-attachments/assets/f9adb9fb-3977-4fc0-8bc9-4330dd777c16" />
