### PR TITLE
[Fix] Fix wrong display of Battery Info in Overview 

### DIFF
--- a/modules/overview/OverviewDashboard.qml
+++ b/modules/overview/OverviewDashboard.qml
@@ -1166,20 +1166,20 @@ Item {
 
                             MaterialSymbol {
                                 text: Battery.isCharging ? "battery_charging_full"
-                                    : Battery.percentage > 80 ? "battery_full"
-                                    : Battery.percentage > 60 ? "battery_5_bar"
-                                    : Battery.percentage > 40 ? "battery_3_bar"
-                                    : Battery.percentage > 20 ? "battery_2_bar" : "battery_1_bar"
+                                    : (Battery.percentage * 100) > 80 ? "battery_full"
+                                    : (Battery.percentage * 100) > 60 ? "battery_5_bar"
+                                    : (Battery.percentage * 100) > 40 ? "battery_3_bar"
+                                    : (Battery.percentage * 100) > 20 ? "battery_2_bar" : "battery_1_bar"
                                 iconSize: 14
                                 fill: 1
-                                color: Battery.percentage <= 20 && !Battery.isCharging ? Appearance.m3colors.m3error
+                                color: (Battery.percentage * 100) <= 20 && !Battery.isCharging ? Appearance.m3colors.m3error
                                     : Battery.isCharging ? Appearance.colors.colTertiary
                                     : root.colSubtext
                             }
                             StyledText {
                                 text: Battery.percentage + "%"
                                 font { pixelSize: Appearance.font.pixelSize.smallest; family: Appearance.font.family.numbers; weight: Font.Medium }
-                                color: Battery.percentage <= 20 && !Battery.isCharging ? Appearance.m3colors.m3error
+                                color: (Battery.percentage * 100) <= 20 && !Battery.isCharging ? Appearance.m3colors.m3error
                                     : Battery.isCharging ? Appearance.colors.colTertiary
                                     : root.colSubtext
                             }


### PR DESCRIPTION
## Summary
- Fixes the following bugs in **dashboard** panel in **overview** module.
    - Battery percentage displayed in 1/100 increments. (it showed `0.86`% instead of `86`%)
    - Both battery text and icon were always in the `alert` color and `low_battery` icon.

|||
|:---:|:---:|
|Before|Fixed|
|<img width="400" height="70" alt="ss-20260312-001325" src="https://github.com/user-attachments/assets/2e2720db-29d1-4a17-94a4-d87d9f7a705b" />|<img width="401" height="59" alt="ss-20260312-002158" src="https://github.com/user-attachments/assets/990c3031-03de-4051-aa6c-8bab52c2937b" />|