### PR TITLE
flake.nix: fix missing shell payload and kirigami QML imports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,10 @@
         ++ optionalQt6 pkgs "qtwayland";
 
       qmlDeps = pkgs:
-        optionalKde pkgs "kirigami"
+        # kirigami-wrapped ships no QML files, use the unwrapped version
+        (lib.optional
+          (builtins.hasAttr "kdePackages" pkgs && builtins.hasAttr "kirigami" pkgs.kdePackages)
+          pkgs.kdePackages.kirigami.passthru.unwrapped)
         ++ optionalKde pkgs "syntax-highlighting"
         ++ optionalQt6 pkgs "qt5compat"
         ++ optionalQt6 pkgs "qtdeclarative"
@@ -130,6 +133,16 @@
           src = lib.cleanSource ./.;
 
           nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          # Prevent patchShebangs from attempting to rewrite Python scripts;
+          # non-executable files are skipped during fixupPhase.
+          preFixup = ''
+            find "$out/share/quickshell/inir" -type f -name '*.py' -exec chmod -x {} +
+          '';
+
+          postFixup = ''
+            find "$out/share/quickshell/inir" -type f -name '*.py' -exec chmod +x {} +
+          '';
 
           installPhase =
             let
@@ -151,6 +164,13 @@
                 [ -n "$dir" ] || continue
                 cp -R "$dir" "$runtime/$dir"
               done < sdata/runtime-payload-dirs.txt
+
+              # Copy root-level QML entry points (shell.qml, settings.qml, etc.)
+              # which aren't listed in runtime-root-files.txt.
+              for f in *.qml; do
+                [ -f "$f" ] || continue
+                install -Dm644 "$f" "$runtime/$f"
+              done
 
               chmod +x "$runtime/setup" "$runtime/scripts/inir"
               find "$runtime/scripts" -type f \( -name '*.sh' -o -name '*.fish' -o -name '*.py' \) -exec chmod +x {} \;


### PR DESCRIPTION
## Changes

Three fixes for the Nix package derivation so it works out of the box on NixOS:

### 1. Root-level QML files not copied to payload

The `installPhase` only copied files from `sdata/runtime-root-files.txt` and directories from `sdata/runtime-payload-dirs.txt`. Root QML entry points like `shell.qml`, `settings.qml`, etc. were left behind. The `makeWrapper` sets `INIR_SYSTEM_RUNTIME_DIR` to `$out/share/quickshell/inir`, but `shell.qml` wasn't there, so `inir run` errored with "Could not find an iNiR shell payload".

**Fix:** Added a glob loop in `installPhase` to copy all `*.qml` files from the source root into the runtime directory.

### 2. `kirigami-wrapped` has no QML files

The `qmlDeps` function used `optionalKde pkgs "kirigami"`, which on nixpkgs >=25.05 resolves to `kirigami-wrapped` — a wrapper package with an empty `lib/qt-6/qml/` directory. The actual `org.kde.kirigami` QML module lives in the unwrapped `kirigami` package (`passthru.unwrapped`).

**Fix:** In `qmlDeps`, access `pkgs.kdePackages.kirigami.passthru.unwrapped` directly instead.

### 3. `patchShebangs` can mangle Python scripts

During `fixupPhase`, `patchShebangs` processes all executable files. Python scripts with `#!/usr/bin/env python3` get rewritten.

**Fix:** Standard Nixpkgs pattern — `preFixup` removes execute bits from `.py` files so `patchShebangs` skips them, `postFixup` restores them.

Yes I used AI for this but it works so better than nothing