### PR TITLE
feat: Tab mode for the stack

### DIFF
--- a/defaults/niri/config.kdl
+++ b/defaults/niri/config.kdl
@@ -279,7 +279,18 @@ binds {
     Mod+J { focus-window-down; }
     Mod+K { focus-window-up; }
     Mod+L { focus-column-right; }
+   
+    Mod+Comma  { consume-or-expel-window-left; }
+    Mod+Period { consume-or-expel-window-right; }
+
+    Mod+Ctrl+Down { expel-window-from-column; }
+    Mod+Minus     { set-column-width "-10%"; }
+    Mod+Equal     { set-column-width "+10%"; }
+    Mod+Alt+Minus { set-window-height "-10%"; }
+    Mod+Alt+Equal { set-window-height "+10%"; }
     
+    Mod+U { toggle-column-tabbed-display; }
+
     // Move windows
     Mod+Shift+Left { move-column-left; }
     Mod+Shift+Right { move-column-right; }


### PR DESCRIPTION
## Summary

* Implemented window stacking and column management via `consume-or-expel` commands.
* Added dedicated keybinds for dynamic column resizing and vertical window movement within stacks.

## Motivation

This change improves workspace ergonomics by enabling a fully keyboard-driven window organization workflow. It allows the user to quickly group related windows into stacks (columns) without breaking focus or using a mouse, which is essential for deep work sessions.

## Testing

Verified on Niri 25.11:
1. Ran `niri validate` — no configuration errors found.
2. Tested `Mod+Comma` / `Mod+Period` for `consume-or-expel` functionality across multiple columns.
3. Verified `Mod+U` for `tabbed-display` toggle.

## Checklist

- [x] Tested on Niri (or Hyprland if applicable)
- [ ] Tested both ii and waffle families for UI changes
- [ ] Tested material, aurora, and inir styles for ii changes
- [x] No hardcoded values (colors, fonts, durations use design tokens)
- [ ] Config changes synced in Config.qml and defaults/config.json
- [ ] Config access uses optional chaining: Config.options?.section?.option ?? default
- [ ] IPC functions have explicit return types (: void, : string, etc.)
- [x] Shell restarted after changes: qs kill -c ii; qs -c ii
- [x] Logs checked for errors: qs log -c ii | tail -50
- [ ] Lazy-loaded components tested (Settings, overlays)
- [x] No console errors or warnings


## Related

Closes #
Fixes #