### PR TITLE
fix(panels): prevent Hyprland stack overflow crash on surface remap

### DIFF
--- a/modules/cheatsheet/Cheatsheet.qml
+++ b/modules/cheatsheet/Cheatsheet.qml
@@ -68,31 +68,15 @@ Scope {
     PanelWindow {
         id: window
 
-        Component.onCompleted: visible = root.cheatsheetOpen
-
-        Connections {
-            target: root
-            function onCheatsheetOpenChanged() {
-                if (root.cheatsheetOpen) {
-                    _closeTimer.stop()
-                    window.visible = true
-                } else {
-                    _closeTimer.restart()
-                }
-            }
-        }
-
-        Timer {
-            id: _closeTimer
-            interval: 250
-            onTriggered: window.visible = false
-        }
-
         exclusionMode: ExclusionMode.Ignore
         color: "transparent"
         WlrLayershell.namespace: "quickshell:cheatsheet"
         WlrLayershell.layer: WlrLayer.Overlay
         WlrLayershell.keyboardFocus: root.cheatsheetOpen ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+        // Keep the surface always mapped to avoid Qt6 physicalDpiChanged infinite
+        // recursion (stack overflow) triggered by Hyprland sending a Wayland scale
+        // event on remap. Input is controlled via mask instead of visibility.
+        mask: Region { item: root.cheatsheetOpen ? backdropClickArea : noInputItem }
 
         anchors {
             top: true
@@ -100,6 +84,8 @@ Scope {
             left: true
             right: true
         }
+
+        Item { id: noInputItem; width: 0; height: 0 }
 
         // Scrim backdrop (matches Overview pattern)
         Rectangle {
@@ -129,6 +115,7 @@ Scope {
 
         // Click outside to close
         MouseArea {
+            id: backdropClickArea
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             onClicked: mouse => {

--- a/modules/clipboard/ClipboardPanel.qml
+++ b/modules/clipboard/ClipboardPanel.qml
@@ -157,31 +157,15 @@ Scope {
     PanelWindow {
         id: window
 
-        Component.onCompleted: visible = GlobalStates.clipboardOpen
-
-        Connections {
-            target: GlobalStates
-            function onClipboardOpenChanged() {
-                if (GlobalStates.clipboardOpen) {
-                    _closeTimer.stop()
-                    window.visible = true
-                } else {
-                    _closeTimer.restart()
-                }
-            }
-        }
-
-        Timer {
-            id: _closeTimer
-            interval: 180
-            onTriggered: window.visible = false
-        }
-
         exclusionMode: ExclusionMode.Ignore
         color: "transparent"
         WlrLayershell.namespace: "quickshell:clipboardPanel"
         WlrLayershell.layer: WlrLayer.Overlay
         WlrLayershell.keyboardFocus: GlobalStates.clipboardOpen ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+        // Keep the surface always mapped to avoid Qt6 physicalDpiChanged infinite
+        // recursion (stack overflow) triggered by Hyprland sending a Wayland scale
+        // event on remap. Input is controlled via mask instead of visibility.
+        mask: Region { item: GlobalStates.clipboardOpen ? backdropClickArea : noInputItem }
 
         anchors {
             top: true
@@ -189,6 +173,8 @@ Scope {
             left: true
             right: true
         }
+
+        Item { id: noInputItem; width: 0; height: 0 }
 
         Item {
             id: keyHandler
@@ -268,6 +254,7 @@ Scope {
 
         // Click outside the panel to close
         MouseArea {
+            id: backdropClickArea
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
             onClicked: mouse => {

--- a/modules/controlPanel/ControlPanel.qml
+++ b/modules/controlPanel/ControlPanel.qml
@@ -43,26 +43,6 @@ Scope {
     PanelWindow {
         id: panelRoot
 
-        Component.onCompleted: visible = GlobalStates.controlPanelOpen
-
-        Connections {
-            target: GlobalStates
-            function onControlPanelOpenChanged() {
-                if (GlobalStates.controlPanelOpen) {
-                    _closeTimer.stop()
-                    panelRoot.visible = true
-                } else {
-                    _closeTimer.restart()
-                }
-            }
-        }
-
-        Timer {
-            id: _closeTimer
-            interval: 250
-            onTriggered: panelRoot.visible = false
-        }
-
         function hide() {
             GlobalStates.controlPanelOpen = false
         }
@@ -74,6 +54,10 @@ Scope {
         WlrLayershell.layer: WlrLayer.Overlay
         WlrLayershell.keyboardFocus: GlobalStates.controlPanelOpen ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
         color: "transparent"
+        // Keep the surface always mapped to avoid Qt6 physicalDpiChanged infinite
+        // recursion (stack overflow) triggered by Hyprland sending a Wayland scale
+        // event on remap. Input is controlled via mask instead of visibility.
+        mask: Region { item: GlobalStates.controlPanelOpen ? backdropClickArea : noInputItem }
 
         anchors {
             top: true
@@ -82,10 +66,12 @@ Scope {
             left: true
         }
 
+        Item { id: noInputItem; width: 0; height: 0 }
+
         CompositorFocusGrab {
             id: grab
             windows: [ panelRoot ]
-            active: CompositorService.isHyprland && panelRoot.visible
+            active: CompositorService.isHyprland && GlobalStates.controlPanelOpen
             onCleared: () => {
                 if (!active) panelRoot.hide()
             }

--- a/modules/overview/Overview.qml
+++ b/modules/overview/Overview.qml
@@ -31,26 +31,6 @@ Scope {
             readonly property bool shouldShow: GlobalStates.overviewOpen && (!activeScreenOnly || monitorIsFocused)
             screen: modelData
 
-            Component.onCompleted: visible = root.shouldShow
-
-            Connections {
-                target: root
-                function onShouldShowChanged() {
-                    if (root.shouldShow) {
-                        _overviewCloseTimer.stop()
-                        root.visible = true
-                    } else {
-                        _overviewCloseTimer.restart()
-                    }
-                }
-            }
-
-            Timer {
-                id: _overviewCloseTimer
-                interval: 250
-                onTriggered: root.visible = false
-            }
-
             exclusionMode: ExclusionMode.Ignore
 
             WlrLayershell.namespace: "quickshell:overview"
@@ -58,6 +38,10 @@ Scope {
             // Keyboard focus only on the monitor that should show
             WlrLayershell.keyboardFocus: root.shouldShow ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
             color: "transparent"
+            // Keep the surface always mapped to avoid Qt6 physicalDpiChanged infinite
+            // recursion (stack overflow) triggered by Hyprland sending a Wayland scale
+            // event on remap. Input is controlled via mask instead of visibility.
+            mask: Region { item: root.shouldShow ? backdropClickArea : noInputItem }
 
             anchors {
                 top: true
@@ -65,6 +49,8 @@ Scope {
                 left: true
                 right: true
             }
+
+            Item { id: noInputItem; width: 0; height: 0 }
 
             // Scrim de fondo: oscurece todo detrás del overview mientras está activo
             Rectangle {

--- a/modules/sidebarLeft/SidebarLeft.qml
+++ b/modules/sidebarLeft/SidebarLeft.qml
@@ -38,7 +38,6 @@ Scope {
         id: sidebarRoot
 
         Component.onCompleted: {
-            visible = GlobalStates.sidebarLeftOpen
             root._sidebarShown = GlobalStates.sidebarLeftOpen
         }
 
@@ -46,25 +45,12 @@ Scope {
             target: GlobalStates
             function onSidebarLeftOpenChanged() {
                 if (GlobalStates.sidebarLeftOpen) {
-                    _closeTimer.stop()
-                    sidebarRoot.visible = true
-                    // Let the surface map for one frame before sliding in
+                    // Let the surface settle for one frame before sliding in
                     Qt.callLater(() => { root._sidebarShown = true })
-                } else if (root.instantOpen || !Appearance.animationsEnabled) {
-                    root._sidebarShown = false
-                    _closeTimer.stop()
-                    sidebarRoot.visible = false
                 } else {
                     root._sidebarShown = false
-                    _closeTimer.restart()
                 }
             }
-        }
-
-        Timer {
-            id: _closeTimer
-            interval: 300
-            onTriggered: sidebarRoot.visible = false
         }
 
         function hide() {
@@ -76,6 +62,10 @@ Scope {
         WlrLayershell.namespace: "quickshell:sidebarLeft"
         WlrLayershell.keyboardFocus: GlobalStates.sidebarLeftOpen ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
         color: "transparent"
+        // Keep the surface always mapped to avoid Qt6 physicalDpiChanged infinite
+        // recursion (stack overflow) triggered by Hyprland sending a Wayland scale
+        // event on remap. Input is controlled via mask instead of visibility.
+        mask: Region { item: GlobalStates.sidebarLeftOpen ? backdropClickArea : noInputItem }
 
         anchors {
             top: true
@@ -84,10 +74,12 @@ Scope {
             right: true
         }
 
+        Item { id: noInputItem; width: 0; height: 0 }
+
         CompositorFocusGrab {
             id: grab
             windows: [ sidebarRoot ]
-            active: CompositorService.isHyprland && sidebarRoot.visible
+            active: CompositorService.isHyprland && GlobalStates.sidebarLeftOpen
             onCleared: () => {
                 if (!active) sidebarRoot.hide()
             }


### PR DESCRIPTION
## Root cause

On **Hyprland**, toggling a panel closed sets `visible = false` on its `PanelWindow`, which unmaps the Wayland surface. When the panel reopens, Hyprland emits a `physicalDpiChanged` scale event on remap. Qt6's handler for that signal re-enters the same signal path, causing **infinite recursion → stack overflow crash**.

The crash does not reproduce on **Niri** because Niri does not emit scale events on surface remap.

The fix was already applied to `SidebarRight` (implicitly, via earlier work). The same `_closeTimer / visible = false` pattern was present in five additional panels.

## Fix

Keep every affected `PanelWindow` always mapped and control input via:

```qml
mask: Region { item: open ? backdropClickArea : noInputItem }
Item { id: noInputItem; width: 0; height: 0 }
```

The `_closeTimer` and all `visible` assignments are removed. `CompositorFocusGrab.active` is updated to use the GlobalState boolean directly instead of `panelRoot.visible`.

## Affected panels

| File | Crash trigger |
|---|---|
| `modules/sidebarLeft/SidebarLeft.qml` | every sidebar toggle |
| `modules/clipboard/ClipboardPanel.qml` | every clipboard toggle |
| `modules/cheatsheet/Cheatsheet.qml` | every cheatsheet toggle |
| `modules/controlPanel/ControlPanel.qml` | every control panel toggle |
| `modules/overview/Overview.qml` | every overview toggle |

## Out of scope

- **Waffle panels** (`WaffleStartMenu`, `WaffleActionCenter`, etc.) — use `Loader { active: ... }` which destroys/recreates the component rather than remapping; different issue.
- **GameMode / fullscreen panels** (`Bar`, `Dock`, `Backdrop`, etc.) — `visible: !GameMode.shouldHidePanels` is intentional for Niri direct scanout; changing it would conflict with that goal.

## Testing
- [x] `inir restart && inir logs` — no errors
- [x] Toggled each affected panel open/close repeatedly on Hyprland — no crash
- [x] Verified click-outside-to-close and keyboard dismiss still work
- [x] Animations unchanged (driven by GlobalState booleans, not surface visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)