### PR TITLE
feat(ytmusic): notify upcoming track on auto-advance

### DIFF
--- a/modules/settings/InterfaceConfig.qml
+++ b/modules/settings/InterfaceConfig.qml
@@ -881,6 +881,33 @@ ContentPage {
             }
 
             ContentSubsection {
+                title: Translation.tr("YT Music")
+                tooltip: Translation.tr("Control how next-track notifications behave")
+                visible: Config.options.sidebar?.ytmusic?.enable ?? false
+
+                SettingsSwitch {
+                    buttonIcon: "music_note"
+                    text: Translation.tr("Up Next notifications")
+                    checked: Config.options.sidebar?.ytmusic?.upNextNotifications ?? true
+                    onCheckedChanged: Config.setNestedValue("sidebar.ytmusic.upNextNotifications", checked)
+                    StyledToolTip {
+                        text: Translation.tr("Show a desktop notification with the upcoming track when playback auto-advances")
+                    }
+                }
+
+                SettingsSwitch {
+                    buttonIcon: "sports_esports"
+                    text: Translation.tr("Mute while fullscreen or GameMode")
+                    enabled: Config.options.sidebar?.ytmusic?.upNextNotifications ?? true
+                    checked: Config.options.sidebar?.ytmusic?.suppressUpNextInFullscreen ?? true
+                    onCheckedChanged: Config.setNestedValue("sidebar.ytmusic.suppressUpNextInFullscreen", checked)
+                    StyledToolTip {
+                        text: Translation.tr("Suppress Up Next notifications when a fullscreen app is active or GameMode is enabled")
+                    }
+                }
+            }
+
+            ContentSubsection {
                 id: rightSidebarWidgets
                 title: Translation.tr("Right Sidebar")
                 tooltip: Translation.tr("Toggle which widgets appear in the right sidebar")

--- a/services/YtMusic.qml
+++ b/services/YtMusic.qml
@@ -252,7 +252,7 @@ Singleton {
             // Also guard against stale EOF from old mpv when user initiated a new play.
             if (root._ipcEofReached && !root._autoAdvanceTriggered && !root._userInitiatedPlay && root.currentVideoId !== "") {
                 root._autoAdvanceTriggered = true
-                root.playNext()
+                root.playNext(true)
             }
         }
     }
@@ -493,7 +493,26 @@ Singleton {
         root.repeatMode = (root.repeatMode + 1) % 3
     }
 
