### PR TITLE
Add setup recipe for code editors (Arch-only)

### DIFF
--- a/scripts/setup/_lib.sh
+++ b/scripts/setup/_lib.sh
@@ -6,12 +6,17 @@
 #   - distro detection         (DISTRO_ID, DISTRO_LIKE, is_arch_like)
 #   - progress notifications   (setup_notify, setup_progress, setup_done, setup_fail)
 #   - command/package helpers  (have_cmd, ensure_aur_helper, install_arch, install_flatpak)
+#   - developer-friendly error reporting (_setup_err_trap, stack trace, TRACE mode)
 #
 # Conventions:
 #   - The recipe must `set -Eeuo pipefail` and call `setup_init "<id>" "<title>"`
 #     before doing any work. `setup_init` traps errors and emits a failure notify.
 #   - All progress notifications share a synchronous tag so the desktop notifier
 #     replaces the previous bubble in place instead of stacking.
+
+# -- Debug / trace mode -------------------------------------------------------
+# Set TRACE=1 to enable bash trace (set -x) for full command debugging.
+[[ "${TRACE:-}" == "1" ]] && set -x
 
 # -- Distro detection --------------------------------------------------------
 _setup_load_distro() {
@@ -69,18 +74,53 @@ setup_fail() {
     setup_notify "$msg" "dialog-error"
 }
 
+# -- Developer-friendly error reporting ---------------------------------------
+_setup_err_trap() {
+    local exit_code=$?
+    local line_no=$LINENO
+    local failed_cmd="$BASH_COMMAND"
+    local src_file="${BASH_SOURCE[1]:-<unknown>}"
+    local func_name="${FUNCNAME[1]:-<main>}"
+
+    printf '\n' >&2
+    printf '\033[1;31m┌─ Error ─────────────────────────────────────────────────────────────┐\033[0m\n' >&2
+    printf '\033[1;31m│\033[0m Setup:    \033[1m%s\033[0m\n' "$SETUP_TITLE" >&2
+    printf '\033[1;31m│\033[0m Exit:     \033[1;31m%d\033[0m\n' "$exit_code" >&2
+    printf '\033[1;31m│\033[0m Line:     \033[1;33m%d\033[0m\n' "$line_no" >&2
+    printf '\033[1;31m│\033[0m File:     \033[2m%s\033[0m\n' "$src_file" >&2
+    printf '\033[1;31m│\033[0m Function: \033[2m%s\033[0m\n' "$func_name" >&2
+    printf '\033[1;31m│\033[0m Command:  \033[2m%s\033[0m\n' "$failed_cmd" >&2
+
+    if (( ${#FUNCNAME[@]} > 2 )); then
+        printf '\033[1;31m├─ Stack trace ───────────────────────────────────────────────────────┤\033[0m\n' >&2
+        local i
+        for ((i=1; i<${#FUNCNAME[@]}; i++)); do
+            printf '\033[1;31m│\033[0m  %s  at  %s:%s\n' "${FUNCNAME[$i]}" "${BASH_SOURCE[$i]:-<unknown>}" "${BASH_LINENO[$((i-1))]}" >&2
+        done
+    fi
+    printf '\033[1;31m└─────────────────────────────────────────────────────────────────────┘\033[0m\n' >&2
+
+    setup_fail "$SETUP_TITLE failed (exit $exit_code) at line $line_no: $failed_cmd"
+    setup_finish_pause
+    exit "$exit_code"
+}
+
 setup_init() {
     SETUP_TAG="setup-$1"
     SETUP_TITLE="$2"
-    trap 'setup_fail "$SETUP_TITLE failed at line $LINENO"' ERR
+    trap '_setup_err_trap' ERR
     setup_notify "Starting…" "download"
     printf '\033[1;35m▶ %s\033[0m  (distro: %s)\n' "$SETUP_TITLE" "$DISTRO_ID"
 }
 
 # -- Package install helpers --------------------------------------------------
+# NOTE: We always use an AUR helper (paru or yay) for ALL packages,
+# including official repo packages. This simplifies the flow and lets the
+# helper handle dependency resolution, building, and caching consistently.
+# Priority: paru > yay > bootstrap yay.
 ensure_aur_helper() {
-    if have_cmd yay; then echo yay; return 0; fi
     if have_cmd paru; then echo paru; return 0; fi
+    if have_cmd yay; then echo yay; return 0; fi
     setup_notify "Bootstrapping yay (AUR helper)…" "download"
     sudo pacman -S --needed --noconfirm git base-devel >&2
     local tmp
@@ -92,20 +132,31 @@ ensure_aur_helper() {
 }
 
 # install_arch <repo-pkgs...> -- <aur-pkgs...>
+# Always uses an AUR helper (paru or yay) for every package.
+# The repo/aur split is kept for callers; everything is merged and handed to
+# the helper so repo packages are resolved through it as well.
 install_arch() {
     local repo=() aur=() seen_split=0
     for a in "$@"; do
         if [[ "$a" == "--" ]]; then seen_split=1; continue; fi
         if (( seen_split )); then aur+=("$a"); else repo+=("$a"); fi
     done
-    if (( ${#repo[@]} )); then
-        sudo pacman -S --needed --noconfirm "${repo[@]}"
+
+    local all_pkgs=()
+    (( ${#repo[@]} )) && all_pkgs+=("${repo[@]}")
+    (( ${#aur[@]} )) && all_pkgs+=("${aur[@]}")
+
+    if (( ${#all_pkgs[@]} == 0 )); then
+        echo "warning: install_arch called with no packages" >&2
+        return 0
     fi
-    if (( ${#aur[@]} )); then
-        local helper
-        helper="$(ensure_aur_helper)"
-        "$helper" -S --needed --noconfirm "${aur[@]}"
-    fi
+
+    local helper
+    helper="$(ensure_aur_helper)"
+
+    echo "  · AUR helper: $helper"
+    echo "  · Installing: ${all_pkgs[*]}"
+    "$helper" -S --needed --noconfirm "${all_pkgs[@]}"
 }
 
 install_flatpak() {

--- a/scripts/setup/_lib.sh
+++ b/scripts/setup/_lib.sh
@@ -6,12 +6,17 @@
 #   - distro detection         (DISTRO_ID, DISTRO_LIKE, is_arch_like)
 #   - progress notifications   (setup_notify, setup_progress, setup_done, setup_fail)
 #   - command/package helpers  (have_cmd, ensure_aur_helper, install_arch, install_flatpak)
+#   - developer-friendly error reporting (setup_err_trap, TRACE mode)
 #
 # Conventions:
 #   - The recipe must `set -Eeuo pipefail` and call `setup_init "<id>" "<title>"`
 #     before doing any work. `setup_init` traps errors and emits a failure notify.
 #   - All progress notifications share a synchronous tag so the desktop notifier
 #     replaces the previous bubble in place instead of stacking.
+
+# -- Debug / trace mode -------------------------------------------------------
+# Set TRACE=1 to enable bash trace (set -x) for full command debugging.
+[[ "${TRACE:-}" == "1" ]] && set -x
 
 # -- Distro detection --------------------------------------------------------
 _setup_load_distro() {
@@ -70,9 +75,31 @@ setup_fail() {
 }
 
 setup_err_trap() {
-    local status="$1"
-    local line="$2"
-    setup_fail "$SETUP_TITLE failed at line $line"
+    local status="${1:-$?}"
+    local line="${2:-$LINENO}"
+    local failed_cmd="${BASH_COMMAND:-<unknown>}"
+    local src_file="${BASH_SOURCE[1]:-<unknown>}"
+    local func_name="${FUNCNAME[1]:-<main>}"
+
+    printf '\n' >&2
+    printf '\033[1;31m┌─ Error ─────────────────────────────────────────────────────────────┐\033[0m\n' >&2
+    printf '\033[1;31m│\033[0m Setup:    \033[1m%s\033[0m\n' "${SETUP_TITLE:-setup}" >&2
+    printf '\033[1;31m│\033[0m Exit:     \033[1;31m%d\033[0m\n' "$status" >&2
+    printf '\033[1;31m│\033[0m Line:     \033[1;33m%d\033[0m\n' "$line" >&2
+    printf '\033[1;31m│\033[0m File:     \033[2m%s\033[0m\n' "$src_file" >&2
+    printf '\033[1;31m│\033[0m Function: \033[2m%s\033[0m\n' "$func_name" >&2
+    printf '\033[1;31m│\033[0m Command:  \033[2m%s\033[0m\n' "$failed_cmd" >&2
+
+    if (( ${#FUNCNAME[@]} > 2 )); then
+        printf '\033[1;31m├─ Stack trace ───────────────────────────────────────────────────────┤\033[0m\n' >&2
+        local i
+        for ((i=1; i<${#FUNCNAME[@]}; i++)); do
+            printf '\033[1;31m│\033[0m  %s  at  %s:%s\n' "${FUNCNAME[$i]}" "${BASH_SOURCE[$i]:-<unknown>}" "${BASH_LINENO[$((i-1))]}" >&2
+        done
+    fi
+    printf '\033[1;31m└─────────────────────────────────────────────────────────────────────┘\033[0m\n' >&2
+
+    setup_fail "${SETUP_TITLE:-Setup} failed at line $line"
     setup_finish_pause
     exit "$status"
 }
@@ -87,8 +114,8 @@ setup_init() {
 
 # -- Package install helpers --------------------------------------------------
 ensure_aur_helper() {
-    if have_cmd yay; then echo yay; return 0; fi
     if have_cmd paru; then echo paru; return 0; fi
+    if have_cmd yay; then echo yay; return 0; fi
     setup_notify "Bootstrapping yay (AUR helper)…" "download"
     sudo pacman -S --needed --noconfirm git base-devel >&2
     local tmp
@@ -106,14 +133,20 @@ install_arch() {
         if [[ "$a" == "--" ]]; then seen_split=1; continue; fi
         if (( seen_split )); then aur+=("$a"); else repo+=("$a"); fi
     done
-    if (( ${#repo[@]} )); then
-        sudo pacman -S --needed --noconfirm "${repo[@]}"
+    local all_pkgs=()
+    (( ${#repo[@]} )) && all_pkgs+=("${repo[@]}")
+    (( ${#aur[@]} )) && all_pkgs+=("${aur[@]}")
+
+    if (( ${#all_pkgs[@]} == 0 )); then
+        echo "warning: install_arch called with no packages" >&2
+        return 0
     fi
-    if (( ${#aur[@]} )); then
-        local helper
-        helper="$(ensure_aur_helper)"
-        "$helper" -S --needed --noconfirm "${aur[@]}"
-    fi
+
+    local helper
+    helper="$(ensure_aur_helper)"
+    echo "  · AUR helper: $helper"
+    echo "  · Installing: ${all_pkgs[*]}"
+    "$helper" -S --needed --noconfirm "${all_pkgs[@]}"
 }
 
 install_flatpak() {

--- a/scripts/setup/editors.sh
+++ b/scripts/setup/editors.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# scripts/setup/editors.sh
+# /setup-editors — install a selected code editor/IDE.
+#
+# @meta name: Setup Code Editors
+# @meta description: Choose and install VS Code, OSS Code, Zed, Cursor, or Neovim + LazyVim
+# @meta icon: code
+# @meta keywords: ide editor vscode code zed cursor neovim lazyvim aur arch
+#
+# Contributor guide:
+# - Keep this script simple and single-file.
+# - To add an editor, add one row to EDITORS below:
+#     key|Display Name|arch repo packages|arch AUR packages|post install hook
+# - Package lists are space-separated. Leave a field empty when unused.
+# - Example:
+#     "helix|Helix|helix||"
+#     "some-editor|Some Editor||some-editor-bin|post_install_some_editor"
+# - If extra setup is needed, add a small post_install_* function below.
+#
+# Current support:
+# - Arch-like distros only, using pacman packages and/or AUR packages.
+# - Other distros get an apology + support-coming-soon notice.
+
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/_lib.sh"
+
+# Add/edit supported editors here.
+# Format: "key|Display Name|arch repo packages|arch AUR packages|post install hook"
+EDITORS=(
+    "vscode|VS Code||visual-studio-code-bin|"
+    "oss-code|OSS Code||code|"
+    "zed|Zed||zed-bin|"
+    "cursor|Cursor||cursor-bin|"
+    "neovim-lazyvim|Neovim + LazyVim||neovim git|post_install_lazyvim"
+)
+
+split_words_into_array() {
+    local raw="$1"
+    local -n out_ref="$2"
+    out_ref=()
+    [[ -z "$raw" ]] && return 0
+    # Package names are expected to be whitespace-free tokens.
+    # shellcheck disable=SC2206
+    out_ref=($raw)
+}
+
+editor_field() {
+    local row="$1" field_index="$2"
+    local key label arch_repo arch_aur hook
+    IFS='|' read -r key label arch_repo arch_aur hook <<< "$row"
+
+    case "$field_index" in
+        key) echo "$key" ;;
+        label) echo "$label" ;;
+        arch_repo) echo "$arch_repo" ;;
+        arch_aur) echo "$arch_aur" ;;
+        hook) echo "$hook" ;;
+    esac
+}
+
+post_install_lazyvim() {
+    local nvim_cfg nvim_data nvim_state nvim_cache
+    nvim_cfg="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
+    nvim_data="${XDG_DATA_HOME:-$HOME/.local/share}/nvim"
+    nvim_state="${XDG_STATE_HOME:-$HOME/.local/state}/nvim"
+    nvim_cache="${XDG_CACHE_HOME:-$HOME/.cache}/nvim"
+
+    if [[ -d "$nvim_cfg" ]] || [[ -d "$nvim_data" ]] || [[ -d "$nvim_state" ]] || [[ -d "$nvim_cache" ]]; then
+        echo "warning: Existing Neovim files detected; skipping LazyVim bootstrap to avoid overwriting your setup." >&2
+        echo "         Back up/remove nvim dirs and rerun if you want the LazyVim starter." >&2
+        return 0
+    fi
+
+    git clone https://github.com/LazyVim/starter "$nvim_cfg"
+    rm -rf "$nvim_cfg/.git"
+    echo "  · LazyVim starter installed to $nvim_cfg"
+}
+
+choose_editor_index() {
+    local cancel_idx choice i row label arch_repo arch_aur details
+
+    # This function returns only the selected array index on stdout; print the
+    # interactive menu on stderr so command substitution does not capture it.
+    echo >&2
+    echo "Select one editor/IDE to install:" >&2
+    for i in "${!EDITORS[@]}"; do
+        row="${EDITORS[$i]}"
+        label="$(editor_field "$row" label)"
+        arch_repo="$(editor_field "$row" arch_repo)"
+        arch_aur="$(editor_field "$row" arch_aur)"
+
+        details=()
+        [[ -n "$arch_repo" ]] && details+=("repo: $arch_repo")
+        [[ -n "$arch_aur" ]] && details+=("aur: $arch_aur")
+
+        if (( ${#details[@]} )); then
+            printf '  %d) %s (%s)\n' "$((i + 1))" "$label" "$(IFS=', '; echo "${details[*]}")" >&2
+        else
+            printf '  %d) %s\n' "$((i + 1))" "$label" >&2
+        fi
+    done
+
+    cancel_idx=$(( ${#EDITORS[@]} + 1 ))
+    printf '  %d) Cancel\n\n' "$cancel_idx" >&2
+
+    while true; do
+        read -r -p "Enter choice [1-${cancel_idx}]: " choice
+        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= cancel_idx )); then
+            break
+        fi
+        echo "Invalid choice. Please enter a number from 1 to ${cancel_idx}." >&2
+    done
+
+    if (( choice == cancel_idx )); then
+        return 1
+    fi
+
+    echo "$((choice - 1))"
+}
+
+install_arch_editor() {
+    local row="$1"
+    local arch_repo arch_aur repo_pkgs aur_pkgs
+
+    arch_repo="$(editor_field "$row" arch_repo)"
+    arch_aur="$(editor_field "$row" arch_aur)"
+    repo_pkgs=()
+    aur_pkgs=()
+
+    split_words_into_array "$arch_repo" repo_pkgs
+    split_words_into_array "$arch_aur" aur_pkgs
+
+    if (( ${#repo_pkgs[@]} == 0 )) && (( ${#aur_pkgs[@]} == 0 )); then
+        echo "No Arch package mapping found for: $(editor_field "$row" label)" >&2
+        return 1
+    fi
+
+    if (( ${#repo_pkgs[@]} )) && (( ${#aur_pkgs[@]} )); then
+        install_arch "${repo_pkgs[@]}" -- "${aur_pkgs[@]}"
+    elif (( ${#repo_pkgs[@]} )); then
+        install_arch "${repo_pkgs[@]}"
+    else
+        install_arch -- "${aur_pkgs[@]}"
+    fi
+}
+
+run_post_install_hook() {
+    local row="$1"
+    local hook label
+
+    hook="$(editor_field "$row" hook)"
+    label="$(editor_field "$row" label)"
+
+    if [[ -n "$hook" ]]; then
+        "$hook"
+    else
+        echo "  · No extra configuration required for ${label}."
+    fi
+}
+
+setup_init "editors" "Setup Code Editors"
+
+if ! is_arch_like; then
+    TOTAL=1
+    setup_progress 1 $TOTAL "Checking distro support"
+    msg="Sorry — code editor setup currently supports Arch-based distros only. Support for other distros is coming soon."
+    echo "$msg" >&2
+    setup_fail "$msg"
+    setup_finish_pause
+    exit 0
+fi
+
+TOTAL=4
+setup_progress 1 $TOTAL "Choose which editor/IDE to install"
+if ! selected_index="$(choose_editor_index)"; then
+    setup_progress 2 $TOTAL "No changes made"
+    setup_done "Cancelled by user"
+    setup_finish_pause
+    exit 0
+fi
+
+selected_row="${EDITORS[$selected_index]}"
+selected_name="$(editor_field "$selected_row" label)"
+
+setup_progress 2 $TOTAL "Installing ${selected_name}"
+install_arch_editor "$selected_row"
+
+setup_progress 3 $TOTAL "Post-install configuration"
+run_post_install_hook "$selected_row"
+
+setup_progress 4 $TOTAL "Finalizing"
+setup_done "${selected_name} setup complete"
+setup_finish_pause

--- a/scripts/setup/editors.sh
+++ b/scripts/setup/editors.sh
@@ -33,7 +33,7 @@ EDITORS=(
     "oss-code|OSS Code||code|"
     "zed|Zed||zed-bin|"
     "cursor|Cursor||cursor-bin|"
-    "neovim-lazyvim|Neovim + LazyVim|neovim git||post_install_lazyvim"
+    "neovim-lazyvim|Neovim + LazyVim||neovim git|post_install_lazyvim"
 )
 
 split_words_into_array() {

--- a/scripts/setup/editors.sh
+++ b/scripts/setup/editors.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# scripts/setup/editors.sh
+# /setup-editors — install a selected code editor/IDE.
+#
+# @meta name: Setup Code Editors
+# @meta description: Choose and install VS Code, OSS Code, Zed, Cursor, or Neovim + LazyVim
+# @meta icon: code
+# @meta keywords: ide editor vscode code zed cursor neovim lazyvim aur arch
+#
+# Contributor guide:
+# - Keep this script simple and single-file.
+# - To add an editor, add one row to EDITORS below:
+#     key|Display Name|arch repo packages|arch AUR packages|post install hook
+# - Package lists are space-separated. Leave a field empty when unused.
+# - Example:
+#     "helix|Helix|helix||"
+#     "some-editor|Some Editor||some-editor-bin|post_install_some_editor"
+# - If extra setup is needed, add a small post_install_* function below.
+#
+# Current support:
+# - Arch-like distros only, using pacman packages and/or AUR packages.
+# - Other distros get an apology + support-coming-soon notice.
+
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/_lib.sh"
+
+# Add/edit supported editors here.
+# Format: "key|Display Name|arch repo packages|arch AUR packages|post install hook"
+EDITORS=(
+    "vscode|VS Code||visual-studio-code-bin|"
+    "oss-code|OSS Code||code|"
+    "zed|Zed||zed-bin|"
+    "cursor|Cursor||cursor-bin|"
+    "neovim-lazyvim|Neovim + LazyVim|neovim git||post_install_lazyvim"
+)
+
+split_words_into_array() {
+    local raw="$1"
+    local -n out_ref="$2"
+    out_ref=()
+    [[ -z "$raw" ]] && return 0
+    # Package names are expected to be whitespace-free tokens.
+    # shellcheck disable=SC2206
+    out_ref=($raw)
+}
+
+editor_field() {
+    local row="$1" field_index="$2"
+    local key label arch_repo arch_aur hook
+    IFS='|' read -r key label arch_repo arch_aur hook <<< "$row"
+
+    case "$field_index" in
+        key) echo "$key" ;;
+        label) echo "$label" ;;
+        arch_repo) echo "$arch_repo" ;;
+        arch_aur) echo "$arch_aur" ;;
+        hook) echo "$hook" ;;
+    esac
+}
+
+post_install_lazyvim() {
+    local nvim_cfg nvim_data nvim_state nvim_cache
+    nvim_cfg="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
+    nvim_data="${XDG_DATA_HOME:-$HOME/.local/share}/nvim"
+    nvim_state="${XDG_STATE_HOME:-$HOME/.local/state}/nvim"
+    nvim_cache="${XDG_CACHE_HOME:-$HOME/.cache}/nvim"
+
+    if [[ -d "$nvim_cfg" ]] || [[ -d "$nvim_data" ]] || [[ -d "$nvim_state" ]] || [[ -d "$nvim_cache" ]]; then
+        echo "warning: Existing Neovim files detected; skipping LazyVim bootstrap to avoid overwriting your setup." >&2
+        echo "         Back up/remove nvim dirs and rerun if you want the LazyVim starter." >&2
+        return 0
+    fi
+
+    git clone https://github.com/LazyVim/starter "$nvim_cfg"
+    rm -rf "$nvim_cfg/.git"
+    echo "  · LazyVim starter installed to $nvim_cfg"
+}
+
+choose_editor_index() {
+    local cancel_idx choice i row label arch_repo arch_aur details
+
+    # This function returns only the selected array index on stdout; print the
+    # interactive menu on stderr so command substitution does not capture it.
+    echo >&2
+    echo "Select one editor/IDE to install:" >&2
+    for i in "${!EDITORS[@]}"; do
+        row="${EDITORS[$i]}"
+        label="$(editor_field "$row" label)"
+        arch_repo="$(editor_field "$row" arch_repo)"
+        arch_aur="$(editor_field "$row" arch_aur)"
+
+        details=()
+        [[ -n "$arch_repo" ]] && details+=("repo: $arch_repo")
+        [[ -n "$arch_aur" ]] && details+=("aur: $arch_aur")
+
+        if (( ${#details[@]} )); then
+            printf '  %d) %s (%s)\n' "$((i + 1))" "$label" "$(IFS=', '; echo "${details[*]}")" >&2
+        else
+            printf '  %d) %s\n' "$((i + 1))" "$label" >&2
+        fi
+    done
+
+    cancel_idx=$(( ${#EDITORS[@]} + 1 ))
+    printf '  %d) Cancel\n\n' "$cancel_idx" >&2
+
+    while true; do
+        read -r -p "Enter choice [1-${cancel_idx}]: " choice
+        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= cancel_idx )); then
+            break
+        fi
+        echo "Invalid choice. Please enter a number from 1 to ${cancel_idx}." >&2
+    done
+
+    if (( choice == cancel_idx )); then
+        return 1
+    fi
+
+    echo "$((choice - 1))"
+}
+
+install_arch_editor() {
+    local row="$1"
+    local arch_repo arch_aur repo_pkgs aur_pkgs
+
+    arch_repo="$(editor_field "$row" arch_repo)"
+    arch_aur="$(editor_field "$row" arch_aur)"
+    repo_pkgs=()
+    aur_pkgs=()
+
+    split_words_into_array "$arch_repo" repo_pkgs
+    split_words_into_array "$arch_aur" aur_pkgs
+
+    if (( ${#repo_pkgs[@]} == 0 )) && (( ${#aur_pkgs[@]} == 0 )); then
+        echo "No Arch package mapping found for: $(editor_field "$row" label)" >&2
+        return 1
+    fi
+
+    if (( ${#repo_pkgs[@]} )) && (( ${#aur_pkgs[@]} )); then
+        install_arch "${repo_pkgs[@]}" -- "${aur_pkgs[@]}"
+    elif (( ${#repo_pkgs[@]} )); then
+        install_arch "${repo_pkgs[@]}"
+    else
+        install_arch -- "${aur_pkgs[@]}"
+    fi
+}
+
+run_post_install_hook() {
+    local row="$1"
+    local hook label
+
+    hook="$(editor_field "$row" hook)"
+    label="$(editor_field "$row" label)"
+
+    if [[ -n "$hook" ]]; then
+        "$hook"
+    else
+        echo "  · No extra configuration required for ${label}."
+    fi
+}
+
+setup_init "editors" "Setup Code Editors"
+
+if ! is_arch_like; then
+    TOTAL=1
+    setup_progress 1 $TOTAL "Checking distro support"
+    msg="Sorry — code editor setup currently supports Arch-based distros only. Support for other distros is coming soon."
+    echo "$msg" >&2
+    setup_fail "$msg"
+    setup_finish_pause
+    exit 0
+fi
+
+TOTAL=4
+setup_progress 1 $TOTAL "Choose which editor/IDE to install"
+if ! selected_index="$(choose_editor_index)"; then
+    setup_progress 2 $TOTAL "No changes made"
+    setup_done "Cancelled by user"
+    setup_finish_pause
+    exit 0
+fi
+
+selected_row="${EDITORS[$selected_index]}"
+selected_name="$(editor_field "$selected_row" label)"
+
+setup_progress 2 $TOTAL "Installing ${selected_name}"
+install_arch_editor "$selected_row"
+
+setup_progress 3 $TOTAL "Post-install configuration"
+run_post_install_hook "$selected_row"
+
+setup_progress 4 $TOTAL "Finalizing"
+setup_done "${selected_name} setup complete"
+setup_finish_pause


### PR DESCRIPTION
## Summary

Add an auto-discovered `/setup-editors` recipe for installing one supported code editor or IDE on Arch-based systems.

## Supported Editors

- VS Code via `visual-studio-code-bin`
- OSS Code via `code`
- Zed via `zed-bin`
- Cursor via `cursor-bin`
- Neovim with the LazyVim starter

## Implementation

- Keeps the editor catalog in one simple `EDITORS` array for easy maintenance.
- Routes Arch package installs through the preferred available AUR helper, choosing `paru` before `yay`.
- Adds detailed setup error output with exit code, source line, file, function, failed command, and stack trace.
- Supports `TRACE=1` for Bash command tracing.
- Holds the setup terminal open after failures so diagnostics remain visible.
- Avoids overwriting an existing Neovim configuration when bootstrapping LazyVim.
- Shows a clear support-coming-soon message on non-Arch distributions.

## Testing

- [x] `bash -n scripts/setup/_lib.sh`
- [x] `bash -n scripts/setup/editors.sh`
- [x] Setup recipe scanner discovers `/setup-editors` metadata
- [x] Mocked package-routing test verifies repository and AUR arguments reach the selected helper
- [x] Cancellation path tested without installing packages
- [x] Error trap tested with a failing command
- [ ] Full clean-Arch install test with real editor packages

The recipe remains intentionally Arch-only for now, as discussed in the review.