### PR TITLE
Refractor/sddm qt6

### DIFF
--- a/dots/sddm/pixel/Main.qml
+++ b/dots/sddm/pixel/Main.qml
@@ -2,7 +2,7 @@
 // States: "clock" (initial) ↔ "login" (password entry), same layout + transitions.
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects 1.0
 import SddmComponents 2.0
 import "."
 

--- a/dots/sddm/pixel/metadata.desktop
+++ b/dots/sddm/pixel/metadata.desktop
@@ -1,11 +1,12 @@
-[Desktop Entry]
+[SddmGreeterTheme]
 Name=ii-pixel
-Comment=iNiR SDDM login screen — Material You dynamic colors
-Type=Service
-X-KDE-PluginInfo-Author=iNiR project
-X-KDE-PluginInfo-Email=
-X-KDE-PluginInfo-Name=ii-pixel
-X-KDE-PluginInfo-Version=1.0
-X-KDE-PluginInfo-Website=https://github.com/snowarch/iNiR
-X-KDE-PluginInfo-Category=Plasma Look And Feel
-X-KDE-ServiceTypes=SDDM/Theme
+Description=iNiR SDDM login screen — Material You dynamic colors
+Author=iNiR Project
+Type=sddm-theme
+Version=1.0
+Website=https://github.com/snowarch/iNiR
+MainScript=Main.qml
+ConfigFile=theme.conf
+Theme-Id=ii-pixel
+Theme-API=2.11
+QtVersion=6


### PR DESCRIPTION
## Summary

Refractor the SDDM theme so that it uses Qt6. Builds on #127 

## Testing

- [x] `journalctl -b | grep sddm`
- [x] Tested the specific feature path that changed

## Notes

Previously sddm on arch uses Qt5 which made using the Qt5Compat module useless and broke the theme in #127 . By making the theme use Qt6, the error is resolved.

Logs: 
[sddm.log](https://github.com/user-attachments/files/27252024/sddm.log)