-    function playNext(): void {
+    function _notifyUpcomingTrack(item): void {
+        if (!item) return
+        if (Config.options?.notifications?.silent ?? false) return
+
+        const title = String(item.title ?? "").trim()
+        if (!title) return
+        const artist = String(item.artist ?? "").trim()
+        const body = artist.length > 0 ? `${title} - ${artist}` : title
+
+        Quickshell.execDetached([
+            "/usr/bin/notify-send",
+            Translation.tr("Up Next"),
+            body,
+            "-a", "YtMusic",
+            "-i", "audio-x-generic"
+        ])
+    }
+
+    function playNext(notifyUpcoming): void {
+        notifyUpcoming = (notifyUpcoming === true)
         root._log("[YtMusic] playNext called. activePlaylist.length=" + activePlaylist.length + " currentIndex=" + currentIndex + " source=" + activePlaylistSource)
         
         if (root.repeatMode === 1 && root.currentVideoId) {
@@ -513,6 +532,8 @@ Singleton {
             
             if (nextIndex >= root.activePlaylist.length) {
                 if (root.queue.length > 0) {
+                    if (notifyUpcoming)
+                        root._notifyUpcomingTrack(root.queue[0])
                     playFromQueue(0)
                     return
                 }
@@ -523,12 +544,17 @@ Singleton {
                 }
             }
             
+            const nextItem = root.activePlaylist[nextIndex]
+            if (notifyUpcoming)
+                root._notifyUpcomingTrack(nextItem)
             root.currentIndex = nextIndex
-            _playInternal(root.activePlaylist[nextIndex])
+            _playInternal(nextItem)
             return
         }
         
         if (root.queue.length > 0) {
+            if (notifyUpcoming)
+                root._notifyUpcomingTrack(root.queue[0])
             playFromQueue(0)
         }
     }
@@ -1694,7 +1720,7 @@ print("")
             if (root._didTrackEndNaturally(code, _stderr) && !root._autoAdvanceTriggered) {
                 // Track ended naturally, advance according to playlist/queue/repeat state
                 root._autoAdvanceTriggered = true
-                root.playNext()
+                root.playNext(true)
             } else if (code !== 0 && code !== 4 && code !== 9 && code !== 15 && code !== 143 && code !== 137) {
                 root.error = Translation.tr("Playback failed")
             }

--- a/services/YtMusic.qml
+++ b/services/YtMusic.qml
@@ -34,6 +34,8 @@ Singleton {
     
     property bool shuffleMode: Config.options?.sidebar?.ytmusic?.shuffleMode ?? false
     property int repeatMode: Config.options?.sidebar?.ytmusic?.repeatMode ?? 0
+    readonly property bool upNextNotificationsEnabled: Config.options?.sidebar?.ytmusic?.upNextNotifications ?? true
+    readonly property bool suppressUpNextInFullscreen: Config.options?.sidebar?.ytmusic?.suppressUpNextInFullscreen ?? true
     
     onShuffleModeChanged: Config.setNestedValue('sidebar.ytmusic.shuffleMode', shuffleMode)
     onRepeatModeChanged: Config.setNestedValue('sidebar.ytmusic.repeatMode', repeatMode)
@@ -493,9 +495,16 @@ Singleton {
         root.repeatMode = (root.repeatMode + 1) % 3
     }
 
+    function _shouldNotifyUpcomingTrack(): bool {
+        if (!root.upNextNotificationsEnabled) return false
+        if (Config.options?.notifications?.silent ?? false) return false
+        if (root.suppressUpNextInFullscreen && (GameMode.active || GameMode.hasAnyFullscreenWindow)) return false
+        return true
+    }
+
     function _notifyUpcomingTrack(item): void {
         if (!item) return
-        if (Config.options?.notifications?.silent ?? false) return
+        if (!root._shouldNotifyUpcomingTrack()) return
 
         const title = String(item.title ?? "").trim()
         if (!title) return

--- a/settings.qml
+++ b/settings.qml
@@ -798,6 +798,20 @@ ApplicationWindow {
         },
         {
             pageIndex: 5, pageName: pages[5].name,
+            section: Translation.tr("Sidebars"),
+            label: Translation.tr("YT Music Up Next notifications"),
+            description: Translation.tr("Enable or disable next-track notifications for YT Music auto-advance"),
+            keywords: ["ytmusic", "youtube", "music", "up next", "notification", "auto", "advance"]
+        },
+        {
+            pageIndex: 5, pageName: pages[5].name,
+            section: Translation.tr("Sidebars"),
+            label: Translation.tr("YT Music fullscreen suppression"),
+            description: Translation.tr("Mute YT Music Up Next notifications during fullscreen apps or GameMode"),
+            keywords: ["ytmusic", "fullscreen", "gamemode", "mute", "suppress", "notification", "gaming"]
+        },
+        {
+            pageIndex: 5, pageName: pages[5].name,
             section: Translation.tr("On-screen display"),
             label: Translation.tr("OSD timeout"),
             description: Translation.tr("How long the volume/brightness OSD stays visible"),


### PR DESCRIPTION
## Summary
- show an `Up Next` notification when YtMusic auto-advances to the next track
- keep manual next/previous behavior unchanged

## Details
- add `_notifyUpcomingTrack(item)` helper in `services/YtMusic.qml`
- update `playNext` to accept an optional notify flag
- call `playNext(true)` from EOF and natural track-end auto-advance paths

## Why
This adds useful playback context without changing core controls or queue logic.