### PR TITLE
Updating fedora install scripts and sddm config scripts

### DIFF
--- a/dots/sddm/pixel/Main.qml
+++ b/dots/sddm/pixel/Main.qml
@@ -2,8 +2,7 @@
 // States: "clock" (initial) ↔ "login" (password entry), same layout + transitions.
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-//import QtGraphicalEffects 1.0
-import Qt5Compat.GraphicalEffects 1.0
+import QtGraphicalEffects 1.0
 import SddmComponents 2.0
 import "."
 

--- a/dots/sddm/pixel/Main.qml
+++ b/dots/sddm/pixel/Main.qml
@@ -2,7 +2,8 @@
 // States: "clock" (initial) ↔ "login" (password entry), same layout + transitions.
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+//import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects 1.0
 import SddmComponents 2.0
 import "."
 

--- a/scripts/sddm/install-pixel-sddm.sh
+++ b/scripts/sddm/install-pixel-sddm.sh
@@ -10,7 +10,13 @@ THEME_SRC="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}/dot
 THEME_DIR="/usr/share/sddm/themes/${THEME_NAME}"
 SYNC_SCRIPT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}/scripts/sddm/sync-pixel-sddm.py"
 SDDM_CONF="/etc/sddm.conf.d/inir-theme.conf"
+WESTON_CONF="/etc/xdg/weston/weston.ini"
+SDDM_DISPLAY_SERVER="x11"
 AUTO_APPLY_MODE="${INIR_SDDM_AUTO_APPLY:-ask}" # ask|yes|no
+
+if grep -qi fedora /etc/os-release; then
+    SDDM_DISPLAY_SERVER="wayland"
+fi
 
 log_info() { echo -e "\033[0;36m[sddm] $*\033[0m"; }
 log_ok()   { echo -e "\033[0;32m[sddm] ✓ $*\033[0m"; }
@@ -178,12 +184,22 @@ if should_apply_theme; then
     # Use X11 as display server - Wayland (kwin_wayland) crashes in some environments (VMs, etc.)
     elevate tee "${SDDM_CONF}" > /dev/null << SDDM_EOF
 [General]
-DisplayServer=wayland
+DisplayServer=${SDDM_DISPLAY_SERVER}
 
 [Theme]
 Current=${THEME_NAME}
 SDDM_EOF
-    log_ok "SDDM configured (${SDDM_CONF}) with X11 display server"
+
+    if grep -qi fedora /etc/os-release && command -v weston > /dev/null 2>&1; then
+
+        elevate mkdir -p /etc/xdg/weston
+        # Enable tap on touchpads (weston)
+        elevate tee "${WESTON_CONF}" > /dev/null << WESTON_EOF
+[libinput]
+enable-tap=true
+WESTON_EOF
+    fi
+    log_ok "SDDM configured (${SDDM_CONF}) with ${SDDM_DISPLAY_SERVER} display server"
 else
     log_info "Installed ${THEME_NAME}, but did not change SDDM Current theme"
 fi

--- a/scripts/sddm/install-pixel-sddm.sh
+++ b/scripts/sddm/install-pixel-sddm.sh
@@ -178,7 +178,7 @@ if should_apply_theme; then
     # Use X11 as display server - Wayland (kwin_wayland) crashes in some environments (VMs, etc.)
     elevate tee "${SDDM_CONF}" > /dev/null << SDDM_EOF
 [General]
-DisplayServer=x11
+DisplayServer=wayland
 
 [Theme]
 Current=${THEME_NAME}

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -150,6 +150,20 @@ if ! rpm -q rpmfusion-nonfree-release &>/dev/null; then
 fi
 
 #####################################################################################
+# Install flatpak if it doesn't exist
+#####################################################################################
+tui_info "Configuring flatpak, if not present (Usually present in fedora workstation)"
+if ! command -v flatpak >/dev/null 2>&1; then
+    v sudo dnf install -y flatpak flatpak-libs
+fi
+log_info "Flatpak is installed"
+
+if ! flatpak remote-list | grep -q "^flathub"; then
+  flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+fi
+log_info "Flathub repository configured"
+
+#####################################################################################
 # Install official repository packages
 #####################################################################################
 tui_info "Installing packages from repositories..."
@@ -231,7 +245,9 @@ FEDORA_CORE_PKGS=(
   # Translation
   translate-shell
 )
