### PR TITLE
fix(spotify): follow spicetify docs, remove incompatible installs, improve maintainability

### DIFF
--- a/scripts/setup/_lib.sh
+++ b/scripts/setup/_lib.sh
@@ -72,7 +72,8 @@ setup_fail() {
 setup_init() {
     SETUP_TAG="setup-$1"
     SETUP_TITLE="$2"
-    trap 'setup_fail "$SETUP_TITLE failed at line $LINENO"' ERR
+    # Hold the terminal open on unexpected errors so the user can read the message.
+    trap 'setup_fail "$SETUP_TITLE failed at line $LINENO"; setup_finish_pause' ERR
     setup_notify "Starting…" "download"
     printf '\033[1;35m▶ %s\033[0m  (distro: %s)\n' "$SETUP_TITLE" "$DISTRO_ID"
 }

--- a/scripts/setup/spotify.sh
+++ b/scripts/setup/spotify.sh
@@ -7,56 +7,48 @@
 # @meta icon: music_note
 # @meta keywords: spotify music spicetify aur flatpak
 #
-# Arch family : `spotify` (AUR) + `spicetify-cli` (AUR). Tries
-#               `spicetify backup apply` first; only launches Spotify
-#               (so the user can sign in and Spotify can generate its
-#               prefs file) if the first apply fails. Then sets prefs_path,
-#               retries, installs the Marketplace, and — only if the user
-#               has enabled `appearance.wallpaperTheming.enableSpicetify`
-#               in config.json — applies the iNiR Spicetify theme.
+# Arch family : `spotify` (AUR) + `spicetify-cli` (AUR).
+#               Follows the official Spicetify docs for Linux setup:
+#               https://spicetify.app/docs/getting-started
+#
+#               We enforce the AUR package because Spicetify CANNOT patch
+#               Flatpak, Snap, or spotify-launcher installs reliably.
 # Other distros: falls back to the Flatpak build of Spotify. Spicetify is
 #                skipped because it cannot patch the Flatpak install reliably.
+#
+# --- Developer notes ---------------------------------------------------------
+# To add/remove an incompatible install type, edit _remove_incompatible().
+# To change the theme script path, edit the THEME_SCRIPT variable below.
+# Set TRACE=1 to enable bash trace (set -x) for debugging.
+# ------------------------------------------------------------------------------
 
+[[ "${TRACE:-}" == "1" ]] && set -x
 set -Eeuo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/_lib.sh"
 
+# ------------------------------------------------------------------------------
+# Config
+# ------------------------------------------------------------------------------
 CONFIG_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/illogical-impulse/config.json"
+THEME_SCRIPT="$SCRIPT_DIR/../colors/apply-spicetify-theme.sh"
+SPOTIFY_DIR="/opt/spotify"
+
+# ------------------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------------------
+
+# Print an error and exit, but always hold the terminal open.
+_die() {
+    setup_fail "$1"
+    setup_finish_pause
+    exit 1
+}
 
 _find_prefs() {
     find "$HOME" -path '*/spotify/prefs' -print -quit 2>/dev/null
-}
-
-_await_or_force_close_spotify() {
-    echo
-    echo "  ┌─────────────────────────────────────────────────────────────┐"
-    echo "  │  Sign in to Spotify so it can write its prefs file.         │"
-    echo "  │  Quit Spotify normally to continue, OR press Enter here     │"
-    echo "  │  to force-quit it.                                          │"
-    echo "  └─────────────────────────────────────────────────────────────┘"
-    echo
-
-    local waited=0
-    while ! pgrep -x spotify >/dev/null 2>&1; do
-        sleep 1
-        waited=$((waited + 1))
-        (( waited >= 30 )) && { echo "  · Spotify did not start; continuing anyway." >&2; return 0; }
-    done
-
-    while pgrep -x spotify >/dev/null 2>&1; do
-        if read -r -t 2 _; then
-            echo "  · Force-closing Spotify…"
-            pkill -x spotify || true
-            for _ in 1 2 3 4 5; do
-                pgrep -x spotify >/dev/null 2>&1 || break
-                sleep 1
-            done
-            pgrep -x spotify >/dev/null 2>&1 && pkill -9 -x spotify || true
-            break
-        fi
-    done
-    echo "  · Spotify closed — resuming setup."
 }
 
 _theme_enabled_in_config() {
@@ -66,154 +58,249 @@ _theme_enabled_in_config() {
         "$CONFIG_PATH" 2>/dev/null)" == "true" ]]
 }
 
-setup_init "spotify" "Setup Spotify + Spicetify"
+# Wait for the user to close Spotify (or force-close with Enter).
+_await_spotify_close() {
+    echo
+    cat <<'BANNER'
+  ┌─────────────────────────────────────────────────────────────┐
+  │  Sign in to Spotify so it can write its prefs file.       │
+  │  Quit Spotify normally to continue, OR press Enter here   │
+  │  to force-quit it.                                        │
+  └─────────────────────────────────────────────────────────────┘
+BANNER
 
-if is_arch_like; then
-    TOTAL=5
+    local waited=0
+    while ! pgrep -x spotify >/dev/null 2>&1; do
+        sleep 1
+        waited=$((waited + 1))
+        if (( waited >= 30 )); then
+            echo "  · Spotify did not start; continuing anyway." >&2
+            return 0
+        fi
+    done
 
-    setup_progress 1 $TOTAL "Installing Spotify (AUR) and Spicetify CLI"
+    while pgrep -x spotify >/dev/null 2>&1; do
+        if read -r -t 2 _; then
+            echo "  · Force-closing Spotify…"
+            pkill -x spotify || true
+            sleep 2
+            pgrep -x spotify >/dev/null 2>&1 && pkill -9 -x spotify || true
+            break
+        fi
+    done
+    echo "  · Spotify closed — resuming setup."
+}
+
+# ------------------------------------------------------------------------------
+# Phase 1 — Remove incompatible installs
+# ------------------------------------------------------------------------------
+# Spicetify can only patch the official AUR package at /opt/spotify.
+# Anything else (Flatpak, Snap, launcher) must go first.
+# ------------------------------------------------------------------------------
+_remove_incompatible() {
+    local helper
+    helper="$(ensure_aur_helper)"
+
+    # Flatpak
+    if have_cmd flatpak; then
+        echo "  · Checking for Flatpak Spotify…"
+        flatpak uninstall -y --user com.spotify.Client 2>/dev/null || \
+            flatpak uninstall -y com.spotify.Client 2>/dev/null || true
+    fi
+
+    # Snap
+    if have_cmd snap; then
+        echo "  · Checking for Snap Spotify…"
+        sudo snap remove spotify >/dev/null 2>&1 || true
+    fi
+
+    # spotify-launcher (AUR) — installs to user dir, not /opt/spotify
+    if have_cmd spotify-launcher; then
+        echo "  · Removing spotify-launcher…"
+        "$helper" -Rns --noconfirm spotify-launcher 2>/dev/null || true
+        rm -rf "$HOME/.local/share/spotify-launcher" 2>/dev/null || true
+    fi
+
+    # Conflicting spicetify packages (prevent interactive "Remove X? [y/N]" prompt)
+    if "$helper" -Q spicetify-cli-git >/dev/null 2>&1; then
+        echo "  · Removing spicetify-cli-git (conflicts with spicetify-cli)…"
+        "$helper" -Rns --noconfirm spicetify-cli-git 2>/dev/null || true
+    fi
+    if "$helper" -Q spicetify-cli >/dev/null 2>&1; then
+        echo "  · Reinstalling spicetify-cli…"
+        "$helper" -Rns --noconfirm spicetify-cli 2>/dev/null || true
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Phase 2 — Install packages
+# ------------------------------------------------------------------------------
+_install_packages() {
     install_arch -- spotify spicetify-cli
 
-    # Verify spicetify is actually available now
+    # Verify spicetify is in PATH; fall back to the curl installer location.
+    if ! have_cmd spicetify && [[ -x "$HOME/.spicetify/spicetify" ]]; then
+        export PATH="$HOME/.spicetify:$PATH"
+    fi
     if ! have_cmd spicetify; then
-        setup_fail "spicetify was installed but is not in PATH. Open a new terminal and rerun /setup-spotify."
-        setup_finish_pause
-        exit 1
+        _die "spicetify was installed but is not in PATH. Open a new terminal and rerun /setup-spotify."
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Phase 3 — Configure Spicetify paths & permissions
+# ------------------------------------------------------------------------------
+# Per Spicetify docs: set spotify_path and grant write permissions.
+# https://spicetify.app/docs/getting-started
+# ------------------------------------------------------------------------------
+_configure_spicetify() {
+    echo "  · Spotify at: $SPOTIFY_DIR"
+
+    if [[ ! -d "$SPOTIFY_DIR/Apps" ]]; then
+        _die "Could not find $SPOTIFY_DIR/Apps. AUR install may have failed."
     fi
 
-    # Detect the Spotify install directory. Prefer /opt/spotify (AUR package,
-    # has .spa files spicetify needs) over the spotify-launcher expanded dir.
-    _spotify_dir() {
-        for d in /opt/spotify "$HOME/.local/share/spotify-launcher/install/usr/share/spotify"; do
-            [[ -d "$d/Apps" ]] && echo "$d" && return
-        done
-    }
+    spicetify config spotify_path "$SPOTIFY_DIR" >/dev/null 2>&1 || true
 
-    setup_progress 2 $TOTAL "Configuring Spicetify paths"
-    spotify_dir="$(_spotify_dir)"
-    if [[ -z "$spotify_dir" ]]; then
-        setup_fail "Could not find Spotify install directory."
-        setup_finish_pause
-        exit 1
-    fi
-    echo "  · Spotify at: $spotify_dir"
+    echo "  · Granting write permissions…"
+    sudo chmod a+wr "$SPOTIFY_DIR" 2>/dev/null || \
+        echo "  · warning: sudo chmod $SPOTIFY_DIR failed (may already be writable)." >&2
+    sudo chmod a+wr "$SPOTIFY_DIR/Apps" -R 2>/dev/null || \
+        echo "  · warning: sudo chmod $SPOTIFY_DIR/Apps failed (may already be writable)." >&2
+}
 
-    # Ensure spicetify config directory exists so subsequent commands don't fail
-    spicetify_cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify"
-    mkdir -p "$spicetify_cfg_dir"
-
-    # Ensure spicetify points to the .spa-based install, not a launcher dir
-    spicetify config spotify_path "$spotify_dir" >/dev/null 2>&1 || true
-
-    # Spicetify needs write access to Spotify's files to inject the CSS/JS.
-    # Try sudo; if it fails (no TTY, no passwordless sudo, etc.) warn and continue
-    # because the user may have already set the permissions manually.
-    if ! sudo chmod -R a+wr "$spotify_dir" 2>/dev/null; then
-        echo "  · warning: could not chmod $spotify_dir (sudo failed or not needed)." >&2
-    fi
-    if [[ -d "$spotify_dir/Apps" ]] && ! sudo chmod -R a+wr "$spotify_dir/Apps" 2>/dev/null; then
-        echo "  · warning: could not chmod $spotify_dir/Apps (sudo failed or not needed)." >&2
-    fi
-
-    setup_progress 3 $TOTAL "Applying Spicetify backup"
-
-    # If Spotify is already running from a previous session, spicetify cannot
-    # patch the files. Ask the user to close it first.
-    if pgrep -x spotify >/dev/null 2>&1; then
-        echo "  · Spotify is already running. Please close it before continuing."
-        while pgrep -x spotify >/dev/null 2>&1; do
-            sleep 1
-        done
-        echo "  · Spotify closed."
-    fi
-
+# ------------------------------------------------------------------------------
+# Phase 4 — First-run: generate prefs file
+# ------------------------------------------------------------------------------
+# Spicetify docs: "If this is a fresh Spotify install, open Spotify and
+# log in for at least 60 seconds before running Spicetify."
+# ------------------------------------------------------------------------------
+_generate_prefs() {
+    local prefs
     prefs="$(_find_prefs)"
     if [[ -n "$prefs" ]]; then
         echo "  · prefs already exists at $prefs"
         spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
+        return 0
     fi
 
-    _spicetify_apply() {
-        if spicetify backup apply; then return 0; fi
-        # Stale backup — try restore then redo
-        if spicetify restore backup apply; then return 0; fi
-        # Deadlocked (version mismatch) — nuke backup state and retry
-        local cfg_dir=""
-        local spicetify_c
-        spicetify_c="$(spicetify -c 2>/dev/null)" || true
-        if [[ -n "$spicetify_c" ]]; then
-            cfg_dir="$(dirname "$spicetify_c")"
-        fi
-        if [[ -n "$cfg_dir" && -d "$cfg_dir" ]]; then
-            echo "  · Clearing stale backup state…"
-            rm -rf "${cfg_dir:?}/Backup" 2>/dev/null || true
-            # Clear [Backup] section values in config
-            if [[ -f "${cfg_dir}/config-xpui.ini" ]]; then
-                sed -i '/^\[Backup\]/,/^\[/{/^\[Backup\]/!{/^\[/!d}}' \
-                    "${cfg_dir}/config-xpui.ini" 2>/dev/null || true
-            fi
-        fi
-        spicetify backup apply
-    }
-
-    if ! _spicetify_apply; then
-        echo
-        echo "  · backup apply failed (likely no prefs file yet)."
-        echo "  · Launching Spotify so it can generate its prefs…"
-        setsid -f spotify >/dev/null 2>&1 < /dev/null || \
-            nohup spotify >/dev/null 2>&1 < /dev/null &
-        setup_notify "Sign in to Spotify, then quit it (or press Enter in the terminal to force-quit)" "media-playback-start"
-        _await_or_force_close_spotify
-
-        prefs="$(_find_prefs)"
-        if [[ -z "$prefs" ]]; then
-            setup_fail "Could not locate spotify/prefs after first run; aborting."
-            setup_finish_pause
-            exit 1
-        fi
-        echo "  · Found prefs at $prefs"
-        spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
-        # Brief pause so Spotify releases file locks before we patch
-        sleep 1
-        if ! _spicetify_apply; then
-            setup_fail "Spicetify backup apply failed even after generating prefs. Check the error above."
-            setup_finish_pause
-            exit 1
-        fi
+    # Close any lingering Spotify process first
+    if pgrep -x spotify >/dev/null 2>&1; then
+        echo "  · Spotify is already running. Closing it first…"
+        pkill -x spotify || true
+        sleep 2
     fi
 
-    setup_progress 4 $TOTAL "Installing Spicetify Marketplace"
+    echo "  · Launching Spotify for first-run (needs ~60s to generate prefs)…"
+    setsid -f spotify >/dev/null 2>&1 < /dev/null || \
+        nohup spotify >/dev/null 2>&1 < /dev/null &
+
+    setup_notify "Sign in to Spotify, then quit it (or press Enter to force-quit)" "media-playback-start"
+    _await_spotify_close
+
+    prefs="$(_find_prefs)"
+    if [[ -z "$prefs" ]]; then
+        _die "Could not locate spotify/prefs after first run; aborting."
+    fi
+    echo "  · Found prefs at $prefs"
+    spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
+}
+
+# ------------------------------------------------------------------------------
+# Phase 5 — Apply Spicetify backup
+# ------------------------------------------------------------------------------
+# Official recovery flow from the docs.
+# ------------------------------------------------------------------------------
+_apply_spicetify() {
+    if spicetify backup apply; then return 0; fi
+
+    # Stale backup — try restore then redo
+    if spicetify restore backup apply; then return 0; fi
+
+    # Deadlocked (version mismatch) — nuke backup state and retry
+    local cfg_dir="" spicetify_c
+    spicetify_c="$(spicetify -c 2>/dev/null)" || true
+    if [[ -n "$spicetify_c" ]]; then
+        cfg_dir="$(dirname "$spicetify_c")"
+    fi
+    if [[ -n "$cfg_dir" && -d "$cfg_dir" ]]; then
+        echo "  · Clearing stale backup state…"
+        rm -rf "${cfg_dir:?}/Backup" 2>/dev/null || true
+        if [[ -f "${cfg_dir}/config-xpui.ini" ]]; then
+            sed -i '/^\[Backup\]/,/^\[/{/^\[Backup\]/!{/^\[/!d}}' \
+                "${cfg_dir}/config-xpui.ini" 2>/dev/null || true
+        fi
+    fi
+    spicetify backup apply
+}
+
+# ------------------------------------------------------------------------------
+# Phase 6 — Marketplace & theme
+# ------------------------------------------------------------------------------
+_install_marketplace() {
     if curl -fsSL https://raw.githubusercontent.com/spicetify/marketplace/main/resources/install.sh \
         | sh; then
-        echo "Marketplace installed."
+        echo "  · Marketplace installed."
     else
-        echo "warning: Marketplace installer failed; you can rerun it later." >&2
+        echo "  · warning: Marketplace installer failed; you can rerun it later." >&2
+    fi
+}
+
+_apply_theme() {
+    if ! _theme_enabled_in_config; then
+        echo "  · Skipping iNiR theme (appearance.wallpaperTheming.enableSpicetify is off)"
+        echo "    Enable it in Settings → Themes → 'Spotify theming' to apply the iNiR theme."
+        return 0
     fi
 
-    if _theme_enabled_in_config; then
-        setup_progress 5 $TOTAL "Applying iNiR Spicetify theme"
-        theme_script="$SCRIPT_DIR/../colors/apply-spicetify-theme.sh"
-        if [[ -x "$theme_script" ]]; then
-            if "$theme_script"; then
-                echo "iNiR theme applied."
-            else
-                echo "warning: theme script returned non-zero; rerun it manually if Spotify looks unstyled." >&2
-            fi
+    echo "  · Applying iNiR Spicetify theme…"
+    if [[ -x "$THEME_SCRIPT" ]]; then
+        if "$THEME_SCRIPT"; then
+            echo "  · iNiR theme applied."
         else
-            echo "warning: $theme_script not found or not executable; skipping theme." >&2
+            echo "  · warning: theme script returned non-zero; rerun it manually if Spotify looks unstyled." >&2
         fi
     else
-        setup_progress 5 $TOTAL "Skipping iNiR theme (appearance.wallpaperTheming.enableSpicetify is off)"
-        echo "  · Enable it in Settings → Themes → 'Spotify theming' to apply the iNiR theme."
+        echo "  · warning: $THEME_SCRIPT not found or not executable; skipping theme." >&2
     fi
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+setup_init "spotify" "Setup Spotify + Spicetify"
+
+if is_arch_like; then
+    TOTAL=6
+
+    setup_progress 1 $TOTAL "Removing incompatible Spotify installs"
+    _remove_incompatible
+
+    setup_progress 2 $TOTAL "Installing Spotify (AUR) and Spicetify CLI"
+    _install_packages
+
+    setup_progress 3 $TOTAL "Configuring Spicetify paths"
+    _configure_spicetify
+
+    setup_progress 4 $TOTAL "First-run: launch Spotify to generate prefs"
+    _generate_prefs
+
+    setup_progress 5 $TOTAL "Applying Spicetify backup"
+    if ! _apply_spicetify; then
+        _die "Spicetify backup apply failed. Check the error above."
+    fi
+
+    setup_progress 6 $TOTAL "Installing Spicetify Marketplace"
+    _install_marketplace
+    _apply_theme
 
     setup_done "Spotify + Spicetify ready. Launch Spotify to verify."
 else
     TOTAL=2
-    setup_progress 1 $TOTAL "Installing Spotify via Flatpak (no Spicetify on non-Arch)"
+    setup_progress 1 $TOTAL "Installing Spotify via Flatpak"
     install_flatpak com.spotify.Client
 
-    setup_progress 2 $TOTAL "Skipping Spicetify (unsupported on Flatpak Spotify)"
+    setup_progress 2 $TOTAL "Skipping Spicetify (unsupported on Flatpak)"
     setup_done "Spotify installed via Flatpak. Spicetify was skipped."
 fi
 

--- a/scripts/setup/spotify.sh
+++ b/scripts/setup/spotify.sh
@@ -74,6 +74,13 @@ if is_arch_like; then
     setup_progress 1 $TOTAL "Installing Spotify (AUR) and Spicetify CLI"
     install_arch -- spotify spicetify-cli
 
+    # Verify spicetify is actually available now
+    if ! have_cmd spicetify; then
+        setup_fail "spicetify was installed but is not in PATH. Open a new terminal and rerun /setup-spotify."
+        setup_finish_pause
+        exit 1
+    fi
+
     # Detect the Spotify install directory. Prefer /opt/spotify (AUR package,
     # has .spa files spicetify needs) over the spotify-launcher expanded dir.
     _spotify_dir() {
@@ -90,12 +97,36 @@ if is_arch_like; then
         exit 1
     fi
     echo "  · Spotify at: $spotify_dir"
+
+    # Ensure spicetify config directory exists so subsequent commands don't fail
+    spicetify_cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify"
+    mkdir -p "$spicetify_cfg_dir"
+
     # Ensure spicetify points to the .spa-based install, not a launcher dir
     spicetify config spotify_path "$spotify_dir" >/dev/null 2>&1 || true
-    sudo chmod a+wr "$spotify_dir"
-    sudo chmod a+wr "$spotify_dir/Apps" -R
+
+    # Spicetify needs write access to Spotify's files to inject the CSS/JS.
+    # Try sudo; if it fails (no TTY, no passwordless sudo, etc.) warn and continue
+    # because the user may have already set the permissions manually.
+    if ! sudo chmod -R a+wr "$spotify_dir" 2>/dev/null; then
+        echo "  · warning: could not chmod $spotify_dir (sudo failed or not needed)." >&2
+    fi
+    if [[ -d "$spotify_dir/Apps" ]] && ! sudo chmod -R a+wr "$spotify_dir/Apps" 2>/dev/null; then
+        echo "  · warning: could not chmod $spotify_dir/Apps (sudo failed or not needed)." >&2
+    fi
 
     setup_progress 3 $TOTAL "Applying Spicetify backup"
+
+    # If Spotify is already running from a previous session, spicetify cannot
+    # patch the files. Ask the user to close it first.
+    if pgrep -x spotify >/dev/null 2>&1; then
+        echo "  · Spotify is already running. Please close it before continuing."
+        while pgrep -x spotify >/dev/null 2>&1; do
+            sleep 1
+        done
+        echo "  · Spotify closed."
+    fi
+
     prefs="$(_find_prefs)"
     if [[ -n "$prefs" ]]; then
         echo "  · prefs already exists at $prefs"
@@ -107,14 +138,20 @@ if is_arch_like; then
         # Stale backup — try restore then redo
         if spicetify restore backup apply; then return 0; fi
         # Deadlocked (version mismatch) — nuke backup state and retry
-        local cfg_dir
-        cfg_dir="$(dirname "$(spicetify -c 2>/dev/null)" 2>/dev/null)"
-        if [[ -n "$cfg_dir" ]]; then
+        local cfg_dir=""
+        local spicetify_c
+        spicetify_c="$(spicetify -c 2>/dev/null)" || true
+        if [[ -n "$spicetify_c" ]]; then
+            cfg_dir="$(dirname "$spicetify_c")"
+        fi
+        if [[ -n "$cfg_dir" && -d "$cfg_dir" ]]; then
             echo "  · Clearing stale backup state…"
             rm -rf "${cfg_dir:?}/Backup" 2>/dev/null || true
             # Clear [Backup] section values in config
-            sed -i '/^\[Backup\]/,/^\[/{/^\[Backup\]/!{/^\[/!d}}' \
-                "${cfg_dir}/config-xpui.ini" 2>/dev/null || true
+            if [[ -f "${cfg_dir}/config-xpui.ini" ]]; then
+                sed -i '/^\[Backup\]/,/^\[/{/^\[Backup\]/!{/^\[/!d}}' \
+                    "${cfg_dir}/config-xpui.ini" 2>/dev/null || true
+            fi
         fi
         spicetify backup apply
     }
@@ -136,7 +173,13 @@ if is_arch_like; then
         fi
         echo "  · Found prefs at $prefs"
         spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
-        _spicetify_apply
+        # Brief pause so Spotify releases file locks before we patch
+        sleep 1
+        if ! _spicetify_apply; then
+            setup_fail "Spicetify backup apply failed even after generating prefs. Check the error above."
+            setup_finish_pause
+            exit 1
+        fi
     fi
 
     setup_progress 4 $TOTAL "Installing Spicetify Marketplace"

--- a/scripts/setup/spotify.sh
+++ b/scripts/setup/spotify.sh
@@ -7,30 +7,47 @@
 # @meta icon: music_note
 # @meta keywords: spotify music spicetify aur flatpak
 #
-# Arch family : `spotify` (AUR) + `spicetify-cli` (AUR). Repairs the
-#               Spicetify v2.44+ wrapper asset when source-built packages omit
-#               it, then tries `spicetify backup apply` first. It only launches
-#               Spotify (so the user can sign in and Spotify can generate its
-#               prefs file) if the first apply fails. Then sets prefs_path,
-#               retries, installs the Marketplace, and — only if the user has
-#               enabled `appearance.wallpaperTheming.enableSpicetify` in
-#               config.json — applies the iNiR Spicetify theme.
+# Arch family : `spotify` (AUR) + `spicetify-cli` (AUR).
+#               Follows the official Spicetify docs for Linux setup:
+#               https://spicetify.app/docs/getting-started
+#
+#               Removes incompatible installs (Flatpak, Snap, spotify-launcher,
+#               and conflicting spicetify-cli-git package), configures paths
+#               and permissions, repairs missing Spicetify v2.44+ wrapper assets,
+#               generates prefs if needed, applies Spicetify backup with
+#               progressive recovery, installs Marketplace, automatically
+#               enables Spicetify theming in iNiR config, and applies the theme.
 # Other distros: falls back to the Flatpak build of Spotify. Spicetify is
 #                skipped because it cannot patch the Flatpak install reliably.
+#
+# --- Developer notes ---------------------------------------------------------
+# Set TRACE=1 to enable bash trace (set -x) for debugging.
+# ------------------------------------------------------------------------------
 
+[[ "${TRACE:-}" == "1" ]] && set -x
 set -Eeuo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/_lib.sh"
+# shellcheck source=scripts/lib/config-path.sh
+. "$SCRIPT_DIR/../lib/config-path.sh"
 
-CONFIG_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/illogical-impulse/config.json"
+# ------------------------------------------------------------------------------
+# Config & Paths
+# ------------------------------------------------------------------------------
+CONFIG_PATH="$(inir_config_file)"
+THEME_SCRIPT="$SCRIPT_DIR/../colors/apply-spicetify-theme.sh"
 
-_find_prefs() {
-    find "$HOME" -path '*/spotify/prefs' -print -quit 2>/dev/null
-}
+# ------------------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------------------
 
-_have_spotify_and_spicetify() {
-    have_cmd spotify && have_cmd spicetify
+# Print an error and exit, holding the terminal open.
+_die() {
+    setup_fail "$1"
+    setup_finish_pause
+    exit 1
 }
 
 _run_may_fail() {
@@ -39,6 +56,14 @@ _run_may_fail() {
     local status=$?
     set -e
     return "$status"
+}
+
+_find_prefs() {
+    find "$HOME" -path '*/spotify/prefs' -print -quit 2>/dev/null
+}
+
+_have_spotify_and_spicetify() {
+    have_cmd spotify && have_cmd spicetify
 }
 
 _spicetify_version() {
@@ -186,6 +211,12 @@ _sync_spotify_wrapper_asset() {
     echo "  · Synced missing Spotify XPUI wrapper asset."
 }
 
+_spotify_dir() {
+    for d in /opt/spotify "$HOME/.local/share/spotify-launcher/install/usr/share/spotify"; do
+        [[ -d "$d/Apps" ]] && echo "$d" && return 0
+    done
+}
+
 _ensure_spotify_writable() {
     local spotify_root="$1"
     local apps_dir="$spotify_root/Apps"
@@ -209,20 +240,26 @@ _ensure_spotify_writable() {
     return 1
 }
 
-_await_or_force_close_spotify() {
+# Wait for the user to close Spotify (or force-close with Enter).
+_await_spotify_close() {
     echo
-    echo "  ┌─────────────────────────────────────────────────────────────┐"
-    echo "  │  Sign in to Spotify so it can write its prefs file.         │"
-    echo "  │  Quit Spotify normally to continue, OR press Enter here     │"
-    echo "  │  to force-quit it.                                          │"
-    echo "  └─────────────────────────────────────────────────────────────┘"
+    cat <<'BANNER'
+  ┌─────────────────────────────────────────────────────────────┐
+  │  Sign in to Spotify so it can write its prefs file.         │
+  │  Quit Spotify normally to continue, OR press Enter here     │
+  │  to force-quit it.                                          │
+  └─────────────────────────────────────────────────────────────┘
+BANNER
     echo
 
     local waited=0
     while ! pgrep -x spotify >/dev/null 2>&1; do
         sleep 1
         waited=$((waited + 1))
-        (( waited >= 30 )) && { echo "  · Spotify did not start; continuing anyway." >&2; return 0; }
+        if (( waited >= 30 )); then
+            echo "  · Spotify did not start; continuing anyway." >&2
+            return 0
+        fi
     done
 
     while pgrep -x spotify >/dev/null 2>&1; do
@@ -240,150 +277,263 @@ _await_or_force_close_spotify() {
     echo "  · Spotify closed — resuming setup."
 }
 
-_theme_enabled_in_config() {
-    [[ -f "$CONFIG_PATH" ]] || return 1
-    have_cmd jq || return 1
-    [[ "$(jq -r '.appearance.wallpaperTheming.enableSpicetify // false' \
-        "$CONFIG_PATH" 2>/dev/null)" == "true" ]]
+_enable_spicetify_theming() {
+    if ! have_cmd jq; then
+        echo "  · jq not available; cannot enable Spicetify theming in config." >&2
+        return 1
+    fi
+    echo "  · Enabling Spicetify theming in iNiR config…"
+    if [[ ! -f "$CONFIG_PATH" ]]; then
+        mkdir -p "$(dirname "$CONFIG_PATH")"
+        echo '{}' > "$CONFIG_PATH"
+    fi
+    local lockfile="$CONFIG_PATH.lock"
+    (
+        flock -w 5 200 || { echo "  · Config lock timeout." >&2; return 1; }
+        jq '.appearance.wallpaperTheming.enableSpicetify = true' \
+            "$CONFIG_PATH" > "$CONFIG_PATH.tmp" \
+            && mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"
+    ) 200>"$lockfile"
 }
 
-setup_init "spotify" "Setup Spotify + Spicetify"
+# ------------------------------------------------------------------------------
+# Phase 1 — Remove incompatible installs
+# ------------------------------------------------------------------------------
+# Spicetify can only patch the official AUR package at /opt/spotify.
+# Conflicting package formats (Flatpak, Snap, launcher) must be removed first.
+# ------------------------------------------------------------------------------
+_remove_incompatible() {
+    local helper
+    helper="$(ensure_aur_helper)"
 
-if is_arch_like; then
-    TOTAL=6
+    # Flatpak Spotify
+    if have_cmd flatpak; then
+        if flatpak list --app 2>/dev/null | grep -q "com.spotify.Client"; then
+            echo "  · Removing Flatpak Spotify…"
+            flatpak uninstall -y --user com.spotify.Client 2>/dev/null || \
+                flatpak uninstall -y com.spotify.Client 2>/dev/null || true
+        fi
+    fi
 
-    setup_progress 1 $TOTAL "Installing Spotify (AUR) and Spicetify CLI"
+    # Snap Spotify
+    if have_cmd snap; then
+        if snap list spotify >/dev/null 2>&1; then
+            echo "  · Removing Snap Spotify…"
+            sudo snap remove spotify >/dev/null 2>&1 || true
+        fi
+    fi
+
+    # spotify-launcher (AUR)
+    if have_cmd spotify-launcher; then
+        echo "  · Removing spotify-launcher…"
+        "$helper" -Rns --noconfirm spotify-launcher 2>/dev/null || true
+        rm -rf "$HOME/.local/share/spotify-launcher" 2>/dev/null || true
+    fi
+
+    # Conflicting spicetify packages (prevent interactive "Remove X? [y/N]" prompt)
+    if "$helper" -Q spicetify-cli-git >/dev/null 2>&1; then
+        echo "  · Removing spicetify-cli-git (conflicts with spicetify-cli)…"
+        "$helper" -Rns --noconfirm spicetify-cli-git 2>/dev/null || true
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Phase 2 — Install packages
+# ------------------------------------------------------------------------------
+_install_packages() {
     if _have_spotify_and_spicetify; then
         echo "  · Spotify and Spicetify are already installed."
     elif ! _run_may_fail install_arch -- spotify spicetify-cli; then
         if _have_spotify_and_spicetify; then
             echo "  · Package install reported an error, but Spotify and Spicetify are available; continuing." >&2
         else
-            setup_fail "Could not install Spotify and Spicetify CLI."
-            setup_finish_pause
-            exit 1
+            _die "Could not install Spotify and Spicetify CLI."
         fi
     fi
 
-    # Detect the Spotify install directory. Prefer /opt/spotify (AUR package,
-    # has .spa files spicetify needs) over the spotify-launcher expanded dir.
-    _spotify_dir() {
-        for d in /opt/spotify "$HOME/.local/share/spotify-launcher/install/usr/share/spotify"; do
-            [[ -d "$d/Apps" ]] && echo "$d" && return
-        done
-    }
+    # Verify spicetify is in PATH; fall back to the curl installer location if present.
+    if ! have_cmd spicetify && [[ -x "$HOME/.spicetify/spicetify" ]]; then
+        export PATH="$HOME/.spicetify:$PATH"
+    fi
+    if ! have_cmd spicetify; then
+        _die "spicetify was installed but is not in PATH. Open a new terminal and rerun /setup-spotify."
+    fi
+}
 
-    setup_progress 2 $TOTAL "Configuring Spicetify paths"
-    spotify_dir="$(_spotify_dir)"
+# ------------------------------------------------------------------------------
+# Phase 3 — Configure Spicetify paths & permissions
+# ------------------------------------------------------------------------------
+_configure_spicetify() {
+    spotify_dir="$(_spotify_dir || true)"
     if [[ -z "$spotify_dir" ]]; then
-        setup_fail "Could not find Spotify install directory."
-        setup_finish_pause
-        exit 1
+        _die "Could not find Spotify install directory (/opt/spotify)."
     fi
     echo "  · Spotify at: $spotify_dir"
-    # Ensure spicetify points to the .spa-based install, not a launcher dir
+
+    # Ensure Spicetify config directory exists
+    local spicetify_cfg_dir
+    spicetify_cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify"
+    mkdir -p "$spicetify_cfg_dir"
+
+    # Ensure spicetify points to the .spa-based install
     spicetify config spotify_path "$spotify_dir" >/dev/null 2>&1 || true
+
     if ! _ensure_spotify_writable "$spotify_dir"; then
-        setup_fail "Could not make Spotify writable for Spicetify patching."
-        setup_finish_pause
-        exit 1
+        _die "Could not make Spotify writable for Spicetify patching."
     fi
 
-    setup_progress 3 $TOTAL "Repairing Spicetify wrapper assets"
     if ! _ensure_spicetify_wrapper_asset; then
-        setup_fail "Could not build/install Spicetify wrapper asset."
-        setup_finish_pause
-        exit 1
+        _die "Could not build/install Spicetify wrapper asset."
     fi
+}
 
-    setup_progress 4 $TOTAL "Applying Spicetify backup"
+# ------------------------------------------------------------------------------
+# Phase 4 — First-run: generate prefs file (if needed)
+# ------------------------------------------------------------------------------
+_generate_prefs_if_needed() {
+    local prefs
     prefs="$(_find_prefs)"
     if [[ -n "$prefs" ]]; then
         echo "  · prefs already exists at $prefs"
         spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
+        return 0
     fi
 
-    _spicetify_apply() {
-        if _run_may_fail spicetify backup apply; then
-            _sync_spotify_wrapper_asset "$spotify_dir"
-            return 0
-        fi
-        # Stale backup — try restore then redo
-        if _run_may_fail spicetify restore backup apply; then
-            _sync_spotify_wrapper_asset "$spotify_dir"
-            return 0
-        fi
-        # Deadlocked (version mismatch) — nuke backup state and retry
-        local cfg_dir
-        cfg_dir="$(dirname "$(spicetify -c 2>/dev/null)" 2>/dev/null)"
-        if [[ -n "$cfg_dir" ]]; then
-            echo "  · Clearing stale backup state…"
-            rm -rf "${cfg_dir:?}/Backup" 2>/dev/null || true
-            # Clear [Backup] section values in config
+    # Close any lingering Spotify process first
+    if pgrep -x spotify >/dev/null 2>&1; then
+        echo "  · Spotify is running. Closing it before first-run setup…"
+        pkill -x spotify || true
+        sleep 2
+    fi
+
+    echo "  · Launching Spotify so it can generate its prefs file…"
+    setsid -f spotify >/dev/null 2>&1 < /dev/null || \
+        nohup spotify >/dev/null 2>&1 < /dev/null &
+
+    setup_notify "Sign in to Spotify, then quit it (or press Enter in the terminal to force-quit)" "media-playback-start"
+    _await_spotify_close
+
+    prefs="$(_find_prefs)"
+    if [[ -z "$prefs" ]]; then
+        _die "Could not locate spotify/prefs after first run; aborting."
+    fi
+    echo "  · Found prefs at $prefs"
+    spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
+}
+
+# ------------------------------------------------------------------------------
+# Phase 5 — Apply Spicetify backup with progressive recovery
+# ------------------------------------------------------------------------------
+_apply_spicetify() {
+    local spotify_root="$1"
+
+    if _run_may_fail spicetify backup apply; then
+        _sync_spotify_wrapper_asset "$spotify_root"
+        return 0
+    fi
+
+    # Stale backup — try restore then redo
+    if _run_may_fail spicetify restore backup apply; then
+        _sync_spotify_wrapper_asset "$spotify_root"
+        return 0
+    fi
+
+    # Deadlocked (version mismatch) — nuke backup state and retry
+    local cfg_dir
+    cfg_dir="$(dirname "$(spicetify -c 2>/dev/null)" 2>/dev/null)"
+    if [[ -n "$cfg_dir" ]]; then
+        echo "  · Clearing stale backup state…"
+        rm -rf "${cfg_dir:?}/Backup" 2>/dev/null || true
+        if [[ -f "${cfg_dir}/config-xpui.ini" ]]; then
             sed -i '/^\[Backup\]/,/^\[/{/^\[Backup\]/!{/^\[/!d}}' \
                 "${cfg_dir}/config-xpui.ini" 2>/dev/null || true
         fi
-        if _run_may_fail spicetify backup apply; then
-            _sync_spotify_wrapper_asset "$spotify_dir"
-            return 0
-        fi
-        return 1
-    }
-
-    if ! _spicetify_apply; then
-        echo
-        echo "  · backup apply failed (likely no prefs file yet)."
-        echo "  · Launching Spotify so it can generate its prefs…"
-        setsid -f spotify >/dev/null 2>&1 < /dev/null || \
-            nohup spotify >/dev/null 2>&1 < /dev/null &
-        setup_notify "Sign in to Spotify, then quit it (or press Enter in the terminal to force-quit)" "media-playback-start"
-        _await_or_force_close_spotify
-
-        prefs="$(_find_prefs)"
-        if [[ -z "$prefs" ]]; then
-            setup_fail "Could not locate spotify/prefs after first run; aborting."
-            setup_finish_pause
-            exit 1
-        fi
-        echo "  · Found prefs at $prefs"
-        spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
-        if ! _spicetify_apply; then
-            setup_fail "Spicetify backup/apply failed after Spotify generated prefs."
-            setup_finish_pause
-            exit 1
-        fi
     fi
 
-    setup_progress 5 $TOTAL "Installing Spicetify Marketplace"
+    if _run_may_fail spicetify backup apply; then
+        _sync_spotify_wrapper_asset "$spotify_root"
+        return 0
+    fi
+
+    return 1
+}
+
+# ------------------------------------------------------------------------------
+# Phase 6 — Marketplace & theme
+# ------------------------------------------------------------------------------
+_install_marketplace() {
     if curl -fsSL https://raw.githubusercontent.com/spicetify/marketplace/main/resources/install.sh \
         | sh; then
-        echo "Marketplace installed."
+        echo "  · Marketplace installed."
     else
-        echo "warning: Marketplace installer failed; you can rerun it later." >&2
+        echo "  · warning: Marketplace installer failed; you can rerun it later." >&2
+    fi
+}
+
+_apply_theme() {
+    if ! _enable_spicetify_theming; then
+        echo "  · warning: Could not enable Spicetify theming in config; continuing." >&2
     fi
 
-    if _theme_enabled_in_config; then
-        setup_progress 6 $TOTAL "Applying iNiR Spicetify theme"
-        theme_script="$SCRIPT_DIR/../colors/apply-spicetify-theme.sh"
-        if [[ -x "$theme_script" ]]; then
-            theme_name="$(jq -r '.appearance.wallpaperTheming.spicetifyTheme // "Inir"' "$CONFIG_PATH" 2>/dev/null)"
-            if [[ "$theme_name" != "Inir" && "$theme_name" != "InirTUI" ]]; then
-                theme_name="Inir"
-            fi
-            if "$theme_script" --theme "$theme_name"; then
-                echo "iNiR theme applied."
-            else
-                echo "warning: theme script returned non-zero; rerun it manually if Spotify looks unstyled." >&2
-            fi
+    if [[ -x "$THEME_SCRIPT" ]]; then
+        local theme_name
+        theme_name="$(jq -r '.appearance.wallpaperTheming.spicetifyTheme // "Inir"' "$CONFIG_PATH" 2>/dev/null || printf 'Inir')"
+        if [[ "$theme_name" != "Inir" && "$theme_name" != "InirTUI" ]]; then
+            theme_name="Inir"
+        fi
+        echo "  · Applying iNiR theme ($theme_name)…"
+        if "$THEME_SCRIPT" --theme "$theme_name"; then
+            echo "  · iNiR theme applied."
         else
-            echo "warning: $theme_script not found or not executable; skipping theme." >&2
+            echo "  · warning: theme script returned non-zero; rerun it manually if Spotify looks unstyled." >&2
         fi
     else
-        setup_progress 6 $TOTAL "Skipping iNiR theme (appearance.wallpaperTheming.enableSpicetify is off)"
-        echo "  · Enable it in Settings → Themes → 'Spotify theming' to apply the iNiR theme."
+        echo "  · warning: $THEME_SCRIPT not found or not executable; skipping theme." >&2
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+setup_init "spotify" "Setup Spotify + Spicetify"
+
+if is_arch_like; then
+    TOTAL=6
+
+    setup_progress 1 $TOTAL "Removing incompatible Spotify installs"
+    _remove_incompatible
+
+    setup_progress 2 $TOTAL "Installing Spotify (AUR) and Spicetify CLI"
+    _install_packages
+
+    setup_progress 3 $TOTAL "Configuring Spicetify paths and assets"
+    _configure_spicetify
+
+    setup_progress 4 $TOTAL "Checking Spotify configuration and preferences"
+    prefs="$(_find_prefs)"
+    if [[ -z "$prefs" ]]; then
+        _generate_prefs_if_needed
+    else
+        echo "  · Found existing prefs at $prefs"
+        spicetify config prefs_path "$prefs" >/dev/null 2>&1 || true
     fi
 
-    setup_done "Spotify + Spicetify ready. Launch Spotify to verify."
+    setup_progress 5 $TOTAL "Applying Spicetify backup"
+    spotify_dir="$(_spotify_dir)"
+    if ! _apply_spicetify "$spotify_dir"; then
+        # If first apply fails and prefs were missing or incomplete, try first-run launch
+        echo "  · backup apply failed; launching Spotify to refresh preferences…"
+        _generate_prefs_if_needed
+        if ! _apply_spicetify "$spotify_dir"; then
+            _die "Spicetify backup apply failed even after generating prefs. Check the error above."
+        fi
+    fi
+
+    setup_progress 6 $TOTAL "Installing Spicetify Marketplace and applying theme"
+    _install_marketplace
+    _apply_theme
+
+    setup_done "Spotify + Spicetify ready with iNiR theming enabled. Launch Spotify to verify."
 else
     TOTAL=2
     setup_progress 1 $TOTAL "Installing Spotify via Flatpak (no Spicetify on non-Arch)"

--- a/scripts/setup/spotify.sh
+++ b/scripts/setup/spotify.sh
@@ -11,12 +11,15 @@
 #               Follows the official Spicetify docs for Linux setup:
 #               https://spicetify.app/docs/getting-started
 #
-#               Removes incompatible installs (Flatpak, Snap, spotify-launcher,
-#               and conflicting spicetify-cli-git package), configures paths
-#               and permissions, repairs missing Spicetify v2.44+ wrapper assets,
-#               generates prefs if needed, applies Spicetify backup with
-#               progressive recovery, installs Marketplace, automatically
-#               enables Spicetify theming in iNiR config, and applies the theme.
+#               Detects incompatible installs (Flatpak, Snap, spotify-launcher,
+#               and conflicting spicetify-cli-git package) and asks before any
+#               removal. It leaves declined conflicts untouched and explains
+#               why setup cannot continue until they are resolved. It then
+#               configures paths and permissions, repairs missing Spicetify
+#               v2.44+ wrapper assets, generates prefs if needed, applies
+#               Spicetify backup with progressive recovery, installs Marketplace,
+#               automatically enables Spicetify theming in iNiR config, and
+#               applies the theme.
 # Other distros: falls back to the Flatpak build of Spotify. Spicetify is
 #                skipped because it cannot patch the Flatpak install reliably.
 #
@@ -297,43 +300,160 @@ _enable_spicetify_theming() {
 }
 
 # ------------------------------------------------------------------------------
-# Phase 1 — Remove incompatible installs
+# Phase 1 — Check and optionally remove incompatible installs
 # ------------------------------------------------------------------------------
 # Spicetify can only patch the official AUR package at /opt/spotify.
-# Conflicting package formats (Flatpak, Snap, launcher) must be removed first.
+# Conflicting package formats are detected first. Every removal requires an
+# explicit confirmation; declining any removal leaves the existing installs
+# untouched and stops setup before package installation begins.
 # ------------------------------------------------------------------------------
+_confirm_removal() {
+    local description="$1"
+    local answer
+
+    printf '\n  · Detected %s.\n' "$description"
+    printf '    Remove it before continuing with the AUR setup? [y/N] '
+    if ! read -r answer; then
+        printf '\n    No confirmation received; leaving it installed.\n' >&2
+        return 1
+    fi
+    [[ "$answer" =~ ^[Yy]([Ee][Ss])?$ ]]
+}
+
+_arch_package_installed() {
+    have_cmd pacman && pacman -Q "$1" >/dev/null 2>&1
+}
+
 _remove_incompatible() {
-    local helper
-    helper="$(ensure_aur_helper)"
+    local flatpak_installed=false
+    local snap_installed=false
+    local launcher_package_installed=false
+    local launcher_command_present=false
+    local launcher_data_present=false
+    local spicetify_git_installed=false
+    local helper=""
+    local -a refused=()
+    local -a manual_conflicts=()
 
-    # Flatpak Spotify
-    if have_cmd flatpak; then
-        if flatpak list --app 2>/dev/null | grep -q "com.spotify.Client"; then
-            echo "  · Removing Flatpak Spotify…"
-            flatpak uninstall -y --user com.spotify.Client 2>/dev/null || \
-                flatpak uninstall -y com.spotify.Client 2>/dev/null || true
-        fi
+    # Detect everything before asking or removing anything, avoiding partial
+    # cleanup when the user declines one of several conflicts.
+    if have_cmd flatpak && _run_may_fail flatpak info com.spotify.Client >/dev/null 2>&1; then
+        flatpak_installed=true
     fi
-
-    # Snap Spotify
-    if have_cmd snap; then
-        if snap list spotify >/dev/null 2>&1; then
-            echo "  · Removing Snap Spotify…"
-            sudo snap remove spotify >/dev/null 2>&1 || true
-        fi
+    if have_cmd snap && _run_may_fail snap list spotify >/dev/null 2>&1; then
+        snap_installed=true
     fi
-
-    # spotify-launcher (AUR)
+    if _arch_package_installed spotify-launcher; then
+        launcher_package_installed=true
+    fi
     if have_cmd spotify-launcher; then
-        echo "  · Removing spotify-launcher…"
-        "$helper" -Rns --noconfirm spotify-launcher 2>/dev/null || true
-        rm -rf "$HOME/.local/share/spotify-launcher" 2>/dev/null || true
+        launcher_command_present=true
+    fi
+    if [[ -d "$HOME/.local/share/spotify-launcher" ]]; then
+        launcher_data_present=true
+    fi
+    if _arch_package_installed spicetify-cli-git; then
+        spicetify_git_installed=true
     fi
 
-    # Conflicting spicetify packages (prevent interactive "Remove X? [y/N]" prompt)
-    if "$helper" -Q spicetify-cli-git >/dev/null 2>&1; then
-        echo "  · Removing spicetify-cli-git (conflicts with spicetify-cli)…"
-        "$helper" -Rns --noconfirm spicetify-cli-git 2>/dev/null || true
+    if ! $flatpak_installed && ! $snap_installed &&
+        ! $launcher_package_installed && ! $launcher_command_present &&
+        ! $launcher_data_present &&
+        ! $spicetify_git_installed; then
+        return 0
+    fi
+
+    # A binary or data directory without a package owner may come from a
+    # manual install. Do not guess how to remove user-managed files.
+    if ! $launcher_package_installed; then
+        if $launcher_command_present; then
+            manual_conflicts+=("spotify-launcher executable on PATH")
+        fi
+        if $launcher_data_present; then
+            manual_conflicts+=("spotify-launcher data at $HOME/.local/share/spotify-launcher")
+        fi
+    fi
+    if (( ${#manual_conflicts[@]} )); then
+        echo >&2
+        echo "  · Found spotify-launcher files without a removable package owner." >&2
+        echo "  · Leaving them untouched; remove them manually if they belong to an old install:" >&2
+        printf '    - %s\n' "${manual_conflicts[@]}" >&2
+        echo "  · Setup cannot continue until this conflict is resolved." >&2
+        return 1
+    fi
+
+    if $flatpak_installed && ! _confirm_removal "Flatpak Spotify (com.spotify.Client)"; then
+        refused+=("Flatpak Spotify")
+    fi
+    if $snap_installed && ! _confirm_removal "Snap Spotify"; then
+        refused+=("Snap Spotify")
+    fi
+    if $launcher_package_installed &&
+        ! _confirm_removal "the spotify-launcher AUR package"; then
+        refused+=("spotify-launcher")
+    fi
+    if $spicetify_git_installed &&
+        ! _confirm_removal "the conflicting spicetify-cli-git package"; then
+        refused+=("spicetify-cli-git")
+    fi
+
+    if (( ${#refused[@]} )); then
+        echo >&2
+        echo "  · Existing installations were left unchanged." >&2
+        echo "  · Resolve these conflicts manually, or rerun and approve their removal:" >&2
+        printf '    - %s\n' "${refused[@]}" >&2
+        echo "  · Setup cannot continue alongside these installations." >&2
+        return 1
+    fi
+
+    if $launcher_package_installed || $spicetify_git_installed; then
+        helper="$(ensure_aur_helper)"
+    fi
+
+    if $flatpak_installed; then
+        echo "  · Removing Flatpak Spotify…"
+        _run_may_fail flatpak uninstall -y --user com.spotify.Client >/dev/null 2>&1 || true
+        _run_may_fail flatpak uninstall -y --system com.spotify.Client >/dev/null 2>&1 || true
+        if _run_may_fail flatpak info com.spotify.Client >/dev/null 2>&1; then
+            echo "  · Could not remove Flatpak Spotify; leaving it installed." >&2
+            return 1
+        fi
+    fi
+
+    if $snap_installed; then
+        echo "  · Removing Snap Spotify…"
+        if ! _run_may_fail sudo snap remove spotify >/dev/null 2>&1 ||
+            _run_may_fail snap list spotify >/dev/null 2>&1; then
+            echo "  · Could not remove Snap Spotify; leaving it installed." >&2
+            return 1
+        fi
+    fi
+
+    if $launcher_package_installed; then
+        echo "  · Removing spotify-launcher…"
+        if ! _run_may_fail "$helper" -Rns --noconfirm spotify-launcher >/dev/null 2>&1 ||
+            _arch_package_installed spotify-launcher; then
+            echo "  · Could not remove spotify-launcher; leaving it installed." >&2
+            return 1
+        fi
+    fi
+
+    if $launcher_data_present; then
+        echo "  · Leaving spotify-launcher data untouched at $HOME/.local/share/spotify-launcher."
+    fi
+
+    if $launcher_command_present && have_cmd spotify-launcher; then
+        echo "  · A spotify-launcher executable is still on PATH after package removal." >&2
+        return 1
+    fi
+
+    if $spicetify_git_installed; then
+        echo "  · Removing spicetify-cli-git…"
+        if ! _run_may_fail "$helper" -Rns --noconfirm spicetify-cli-git >/dev/null 2>&1 ||
+            _arch_package_installed spicetify-cli-git; then
+            echo "  · Could not remove spicetify-cli-git; leaving it installed." >&2
+            return 1
+        fi
     fi
 }
 
@@ -500,8 +620,10 @@ setup_init "spotify" "Setup Spotify + Spicetify"
 if is_arch_like; then
     TOTAL=6
 
-    setup_progress 1 $TOTAL "Removing incompatible Spotify installs"
-    _remove_incompatible
+    setup_progress 1 $TOTAL "Checking for incompatible Spotify installs"
+    if ! _remove_incompatible; then
+        _die "Could not resolve existing Spotify installation conflicts. Review the message above and rerun setup."
+    fi
 
     setup_progress 2 $TOTAL "Installing Spotify (AUR) and Spicetify CLI"
     _install_packages


### PR DESCRIPTION
## Summary

Refactors the Spotify setup recipe while keeping installation safe for users who already have Spotify or Spicetify installed.

## Changes

- Keeps the phased Spotify and Spicetify setup flow.
- Detects Flatpak Spotify, Snap Spotify, `spotify-launcher`, and `spicetify-cli-git` before making package changes.
- Asks explicitly before removing each package-owned conflicting installation, with a safe default of `No`.
- Collects all decisions before performing cleanup, so declining one conflict leaves every detected installation untouched and stops setup before package installation.
- Leaves manually managed `spotify-launcher` binaries and data directories untouched and explains how to resolve them manually.
- Retains Spicetify v2.44+ wrapper-asset repair, preferences generation, progressive backup recovery, Marketplace setup, and iNiR theme application.
- Automatically enables Spotify theming in the iNiR configuration after successful setup.
- Rebases the branch on the latest upstream `prerelease` branch.

## Testing

- [x] `bash -n scripts/setup/spotify.sh`
- [x] `git diff --check`
- [x] Declining a mocked Flatpak conflict leaves it untouched and skips uninstall/package-install commands
- [ ] Full clean-Arch integration test with actual Spotify and Spicetify packages

The recipe remains focused on Arch-based installation for Spicetify compatibility.
