### PR TITLE
fix(shell): time format preferences consistency 

### DIFF
--- a/modules/lock/LockSurface.qml
+++ b/modules/lock/LockSurface.qml
@@ -238,7 +238,7 @@ MouseArea {
             Text {
                 id: clockText
                 Layout.alignment: Qt.AlignHCenter
-                text: Qt.formatTime(new Date(), "hh:mm")
+                text: DateTime.time
                 font.pixelSize: Math.round(108 * Appearance.fontSizeScale)
                 font.weight: Font.DemiBold
                 font.family: Appearance.font.family.appearance
@@ -251,13 +251,6 @@ MouseArea {
                     radius: 16
                     samples: 33
                     color: Qt.rgba(0, 0, 0, 0.5)
-                }
-                
-                Timer {
-                    interval: 1000
-                    running: true
-                    repeat: true
-                    onTriggered: clockText.text = Qt.formatTime(new Date(), "hh:mm")
                 }
             }
             

--- a/modules/sidebarLeft/widgets/GlanceHeader.qml
+++ b/modules/sidebarLeft/widgets/GlanceHeader.qml
@@ -29,7 +29,7 @@ Item {
             spacing: 8
 
             StyledText {
-                text: Qt.formatTime(DateTime.clock.date, "HH:mm")
+                text: DateTime.time
                 font.pixelSize: Appearance.font.pixelSize.huge * 2
                 font.weight: Font.Light
                 font.family: Appearance.font.family.numbers

--- a/modules/waffle/lock/WaffleLockSurface.qml
+++ b/modules/waffle/lock/WaffleLockSurface.qml
@@ -229,7 +229,7 @@ MouseArea {
             Text {
                 id: clockText
                 Layout.alignment: Qt.AlignHCenter
-                text: Qt.formatTime(new Date(), "hh:mm")
+                text: DateTime.time
                 font.pixelSize: root.clockFontSize
                 font.weight: Looks.font.weight.thin  // Light weight like Windows 11
                 font.family: Looks.font.family.ui
@@ -242,13 +242,6 @@ MouseArea {
                     radius: 8
                     samples: 17
                     color: root.textShadowColor
-                }
-                
-                Timer {
-                    interval: 1000
-                    running: true
-                    repeat: true
-                    onTriggered: clockText.text = Qt.formatTime(new Date(), "hh:mm")
                 }
             }
             

--- a/modules/waffle/lock/WaffleLockSurfaceSafe.qml
+++ b/modules/waffle/lock/WaffleLockSurfaceSafe.qml
@@ -328,18 +328,11 @@ MouseArea {
             Text {
                 id: clockText
                 Layout.alignment: Qt.AlignHCenter
-                text: Qt.formatTime(new Date(), "hh:mm")
+                text: DateTime.time
                 font.pixelSize: root.clockFontSize
                 font.weight: Looks.font.weight.thin
                 font.family: Looks.font.family.ui
                 color: root.textColor
-
-                Timer {
-                    interval: 1000
-                    running: true
-                    repeat: true
-                    onTriggered: clockText.text = Qt.formatTime(new Date(), "hh:mm")
-                }
             }
 
             Text {


### PR DESCRIPTION
## Summary

This fixes an issue where settings your clock format to be 12hr in the settings doesn't apply to the lockscreen clock and Left Sidebar.

https://github.com/user-attachments/assets/fcae60fc-d8ab-448e-b63a-1d969b023de4

## Testing

- [x] `inir restart && inir logs` — no errors
- [x] Tested the specific feature path that changed
- [x] Both panel families checked (if shared code changed)

## Notes

