### PR TITLE
fix: Make sure to use qt5compat because sddm uses qt6

### DIFF
--- a/dots/sddm/pixel/Main.qml
+++ b/dots/sddm/pixel/Main.qml
@@ -2,7 +2,7 @@
 // States: "clock" (initial) ↔ "login" (password entry), same layout + transitions.
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects 1.0
 import SddmComponents 2.0
 import "."
 


### PR DESCRIPTION
## Summary

SDDM fix (theme overall not working due to GraphicalEffects being a qt5 library)

## Testing

- [x] `sddm-greeter-qt6 --test-mode --theme /usr/share/sddm/themes/ii-pixel/` theme works
- [x] rebooted several times, theme and login works