-
+FEDORA_FLATPAKS={
+  io.missioncenter.MissionCenter
+}
 # Qt6 packages
 FEDORA_QT6_PKGS=(
   qt6-qtbase
@@ -369,6 +385,9 @@ v sudo dnf install $installflags "${FEDORA_QT6_PKGS[@]}"
 
 log_info "Installing Qt6 packages (2)..."
 v sudo dnf install --setopt=install_weak_deps=False "${FEDORA_QT_PKGS_2[@]}"
+
+log_info "Installing flatpaks..."
+v flatpak install flathub ${FEDORA_FLATPAKS[@]} -y"
 
 # Install based on flags
 if ${INSTALL_AUDIO:-true}; then

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -335,20 +335,23 @@ $ask || installflags="-y --skip-unavailable"
 # If noctalia-qs present, replace with quickshell
 # If quickshell-git present, proceed normally
 #####################################################################################
-
+$QS_INSTALL=false
 if rpm -q noctalia-qs &>/dev/null; then
   log_info "noctalia-qs present. iNir needs quickshell (preferable) or quickshell-git. Removing?"
   if ! sudo dnf remove noctalia-qs; then
     log_warning "noctalia-qs not removed. There may be problems with running iNir with noctalia-qs"
   else
-    v sudo dnf install quickshell -y
+    $QS_INSTALL=true
   fi
 fi
 if ! rpm -q quickshell-git &>/dev/null; then
-  v sudo dnf install quickshell -y
+  $QS_INSTALL=true
 fi
 # Install core packages. Need weak deps, in case dnf is configured to always ignore weak deps.
 log_info "Installing core packages (Quickshell + Niri)..."
+if $QS_INSTALL; then
+  v sudo dnf install quickshell -y
+fi
 v sudo dnf install --setopt=install_weak_deps=True $installflags "${FEDORA_CORE_PKGS[@]}"
 
 # Install Qt6 packages

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -479,10 +479,10 @@ if ! command -v awww &>/dev/null; then
     if cargo install --git https://codeberg.org/LGFae/awww.git awww-daemon awww 2>/dev/null; then
       log_success "awww installed via Cargo"
     else
-      log_warning "awww build failed — install manually: cargo install --git https://codeberg.org/LGFae/awww.git awww"
+      log_warning "awww build failed — install manually: cargo install --git https://codeberg.org/LGFae/awww.git awww awww-daemon"
     fi
   else
-    log_warning "awww requires Rust — install Rust first, then: cargo install --git https://codeberg.org/LGFae/awww.git awww"
+    log_warning "awww requires Rust — install Rust first, then: cargo install --git https://codeberg.org/LGFae/awww.git awww awww-daemon"
     log_info "Installing Rust can be done through this command from the official website: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
   fi
 fi

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -265,7 +265,8 @@ FEDORA_QT6_PKGS=(
   kde-gtk-config
   breeze-gtk
 
-  sddm  
+  sddm
+  qalculate
 )
 
 FEDORA_QT_PKGS_2=(
@@ -284,6 +285,7 @@ FEDORA_AUDIO_PKGS=(
 
 # Toolkit packages
 FEDORA_TOOLKIT_PKGS=(
+  gum
   wtype
   ydotool
   python3-evdev
@@ -357,11 +359,12 @@ if ! rpm -q quickshell-git &>/dev/null; then
   QS_INSTALL=true
 fi
 # Install core packages. Need weak deps, in case dnf is configured to always ignore weak deps.
-log_info "Installing core packages (Quickshell + Niri)..."
+log_info "Installing Quickshell..."
 if $QS_INSTALL; then
   v sudo dnf install quickshell -y
 fi
-sudo dnf install --setopt=install_weak_deps=True -y $installflags "${FEDORA_CORE_PKGS[@]}"
+log_info "Installing Core packages (Niri and others)..."
+v sudo dnf install --setopt=install_weak_deps=True -y $installflags "${FEDORA_CORE_PKGS[@]}"
 
 # Install Qt6 packages
 log_info "Installing Qt6 packages..."
@@ -459,12 +462,6 @@ install_github_binary() {
   rm -rf "$temp_dir"
 }
 
-# gum - TUI tool (download .rpm from GitHub)
-if ! command -v gum &>/dev/null; then
-  log_info "Installing gum from official repo..."
-  v sudo dnf install -y gum
-fi
-
 # cliphist - clipboard manager
 if ! command -v cliphist &>/dev/null; then
   log_info "Installing cliphist from official repo...."
@@ -526,6 +523,7 @@ fi
 #    fi
 #  }
 #fi
+tui_info "Installing python runtime 3.12"
 uv python install 3.12
 
 #####################################################################################

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -194,6 +194,7 @@ FEDORA_CORE_PKGS=(
   wlsunset
   dunst
   uv
+  unzip
   
   # XDG Portals
   xdg-desktop-portal

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -258,6 +258,8 @@ FEDORA_QT6_PKGS=(
   qt6ct
   kde-gtk-config
   breeze-gtk
+
+  sddm  
 )
 
 # Audio packages
@@ -579,6 +581,65 @@ if ! fc-list | grep -qi "JetBrainsMono Nerd"; then
   rm -rf "$TEMP_DIR"
 fi
 
+# Roboto Flex 
+if ! fc-list | grep -qi "Roboto Flex"; then
+  log_info "Downloading Roboto Flex Font..."
+  
+  NERD_FONTS_URL="https://github.com/googlefonts/roboto-flex/releases/download/3.200/roboto-flex-fonts.zip"
+  TEMP_DIR="/tmp/fonts-$$"
+  mkdir -p "$TEMP_DIR"
+  
+  if curl -fsSL -o "$TEMP_DIR/RobotoFlex.zip" "$NERD_FONTS_URL"; then
+    unzip -o "$TEMP_DIR/RobotoFlex.zip" -d "$FONT_DIR" >/dev/null 2>&1
+    mv $FONT_DIR/roboto-flex-fonts/fonts/variable/ $FONT_DIR
+    rm -rf $FONT_DIR/roboto-flex-fonts
+    fc-cache -f "$FONT_DIR"
+    log_success "Roboto Flex installed"
+  else
+    log_warning "Could not download Roboto Flex"
+  fi
+  
+  rm -rf "$TEMP_DIR"
+fi
+
+# Oxanium
+if ! fc-list | grep -qi "Oxanium"; then
+  log_info "Downloading Oxanium Font..."
+  
+  NERD_FONTS_URL="https://github.com/sevmeyer/oxanium/releases/download/2.000/oxanium-2.000.zip"
+  TEMP_DIR="/tmp/fonts-$$"
+  mkdir -p "$TEMP_DIR"
+  
+  if curl -fsSL -o "$TEMP_DIR/Oxanium.zip" "$NERD_FONTS_URL"; then
+    unzip -o "$TEMP_DIR/Oxanium.zip" -d "$FONT_DIR/temp" >/dev/null 2>&1
+    mv $FONT_DIR/temp/fonts/ttf/* $FONT_DIR
+    rm -rf $FONT_DIR/temp
+    fc-cache -f "$FONT_DIR"
+    log_success "Oxanium font installed"
+  else
+    log_warning "Could not download Oxanium Font"
+  fi
+  
+  rm -rf "$TEMP_DIR"
+fi
+# Oxanium, but using variable font
+#if ! fc-list | grep -qi "Oxanium"; then
+#  log_info "Downloading Oxanium Font..."
+  
+#  NERD_FONTS_URL="https://github.com/google/fonts/raw/main/ofl/oxanium/Oxanium%5Bwght%5D.ttf"
+#  TEMP_DIR="/tmp/fonts-$$"
+#  mkdir -p "$TEMP_DIR"
+  
+#  if curl -fsSL -o "$TEMP_DIR/Oxanium.zip" "$NERD_FONTS_URL"; then
+#    unzip -o "$TEMP_DIR/Oxanium.zip" -d "$FONT_DIR" >/dev/null 2>&1
+#    fc-cache -f "$FONT_DIR"
+#    log_success "Oxanium font installed"
+#  else
+#    log_warning "Could not download Oxanium Font"
+#  fi
+#  
+#  rm -rf "$TEMP_DIR"
+#fi
 #####################################################################################
 # Icon themes (WhiteSur, MacTahoe)
 #####################################################################################
@@ -674,6 +735,14 @@ if ! fc-list | grep -qi "Space Grotesk"; then
   curl -fsSL -o "$FONT_DIR/SpaceGrotesk.ttf" \
     "https://github.com/floriankarsten/space-grotesk/raw/master/fonts/ttf/SpaceGrotesk%5Bwght%5D.ttf" 2>/dev/null && \
     log_success "Space Grotesk installed"
+fi
+
+# Readex Pro
+if ! fc-list | grep -qi "Readex Pro"; then
+  log_info "Downloading Readex font..."
+  curl -fsSL -o "$FONT_DIR/Readex.ttf" \
+    "https://raw.githubusercontent.com/ThomasJockin/readexpro/master/fonts/variable/Readexpro%5BHEXP%2Cwght%5D.ttf" 2>/dev/null && \
+    log_success "Readex installed"
 fi
 
 # Rubik

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -215,6 +215,11 @@ FEDORA_CORE_PKGS=(
   
   # Shell (required for scripts)
   fish
+
+  # tuned
+  tuned
+  tuned-gui
+  tuned-ppd
   
   # System monitor (not available in all Fedora versions)
   # mission-center
@@ -279,7 +284,6 @@ FEDORA_AUDIO_PKGS=(
 
 # Toolkit packages
 FEDORA_TOOLKIT_PKGS=(
-  #python3
   wtype
   ydotool
   python3-evdev

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -335,17 +335,17 @@ $ask || installflags="-y --skip-unavailable"
 # If noctalia-qs present, replace with quickshell
 # If quickshell-git present, proceed normally
 #####################################################################################
-$QS_INSTALL=false
+QS_INSTALL=false
 if rpm -q noctalia-qs &>/dev/null; then
   log_info "noctalia-qs present. iNir needs quickshell (preferable) or quickshell-git. Removing?"
   if ! sudo dnf remove noctalia-qs; then
     log_warning "noctalia-qs not removed. There may be problems with running iNir with noctalia-qs"
   else
-    $QS_INSTALL=true
+    QS_INSTALL=true
   fi
 fi
 if ! rpm -q quickshell-git &>/dev/null; then
-  $QS_INSTALL=true
+  QS_INSTALL=true
 fi
 # Install core packages. Need weak deps, in case dnf is configured to always ignore weak deps.
 log_info "Installing core packages (Quickshell + Niri)..."

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -149,19 +149,6 @@ if ! rpm -q rpmfusion-nonfree-release &>/dev/null; then
     "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VERSION}.noarch.rpm"
 fi
 
-#####################################################################################
-# Install flatpak if it doesn't exist
-#####################################################################################
-tui_info "Configuring flatpak, if not present (Usually present in fedora workstation)"
-if ! command -v flatpak >/dev/null 2>&1; then
-    v sudo dnf install -y flatpak flatpak-libs
-fi
-log_info "Flatpak is installed"
-
-if ! flatpak remote-list | grep -q "^flathub"; then
-  flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-fi
-log_info "Flathub repository configured"
 
 #####################################################################################
 # Install official repository packages
@@ -245,9 +232,6 @@ FEDORA_CORE_PKGS=(
   # Translation
   translate-shell
 )
-FEDORA_FLATPAKS={
-  io.missioncenter.MissionCenter
-}
 # Qt6 packages
 FEDORA_QT6_PKGS=(
   qt6-qtbase
@@ -385,9 +369,6 @@ v sudo dnf install $installflags "${FEDORA_QT6_PKGS[@]}"
 
 log_info "Installing Qt6 packages (2)..."
 v sudo dnf install --setopt=install_weak_deps=False "${FEDORA_QT_PKGS_2[@]}"
-
-log_info "Installing flatpaks..."
-v flatpak install flathub ${FEDORA_FLATPAKS[@]} -y"
 
 # Install based on flags
 if ${INSTALL_AUDIO:-true}; then

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -352,7 +352,7 @@ log_info "Installing core packages (Quickshell + Niri)..."
 if $QS_INSTALL; then
   v sudo dnf install quickshell -y
 fi
-v sudo dnf install --setopt=install_weak_deps=True $installflags "${FEDORA_CORE_PKGS[@]}"
+sudo dnf install --setopt=install_weak_deps=True -y $installflags "${FEDORA_CORE_PKGS[@]}"
 
 # Install Qt6 packages
 log_info "Installing Qt6 packages..."

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -526,6 +526,7 @@ fi
 #    fi
 #  }
 #fi
+uv python install 3.12
 
 #####################################################################################
 # Install critical fonts
@@ -594,7 +595,7 @@ if ! fc-list | grep -qi "Roboto Flex"; then
   
   if curl -fsSL -o "$TEMP_DIR/RobotoFlex.zip" "$NERD_FONTS_URL"; then
     unzip -o "$TEMP_DIR/RobotoFlex.zip" -d "$FONT_DIR" >/dev/null 2>&1
-    mv $FONT_DIR/roboto-flex-fonts/fonts/variable/ $FONT_DIR
+    mv $FONT_DIR/roboto-flex-fonts/fonts/variable/* $FONT_DIR
     rm -rf $FONT_DIR/roboto-flex-fonts
     fc-cache -f "$FONT_DIR"
     log_success "Roboto Flex installed"
@@ -781,9 +782,7 @@ tui_info "Installing CLI tools..."
 # Starship prompt
 if ! command -v starship &>/dev/null; then
   log_info "Installing Starship prompt..."
-  mkdir -p ~/.local/bin
-  curl -sS https://starship.rs/install.sh | sh -s -- -y -b ~/.local/bin 2>/dev/null || \
-    log_warning "Could not install Starship"
+  v sudo dnf install -y starship
 fi
 
 # Eza (modern ls replacement) Now in the official repos

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -75,10 +75,11 @@ if [[ -n "${ONLY_MISSING_DEPS:-}" ]]; then
       dnf copr list --enabled 2>/dev/null | grep -q "errornointernet/quickshell" || \
         v sudo dnf copr enable -y errornointernet/quickshell
     fi
-    if [[ " ${_fed_miss_pkgs[*]} " == *" niri " ]]; then
-      dnf copr list --enabled 2>/dev/null | grep -q "yalter/niri" || \
-        v sudo dnf copr enable -y yalter/niri
-    fi
+    #if [[ " ${_fed_miss_pkgs[*]} " == *" niri " ]]; then
+    #  dnf copr list --enabled 2>/dev/null | grep -q "yalter/niri" || \
+    #    v sudo dnf copr enable -y yalter/niri
+    #fi
+    # Unecessary as niri(release version) is in the official repos
 
     v sudo dnf install $_fed_installflags "${_fed_miss_pkgs[@]}"
   fi
@@ -115,10 +116,11 @@ if ! dnf copr list --enabled 2>/dev/null | grep -q "errornointernet/quickshell";
 fi
 
 # Niri compositor
-if ! dnf copr list --enabled 2>/dev/null | grep -q "yalter/niri"; then
-  log_info "Enabling Niri COPR..."
-  v sudo dnf copr enable -y yalter/niri
-fi
+# if ! dnf copr list --enabled 2>/dev/null | grep -q "yalter/niri"; then
+#  log_info "Enabling Niri COPR..."
+#  v sudo dnf copr enable -y yalter/niri
+# fi
+# Unecessary as niri(release version) is in the official repos
 
 #####################################################################################
 # Enable RPM Fusion (for ffmpeg, etc.)
@@ -224,6 +226,8 @@ FEDORA_QT6_PKGS=(
   qt6-qtpositioning
   qt6-qtsensors
   qt6-qttools
+  qt6-qttranslations
+  qt6-qtquicktimeline
   
   # System libs
   jemalloc
@@ -244,12 +248,6 @@ FEDORA_QT6_PKGS=(
 
 # Audio packages
 FEDORA_AUDIO_PKGS=(
-  pipewire
-  pipewire-pulseaudio
-  pipewire-alsa
-  wireplumber
-  playerctl
-  libdbusmenu-gtk3
   pavucontrol
   cava
   easyeffects
@@ -260,7 +258,7 @@ FEDORA_AUDIO_PKGS=(
 
 # Toolkit packages
 FEDORA_TOOLKIT_PKGS=(
-  upower
+  python3
   wtype
   ydotool
   python3-evdev

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -70,10 +70,14 @@ if [[ -n "${ONLY_MISSING_DEPS:-}" ]]; then
       *) v sudo dnf upgrade -y --refresh ;;
     esac
 
-    # quickshell and niri come from COPR on Fedora; ensure repos are enabled
+    # quickshell and starship come from COPR on Fedora; ensure repos are enabled
     if [[ " ${_fed_miss_pkgs[*]} " == *" quickshell " ]]; then
       dnf copr list --enabled 2>/dev/null | grep -q "errornointernet/quickshell" || \
         v sudo dnf copr enable -y errornointernet/quickshell
+    fi
+    if [[ " ${_fed_miss_pkgs[*]} " == *" quickshell " ]]; then
+      dnf copr list --enabled 2>/dev/null | grep -q "atim/starship" || \
+        v sudo dnf copr enable -y atim/starship
     fi
     #if [[ " ${_fed_miss_pkgs[*]} " == *" niri " ]]; then
     #  dnf copr list --enabled 2>/dev/null | grep -q "yalter/niri" || \
@@ -112,6 +116,14 @@ if ! dnf copr list --enabled 2>/dev/null | grep -q "errornointernet/quickshell";
   v sudo dnf copr enable -y errornointernet/quickshell || {
     log_error "Failed to enable Quickshell COPR — install manually:"
     log_warning "https://copr.fedorainfracloud.org/coprs/errornointernet/quickshell/"
+  }
+fi
+
+if ! dnf copr list --enabled 2>/dev/null | grep -q "atim/starship"; then
+  log_info "Enabling Quickshell COPR (precompiled)..."
+  v sudo dnf copr enable -y atim/starship || {
+    log_error "Failed to enable Starship COPR — install manually:"
+    log_warning "https://copr.fedorainfracloud.org/coprs/atim/starship/"
   }
 fi
 
@@ -314,6 +326,23 @@ FEDORA_FONT_PKGS=(
 installflags=""
 $ask || installflags="-y --skip-unavailable"
 
+#####################################################################################
+# Ensuring no conflicts with noctalia-qs, quickshell-git and niri-git
+# If noctalia-qs present, replace with quickshell
+# If quickshell-git present, proceed normally
+#####################################################################################
+
+if rpm -q noctalia-qs &>/dev/null; then
+  log_info "noctalia-qs present. iNir needs quickshell (preferable) or quickshell-git. Removing?"
+  if ! sudo dnf remove noctalia-qs; then
+    log_warning "noctalia-qs not removed. There may be problems with running iNir with noctalia-qs"
+  else
+    v sudo dnf install quickshell -y
+  fi
+fi
+if ! rpm -q quickshell-git &>/dev/null; then
+  v sudo dnf install quickshell -y
+
 # Install core packages
 log_info "Installing core packages (Quickshell + Niri)..."
 v sudo dnf install $installflags "${FEDORA_CORE_PKGS[@]}"
@@ -413,16 +442,18 @@ install_github_binary() {
 
 # gum - TUI tool (download .rpm from GitHub)
 if ! command -v gum &>/dev/null; then
-  log_info "Installing gum from GitHub..."
-  GUM_RPM_URL=$(curl -s "https://api.github.com/repos/charmbracelet/gum/releases/latest" | \
-    jq -r '.assets[] | select(.name | test("linux.*x86_64.*rpm$")) | .browser_download_url' | head -1)
-  if [[ -n "$GUM_RPM_URL" && "$GUM_RPM_URL" != "null" ]]; then
-    v sudo dnf install -y "$GUM_RPM_URL"
-  fi
+  log_info "Installing gum from official repo..."
+  v sudo dnf install -y gum
 fi
 
 # cliphist - clipboard manager
-install_github_binary "cliphist" "sentriz/cliphist" "linux-amd64$"
+if ! command -v cliphist &>/dev/null; then
+  log_info "Installing cliphist from official repo...."
+  if ! sudo dnf install -y cliphist; then # Cliphist available on fedra 44
+    log_warn "dnf install failed, falling back to GitHub binary..."
+    install_github_binary "cliphist" "sentriz/cliphist" "linux-amd64$"
+  fi
+fi
 
 # xwayland-satellite - X11 compatibility (try cargo-binstall first)
 if ! command -v xwayland-satellite &>/dev/null; then
@@ -681,17 +712,10 @@ if ! command -v starship &>/dev/null; then
     log_warning "Could not install Starship"
 fi
 
-# Eza (modern ls replacement)
+# Eza (modern ls replacement) Now in the official repos
 if ! command -v eza &>/dev/null; then
   log_info "Installing Eza..."
-  mkdir -p ~/.local/bin
-  if curl -fsSL -o /tmp/eza.tar.gz \
-    'https://github.com/eza-community/eza/releases/latest/download/eza_x86_64-unknown-linux-musl.tar.gz'; then
-    tar -xzf /tmp/eza.tar.gz -C ~/.local/bin
-    chmod +x ~/.local/bin/eza
-    log_success "Eza installed"
-  fi
-  rm -f /tmp/eza.tar.gz
+  v sudo dnf install -y eza
 fi
 
 #####################################################################################
@@ -749,7 +773,6 @@ log_success "══════════════════════�
 echo ""
 log_info "Installed from COPR (no compilation):"
 echo "  - quickshell (errornointernet/quickshell)"
-echo "  - niri (yalter/niri)"
 echo ""
 log_info "Installed from GitHub releases:"
 echo "  - gum, cliphist, darkly, starship, eza"

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -489,21 +489,25 @@ fi
 
 # darkly - Qt theme (download .rpm from GitHub)
 if ${INSTALL_FONTS:-true}; then
-  if ! rpm -q darkly &>/dev/null; then
-    log_info "Installing darkly theme from GitHub..."
-    DARKLY_RPM_URL=$(curl -s "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
-      jq -r ".assets[] | select(.name | test(\"fc${FEDORA_VERSION}.*x86_64.rpm$\")) | .browser_download_url" | head -1)
-    
-    # Fallback to any Fedora RPM if exact version not found
-    if [[ -z "$DARKLY_RPM_URL" || "$DARKLY_RPM_URL" == "null" ]]; then
+  log_info "Installing Darkly from COPR"
+  if ! sudo dnf install darkly -y; then
+    log_warning "Failed to install from COPR. Falling back to GitHub Releases..."
+    if ! rpm -q darkly &>/dev/null; then
+      log_info "Installing darkly theme from GitHub..."
       DARKLY_RPM_URL=$(curl -s "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
-        jq -r '.assets[] | select(.name | test("fc[0-9]+.*x86_64.rpm$")) | .browser_download_url' | head -1)
-    fi
+        jq -r ".assets[] | select(.name | test(\"fc${FEDORA_VERSION}.*x86_64.rpm$\")) | .browser_download_url" | head -1)
     
-    if [[ -n "$DARKLY_RPM_URL" && "$DARKLY_RPM_URL" != "null" ]]; then
-      v sudo dnf install -y "$DARKLY_RPM_URL"
-    else
-      log_warning "darkly RPM not found for Fedora ${FEDORA_VERSION}"
+      # Fallback to any Fedora RPM if exact version not found
+      if [[ -z "$DARKLY_RPM_URL" || "$DARKLY_RPM_URL" == "null" ]]; then
+        DARKLY_RPM_URL=$(curl -s "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
+          jq -r '.assets[] | select(.name | test("fc[0-9]+.*x86_64.rpm$")) | .browser_download_url' | head -1)
+      fi
+    
+      if [[ -n "$DARKLY_RPM_URL" && "$DARKLY_RPM_URL" != "null" ]]; then
+        v sudo dnf install -y "$DARKLY_RPM_URL"
+      else
+        log_warning "darkly RPM not found for Fedora ${FEDORA_VERSION}"
+      fi
     fi
   fi
 fi

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -475,8 +475,8 @@ fi
 if ! command -v awww &>/dev/null; then
   log_info "Installing awww (wallpaper daemon)..."
   if command -v cargo &>/dev/null; then
-    sudo dnf install -y lz4-devel
-    if cargo install --git https://codeberg.org/LGFae/awww.git awww 2>/dev/null; then
+    sudo dnf install -y lz4-devel wayland-protocols-devel
+    if cargo install --git https://codeberg.org/LGFae/awww.git awww-daemon awww 2>/dev/null; then
       log_success "awww installed via Cargo"
     else
       log_warning "awww build failed — install manually: cargo install --git https://codeberg.org/LGFae/awww.git awww"

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -254,6 +254,7 @@ FEDORA_QT6_PKGS=(
   kf6-kirigami
   kdialog
   kf6-syntax-highlighting
+  kdecoration
   
   # Qt theming
   qt6ct
@@ -261,6 +262,10 @@ FEDORA_QT6_PKGS=(
   breeze-gtk
 
   sddm  
+)
+
+FEDORA_QT_PKGS_2=(
+  plasma-integration
 )
 
 # Audio packages
@@ -358,6 +363,9 @@ sudo dnf install --setopt=install_weak_deps=True -y $installflags "${FEDORA_CORE
 # Install Qt6 packages
 log_info "Installing Qt6 packages..."
 v sudo dnf install $installflags "${FEDORA_QT6_PKGS[@]}"
+
+log_info "Installing Qt6 packages (2)..."
+v sudo dnf install --setopt=install_weak_deps=False "${FEDORA_QT_PKGS_2[@]}"
 
 # Install based on flags
 if ${INSTALL_AUDIO:-true}; then

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -120,7 +120,7 @@ if ! dnf copr list --enabled 2>/dev/null | grep -q "errornointernet/quickshell";
 fi
 
 if ! dnf copr list --enabled 2>/dev/null | grep -q "atim/starship"; then
-  log_info "Enabling Quickshell COPR (precompiled)..."
+  log_info "Enabling Starship COPR (precompiled)..."
   v sudo dnf copr enable -y atim/starship || {
     log_error "Failed to enable Starship COPR — install manually:"
     log_warning "https://copr.fedorainfracloud.org/coprs/atim/starship/"
@@ -346,7 +346,7 @@ if rpm -q noctalia-qs &>/dev/null; then
 fi
 if ! rpm -q quickshell-git &>/dev/null; then
   v sudo dnf install quickshell -y
-
+fi
 # Install core packages. Need weak deps, in case dnf is configured to always ignore weak deps.
 log_info "Installing core packages (Quickshell + Niri)..."
 v sudo dnf install --setopt=install_weak_deps=True $installflags "${FEDORA_CORE_PKGS[@]}"

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -758,19 +758,6 @@ if ! fc-list | grep -qi "Rubik"; then
     log_success "Rubik installed"
 fi
 
-# Geist (used by default in iNiR)
-if ! fc-list | grep -qi "Geist"; then
-  log_info "Downloading Geist font..."
-  TEMP_DIR="/tmp/geist-font-$$"
-  mkdir -p "$TEMP_DIR"
-  if curl -fsSL -o "$TEMP_DIR/geist.zip" \
-    "https://github.com/vercel/geist-font/releases/latest/download/Geist.zip"; then
-    unzip -o "$TEMP_DIR/geist.zip" -d "$TEMP_DIR" >/dev/null 2>&1
-    find "$TEMP_DIR" -name "*.ttf" -exec cp {} "$FONT_DIR/" \;
-    log_success "Geist font installed"
-  fi
-  rm -rf "$TEMP_DIR"
-fi
 
 # Refresh font cache
 fc-cache -f "$FONT_DIR" 2>/dev/null
@@ -780,17 +767,7 @@ fc-cache -f "$FONT_DIR" 2>/dev/null
 #####################################################################################
 tui_info "Installing CLI tools..."
 
-# Starship prompt
-if ! command -v starship &>/dev/null; then
-  log_info "Installing Starship prompt..."
-  v sudo dnf install -y starship
-fi
-
-# Eza (modern ls replacement) Now in the official repos
-if ! command -v eza &>/dev/null; then
-  log_info "Installing Eza..."
-  v sudo dnf install -y eza
-fi
+v sudo dnf install -y starship eza
 
 #####################################################################################
 # Install adw-gtk3 theme

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -192,7 +192,6 @@ FEDORA_CORE_PKGS=(
   wl-clipboard
   libnotify
   wlsunset
-  dunst
   uv
   unzip
   
@@ -280,7 +279,7 @@ FEDORA_AUDIO_PKGS=(
 
 # Toolkit packages
 FEDORA_TOOLKIT_PKGS=(
-  python3
+  #python3
   wtype
   ydotool
   python3-evdev
@@ -468,18 +467,6 @@ if ! command -v cliphist &>/dev/null; then
   if ! sudo dnf install -y cliphist; then # Cliphist available on fedra 44
     log_warn "dnf install failed, falling back to GitHub binary..."
     install_github_binary "cliphist" "sentriz/cliphist" "linux-amd64$"
-  fi
-fi
-
-# xwayland-satellite - X11 compatibility (try cargo-binstall first)
-if ! command -v xwayland-satellite &>/dev/null; then
-  log_info "Installing xwayland-satellite..."
-  if command -v cargo-binstall &>/dev/null; then
-    cargo-binstall -y xwayland-satellite
-  elif command -v cargo &>/dev/null; then
-    cargo install xwayland-satellite
-  else
-    log_warning "xwayland-satellite requires Rust — install with: cargo install xwayland-satellite"
   fi
 fi
 
@@ -801,7 +788,7 @@ fi
 tui_info "Setting up configuration files..."
 
 # GTK configuration
-setup-gtk-config "Bibata-Modern-Classic" "WhiteSur-dark" "adw-gtk3-dark" "Geist"
+setup-gtk-config "Bibata-Modern-Classic" "WhiteSur-dark" "adw-gtk3-dark"
 
 # Kvantum configuration
 setup-kvantum-config "MaterialAdw"

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -157,7 +157,8 @@ tui_info "Installing packages from repositories..."
 # Core system packages (including Quickshell and Niri from COPR)
 FEDORA_CORE_PKGS=(
   # Quickshell (from COPR - no compilation needed!)
-  quickshell
+  # quickshell
+  # due to possible conflict with quickshell-git or noctalia-qs, resolved later
   
   # Niri compositor (from COPR)
   niri
@@ -192,6 +193,7 @@ FEDORA_CORE_PKGS=(
   libnotify
   wlsunset
   dunst
+  uv
   
   # XDG Portals
   xdg-desktop-portal
@@ -343,9 +345,9 @@ fi
 if ! rpm -q quickshell-git &>/dev/null; then
   v sudo dnf install quickshell -y
 
-# Install core packages
+# Install core packages. Need weak deps, in case dnf is configured to always ignore weak deps.
 log_info "Installing core packages (Quickshell + Niri)..."
-v sudo dnf install $installflags "${FEDORA_CORE_PKGS[@]}"
+v sudo dnf install --setopt=install_weak_deps=True $installflags "${FEDORA_CORE_PKGS[@]}"
 
 # Install Qt6 packages
 log_info "Installing Qt6 packages..."
@@ -505,20 +507,20 @@ if ${INSTALL_FONTS:-true}; then
 fi
 
 #####################################################################################
-# Install uv (Python package manager)
+# Install uv (Python package manager) Unecessary for now because uv in fedora rpos
 #####################################################################################
-tui_info "Installing uv (Python package manager)..."
-if ! command -v uv &>/dev/null; then
+#tui_info "Installing uv (Python package manager)..."
+#if ! command -v uv &>/dev/null; then
   # Try the official installer first (fastest)
-  curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null || {
+#  curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null || {
     # Fallback to cargo
-    if command -v cargo &>/dev/null; then
-      cargo install uv
-    else
-      log_warning "Could not install uv. Install manually: https://github.com/astral-sh/uv"
-    fi
-  }
-fi
+#    if command -v cargo &>/dev/null; then
+#      cargo install uv
+#    else
+#      log_warning "Could not install uv. Install manually: https://github.com/astral-sh/uv"
+#    fi
+#  }
+#fi
 
 #####################################################################################
 # Install critical fonts


### PR DESCRIPTION
## Summary

The PR updates fedora install script so that dependencies are up to date with the arch install scripts, which is officially supported by @snowarch 

This PR also updates the sddm install script so that the default DisplayServer is now wayland. Otherwise, due to missing dependencies, sddm will not work on fedora. The sddm `ii-pixel` theme will however not load until #127 is merged. 

## Testing

- [x] `inir restart && inir logs` — no errors
- [x] Tested the specific feature path that changed
- [ ] Both panel families checked (if shared code changed)

[logs.txt](https://github.com/user-attachments/files/27006209/logs.txt)


## Notes
1) `hyprpicker` and dependencies were not added
2) `missioncenter` package is not available in fedora repos. The flatpak is usually used instead. However, due to the sandbox nature of flatpaks, missioncenter will not follow theming. I am working on a solution for this.