### PR TITLE
awww build dependencies in fedora

### DIFF
--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -442,7 +442,7 @@ fi
 if ! command -v awww &>/dev/null; then
   log_info "Installing awww (wallpaper daemon)..."
   if command -v cargo &>/dev/null; then
-    sudo dnf install -y lz4 lz4-devel
+    sudo dnf install -y lz4-devel
     if cargo install --git https://codeberg.org/LGFae/awww.git awww 2>/dev/null; then
       log_success "awww installed via Cargo"
     else

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -442,13 +442,15 @@ fi
 if ! command -v awww &>/dev/null; then
   log_info "Installing awww (wallpaper daemon)..."
   if command -v cargo &>/dev/null; then
-    if cargo install --git https://codeberg.org/LGFae/awww.git 2>/dev/null; then
+    sudo dnf install -y lz4 lz4-devel
+    if cargo install --git https://codeberg.org/LGFae/awww.git awww 2>/dev/null; then
       log_success "awww installed via Cargo"
     else
-      log_warning "awww build failed — install manually: cargo install --git https://codeberg.org/LGFae/awww.git"
+      log_warning "awww build failed — install manually: cargo install --git https://codeberg.org/LGFae/awww.git awww"
     fi
   else
-    log_warning "awww requires Rust — install Rust first, then: cargo install --git https://codeberg.org/LGFae/awww.git"
+    log_warning "awww requires Rust — install Rust first, then: cargo install --git https://codeberg.org/LGFae/awww.git awww"
+    log_info "Installing Rust can be done through this command from the official website: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Awww building did not work because of missing lz4-devel and the command to build was incomplete.  Installed in a fedora 43 vm, works fine.

## Testing

- [x] `inir restart && inir logs` — no errors
- [x] Tested the specific feature path that changed
- [ ] Both panel families checked (if shared code changed)

## Notes

Closes #
