### PR TITLE
feat(settings): add compositor window blur and auto Refresh Rate toggle

### DIFF
--- a/modules/background/widgets/WidgetSurface.qml
+++ b/modules/background/widgets/WidgetSurface.qml
@@ -77,8 +77,8 @@ Rectangle {
         // Don't load/blur when the compositor is already blurring underneath.
         // Each WidgetSurface keeps its own FBO when layer.enabled is true; with
         // many widgets enabled this multiplies fast. See #159.
-        visible: root._glass && !Appearance.compositorBlurActive && status === Image.Ready
-        source: (root._glass && !Appearance.compositorBlurActive) ? root._wallpaperUrl : ""
+        visible: root._glass && status === Image.Ready
+        source: root._glass ? root._wallpaperUrl : ""
         fillMode: Image.PreserveAspectCrop
         cache: true
         asynchronous: true
@@ -86,7 +86,7 @@ Rectangle {
         sourceSize.height: root.screenHeight
 
         // OPTIMIZATION: Release FBO when widget is not visible or power is off
-        layer.enabled: root._glass && !Appearance.compositorBlurActive && root.visible && root.powerActive
+        layer.enabled: root._glass && root.visible && root.powerActive
         layer.effect: MultiEffect {
             source: blurredWallpaper
             anchors.fill: source

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -282,8 +282,7 @@ Scope {
                                             sourceSize.height: barRoot.screen?.height ?? 1080
                                             asynchronous: true
                                             
-                                            // See #159 — skip QML blur when compositor blur covers this layer
-                                            layer.enabled: Appearance.effectsEnabled && Appearance.auroraEverywhere && !Appearance.compositorBlurActive
+                                            layer.enabled: Appearance.effectsEnabled && Appearance.auroraEverywhere
                                             layer.effect: MultiEffect {
                                                 source: blurImg
                                                 anchors.fill: source

--- a/modules/bar/BarContent.qml
+++ b/modules/bar/BarContent.qml
@@ -390,8 +390,6 @@ Item { // Bar content region
         color: {
             if (root.angelEverywhere) {
                 const base = blendedColors?.colLayer0 ?? Appearance.colors.colLayer0
-                if (Appearance.compositorBlurActive)
-                    return ColorUtils.transparentize(base, Appearance.angel.compositorPanelTransparentize)
                 return ColorUtils.applyAlpha(base, 1)
             }
             if (root.inirEverywhere) {
@@ -399,8 +397,6 @@ Item { // Bar content region
             }
             if (auroraEverywhere) {
                 const base = blendedColors?.colLayer0 ?? Appearance.colors.colLayer0
-                if (Appearance.compositorBlurActive)
-                    return ColorUtils.transparentize(base, Appearance.aurora.compositorOverlayTransparentize)
                 return ColorUtils.applyAlpha(base, 1)
             }
             // Material/Cards
@@ -473,17 +469,15 @@ Item { // Bar content region
             y: barBackground.isBottom ? -(root.screen?.height ?? 1080) + barBackground.height + barBackground.barMargin : -barBackground.barMargin
             width: root.screen?.width ?? 1920
             height: root.screen?.height ?? 1080
-            visible: barBackground.auroraEverywhere && !root.inirEverywhere && !barBackground.gameModeMinimal && !Appearance.compositorBlurActive
-            source: Appearance.compositorBlurActive ? "" : root.wallpaperUrl
+            visible: barBackground.auroraEverywhere && !root.inirEverywhere && !barBackground.gameModeMinimal
+            source: root.wallpaperUrl
             fillMode: Image.PreserveAspectCrop
             cache: true
             sourceSize.width: root.screen?.width ?? 1920
             sourceSize.height: root.screen?.height ?? 1080
             asynchronous: true
 
-            // Skip QML blur when the compositor is already blurring this layer
-            // (avoids double-blur and the FBO cost). See #159.
-            layer.enabled: Appearance.effectsEnabled && barBackground.auroraEverywhere && !root.inirEverywhere && !Appearance.compositorBlurActive
+            layer.enabled: Appearance.effectsEnabled && barBackground.auroraEverywhere && !root.inirEverywhere
             layer.effect: MultiEffect {
                 source: blurredWallpaper
                 anchors.fill: source

--- a/modules/common/Appearance.qml
+++ b/modules/common/Appearance.qml
@@ -88,10 +88,7 @@ Singleton {
     // Master switches for effects and animations
     property bool effectsEnabled: !Config.options?.performance?.lowPower && !_gameModeDisablesEffects
     property bool animationsEnabled: !_gameModeDisablesAnimations && !(Config.options?.performance?.reduceAnimations ?? false)
-    // Set to true when the compositor is already blurring the window surface so
-    // panels can skip their own QML MultiEffect blur (avoids double-blur and FBO cost).
-    // Currently always false on Niri (no compositor blur); Hyprland hook TBD (ref #159).
-    readonly property bool compositorBlurActive: false
+
 
     // Minimal mode: panels become transparent, no backgrounds, reduced visual weight
     // Components should check this to hide backgrounds/shadows during GameMode

--- a/modules/dock/Dock.qml
+++ b/modules/dock/Dock.qml
@@ -233,8 +233,7 @@ Scope {
                                     sourceSize.height: dockRoot.screen?.height ?? 1080
                                     asynchronous: true
 
-                                    // See #159 — skip QML blur when compositor blur covers this layer
-                                    layer.enabled: Appearance.effectsEnabled && dockVisualBackground.auroraEverywhere && !dockVisualBackground.inirEverywhere && !dockVisualBackground.gameModeMinimal && !Appearance.compositorBlurActive
+                                    layer.enabled: Appearance.effectsEnabled && dockVisualBackground.auroraEverywhere && !dockVisualBackground.inirEverywhere && !dockVisualBackground.gameModeMinimal
                                     layer.effect: MultiEffect {
                                         source: dockBlurredWallpaper
                                         anchors.fill: source

--- a/modules/dock/DockMacBackground.qml
+++ b/modules/dock/DockMacBackground.qml
@@ -93,8 +93,7 @@ Rectangle {
             ? (-(scrH / 2) + root.height / 2)
             : (-(scrH)     + root.height + Appearance.sizes.hyprlandGapsOut)
 
-        // See #159 — skip QML blur when compositor blur covers this layer
-        layer.enabled: Appearance.effectsEnabled && !root.gameModeMinimal && !Appearance.compositorBlurActive
+        layer.enabled: Appearance.effectsEnabled && !root.gameModeMinimal
         layer.effect: MultiEffect {
             source: macBlurWall
             anchors.fill: source

--- a/modules/settings/NiriConfig.qml
+++ b/modules/settings/NiriConfig.qml
@@ -1521,13 +1521,31 @@ ContentPage {
                 title: Translation.tr("Refresh rate")
                 visible: root.refreshOptions.length > 1
 
-                StyledComboBox {
-                    id: refreshRateCombo
+                ColumnLayout {
                     Layout.fillWidth: true
-                    enabled: !root.displayControlsLocked
-                    model: root.refreshOptions
-                    textRole: "displayName"
-                    onActivated: root.safeApplyOutput("mode", "mode", `${root.currentResolution}@${model[currentIndex].rateString}`)
+                    spacing: 8
+
+                    StyledComboBox {
+                        id: refreshRateCombo
+                        Layout.fillWidth: true
+                        enabled: !root.displayControlsLocked && !(BlurService.ready && BlurService.options.refresh_rate_efficiency)
+                        model: root.refreshOptions
+                        textRole: "displayName"
+                        onActivated: root.safeApplyOutput("mode", "mode", `${root.currentResolution}@${model[currentIndex].rateString}`)
+                    }
+
+                    SettingsSwitch {
+                        Layout.fillWidth: true
+                        enabled: !root.displayControlsLocked
+                        buttonIcon: "battery_saver"
+                        text: Translation.tr("Auto Refresh Rate Efficiency")
+                        checked: BlurService.ready && BlurService.options.refresh_rate_efficiency
+                        onCheckedChanged: {
+                            if (BlurService.ready && BlurService.options.refresh_rate_efficiency !== checked) {
+                                BlurService.options.refresh_rate_efficiency = checked
+                            }
+                        }
+                    }
                 }
             }
 
@@ -2101,8 +2119,8 @@ ContentPage {
             SettingsDivider {}
 
             ContentSubsection {
-                title: Translation.tr("Inactive window opacity")
-                tooltip: Translation.tr("Transparency of unfocused windows (1.0 = fully opaque)")
+                title: Translation.tr("Global inactive window opacity")
+                tooltip: Translation.tr("Transparency of unfocused windows before any app-specific blur rule overrides (1.0 = fully opaque)")
 
                 RowLayout {
                     Layout.fillWidth: true
@@ -2142,6 +2160,382 @@ ContentPage {
                 onCheckedChanged: {
                     if (!root.windowRulesReady) return
                     root.setConfig("window-rules", "clip-to-geometry", checked ? "true" : "false")
+                }
+            }
+        }
+    }
+
+    SettingsCardSection {
+        expanded: false
+        icon: "blur_on"
+        title: Translation.tr("Window Blur")
+
+        SettingsGroup {
+            StyledText {
+                Layout.fillWidth: true
+                text: Translation.tr("Blur is managed through Niri's global blur block plus dedicated window and layer rules. The blur opacities below only apply to matched app IDs and namespaces, which avoids conflicting with the global inactive-opacity rule above.")
+                color: Appearance.colors.colOnSurfaceVariant
+                font.pixelSize: Appearance.font.pixelSize.small
+                wrapMode: Text.WordWrap
+            }
+
+            ContentSubsection {
+                title: Translation.tr("Blur Mode")
+
+                ConfigSelectionArray {
+                    currentValue: BlurService.ready ? BlurService.options.mode : "auto"
+                    options: [
+                        { displayName: Translation.tr("Always On"), icon: "blur_on", value: "on" },
+                        { displayName: Translation.tr("Always Off"), icon: "blur_off", value: "off" },
+                        { displayName: Translation.tr("Auto (On Charge)"), icon: "blur_circular", value: "auto" }
+                    ]
+                    onSelected: newValue => {
+                        BlurService.options.mode = newValue;
+                    }
+                }
+            }
+
+            ContentSubsection {
+                title: Translation.tr("Managed Window Rules")
+                visible: BlurService.ready && BlurService.options.mode !== "off"
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    SettingsSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "check_box"
+                        text: Translation.tr("Apply blur to matching windows")
+                        checked: BlurService.ready && BlurService.options.window_rules_enabled
+                        onCheckedChanged: {
+                            if (BlurService.ready)
+                                BlurService.options.window_rules_enabled = checked;
+                        }
+                    }
+
+                    MaterialTextField {
+                        Layout.fillWidth: true
+                        enabled: BlurService.ready && BlurService.options.window_rules_enabled
+                        placeholderText: Translation.tr("Window app-id regex, for example ^(Alacritty|kitty|foot)$")
+                        text: BlurService.ready ? BlurService.options.window_matcher : ""
+                        onEditingFinished: {
+                            if (BlurService.ready)
+                                BlurService.options.window_matcher = text.trim();
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Active opacity:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: activeBlurOpacitySlider
+                            Layout.fillWidth: true
+                            enabled: BlurService.ready && BlurService.options.window_rules_enabled
+                            from: 10
+                            to: 100
+                            value: Math.round((BlurService.ready ? BlurService.options.active_opacity : 0.95) * 100)
+                            stepSize: 5
+                            configuration: StyledSlider.Configuration.S
+
+                            onMoved: {
+                                const val = value / 100.0
+                                if (BlurService.ready && val !== BlurService.options.active_opacity)
+                                    BlurService.options.active_opacity = val
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(activeBlurOpacitySlider.value) + "%"
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 35
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Inactive opacity:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: inactiveBlurOpacitySlider
+                            Layout.fillWidth: true
+                            enabled: BlurService.ready && BlurService.options.window_rules_enabled
+                            from: 10
+                            to: 100
+                            value: Math.round((BlurService.ready ? BlurService.options.inactive_opacity : 0.70) * 100)
+                            stepSize: 5
+                            configuration: StyledSlider.Configuration.S
+
+                            onMoved: {
+                                const val = value / 100.0
+                                if (BlurService.ready && val !== BlurService.options.inactive_opacity)
+                                    BlurService.options.inactive_opacity = val
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(inactiveBlurOpacitySlider.value) + "%"
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 35
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+                }
+            }
+
+            ContentSubsection {
+                title: Translation.tr("Managed Layer Rules")
+                visible: BlurService.ready && BlurService.options.mode !== "off"
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    SettingsSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "layers"
+                        text: Translation.tr("Apply blur to matching layer-shell surfaces")
+                        checked: BlurService.ready && BlurService.options.layer_rules_enabled
+                        onCheckedChanged: {
+                            if (BlurService.ready)
+                                BlurService.options.layer_rules_enabled = checked;
+                        }
+                    }
+
+                    MaterialTextField {
+                        Layout.fillWidth: true
+                        enabled: BlurService.ready && BlurService.options.layer_rules_enabled
+                        placeholderText: Translation.tr("Layer namespace regex, for example ^(launcher|waybar|walker|fuzzel)$")
+                        text: BlurService.ready ? BlurService.options.layer_namespace : ""
+                        onEditingFinished: {
+                            if (BlurService.ready)
+                                BlurService.options.layer_namespace = text.trim();
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Layer opacity:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: layerBlurOpacitySlider
+                            Layout.fillWidth: true
+                            enabled: BlurService.ready && BlurService.options.layer_rules_enabled
+                            from: 10
+                            to: 100
+                            value: Math.round((BlurService.ready ? BlurService.options.layer_opacity : 0.85) * 100)
+                            stepSize: 5
+                            configuration: StyledSlider.Configuration.S
+
+                            onMoved: {
+                                const val = value / 100.0
+                                if (BlurService.ready && val !== BlurService.options.layer_opacity)
+                                    BlurService.options.layer_opacity = val
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(layerBlurOpacitySlider.value) + "%"
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 35
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+                }
+            }
+
+            ContentSubsection {
+                title: Translation.tr("Blur Quality")
+                visible: BlurService.ready && BlurService.options.mode !== "off"
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    SettingsSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "visibility"
+                        text: Translation.tr("Enable xray blur for better performance")
+                        checked: BlurService.ready && BlurService.options.xray
+                        onCheckedChanged: {
+                            if (BlurService.ready)
+                                BlurService.options.xray = checked;
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Passes:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: blurPassesSlider
+                            Layout.fillWidth: true
+                            from: 1
+                            to: 6
+                            stepSize: 1
+                            value: BlurService.ready ? BlurService.options.passes : 3
+                            configuration: StyledSlider.Configuration.S
+                            onMoved: {
+                                const val = Math.round(value)
+                                if (BlurService.ready && val !== BlurService.options.passes)
+                                    BlurService.options.passes = val
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(blurPassesSlider.value)
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 30
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Offset:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: blurOffsetSlider
+                            Layout.fillWidth: true
+                            from: 100
+                            to: 500
+                            stepSize: 25
+                            value: Math.round((BlurService.ready ? BlurService.options.offset : 3.0) * 100)
+                            configuration: StyledSlider.Configuration.S
+                            onMoved: {
+                                const val = value / 100.0
+                                if (BlurService.ready && val !== BlurService.options.offset)
+                                    BlurService.options.offset = val
+                            }
+                        }
+
+                        StyledText {
+                            text: (blurOffsetSlider.value / 100.0).toFixed(2)
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 40
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Noise:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: blurNoiseSlider
+                            Layout.fillWidth: true
+                            from: 0
+                            to: 100
+                            stepSize: 1
+                            value: Math.round((BlurService.ready ? BlurService.options.noise : 0.02) * 1000)
+                            configuration: StyledSlider.Configuration.S
+                            onMoved: {
+                                const val = value / 1000.0
+                                if (BlurService.ready && val !== BlurService.options.noise)
+                                    BlurService.options.noise = val
+                            }
+                        }
+
+                        StyledText {
+                            text: (blurNoiseSlider.value / 1000.0).toFixed(3)
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 45
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Saturation:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: blurSaturationSlider
+                            Layout.fillWidth: true
+                            from: 50
+                            to: 250
+                            stepSize: 5
+                            value: Math.round((BlurService.ready ? BlurService.options.saturation : 1.5) * 100)
+                            configuration: StyledSlider.Configuration.S
+                            onMoved: {
+                                const val = value / 100.0
+                                if (BlurService.ready && val !== BlurService.options.saturation)
+                                    BlurService.options.saturation = val
+                            }
+                        }
+
+                        StyledText {
+                            text: (blurSaturationSlider.value / 100.0).toFixed(2)
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 40
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: Translation.tr("Recommended baseline: passes 3, offset 3.00, noise 0.020, saturation 1.50. Per current Niri guidance, increase offset first, then add passes only if you still want a smoother blur.")
+                        color: Appearance.colors.colOnSurfaceVariant
+                        font.pixelSize: Appearance.font.pixelSize.smallest
+                        wrapMode: Text.WordWrap
+                    }
                 }
             }
         }

--- a/modules/settings/NiriConfig.qml
+++ b/modules/settings/NiriConfig.qml
@@ -2291,11 +2291,65 @@ ContentPage {
                             Layout.preferredWidth: 35
                             horizontalAlignment: Text.AlignRight
                         }
+            ContentSubsection {
+                title: Translation.tr("Layer Blur")
+                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    SettingsSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "layers"
+                        text: Translation.tr("Enable layer surface background blur")
+                        checked: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
+                        onCheckedChanged: {
+                            if (root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true) !== checked)
+                                root.setConfig("window-rules", "layer-blur", checked ? "true" : "false");
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+                        visible: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
+
+                        StyledText {
+                            text: Translation.tr("Layer opacity:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: layerBlurOpacitySlider
+                            Layout.fillWidth: true
+                            enabled: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
+                            from: 10
+                            to: 100
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.layer_opacity ?? 0.85) : 0.85) * 100)
+                            stepSize: 5
+                            configuration: StyledSlider.Configuration.S
+
+                            onMoved: {
+                                if (pressed) return
+                                const val = value / 100.0
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.layer_opacity ?? 0.85))
+                                    root.setConfig("window-rules", "layer-opacity", String(val))
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(layerBlurOpacitySlider.value) + "%"
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 35
+                            horizontalAlignment: Text.AlignRight
+                        }
                     }
                 }
             }
-
-
 
             ContentSubsection {
                 title: Translation.tr("Blur Quality")

--- a/modules/settings/NiriConfig.qml
+++ b/modules/settings/NiriConfig.qml
@@ -2295,65 +2295,7 @@ ContentPage {
                 }
             }
 
-            ContentSubsection {
-                title: Translation.tr("Layer Blur")
-                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
 
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: 8
-
-                    SettingsSwitch {
-                        Layout.fillWidth: true
-                        buttonIcon: "layers"
-                        text: Translation.tr("Enable layer surface background blur")
-                        checked: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
-                        onCheckedChanged: {
-                            if (root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true) !== checked)
-                                root.setConfig("window-rules", "layer-blur", checked ? "true" : "false");
-                        }
-                    }
-
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 8
-                        visible: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
-
-                        StyledText {
-                            text: Translation.tr("Layer opacity:")
-                            font.pixelSize: Appearance.font.pixelSize.smallest
-                            color: Appearance.colors.colSubtext
-                        }
-
-                        StyledSlider {
-                            id: layerBlurOpacitySlider
-                            Layout.fillWidth: true
-                            enabled: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
-                            from: 10
-                            to: 100
-                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.layer_opacity ?? 0.85) : 0.85) * 100)
-                            stepSize: 5
-                            configuration: StyledSlider.Configuration.S
-
-                            onMoved: {
-                                if (pressed) return
-                                const val = value / 100.0
-                                if (root.windowRulesReady && val !== (root.windowRulesData?.layer_opacity ?? 0.85))
-                                    root.setConfig("window-rules", "layer-opacity", String(val))
-                            }
-                        }
-
-                        StyledText {
-                            text: Math.round(layerBlurOpacitySlider.value) + "%"
-                            font.pixelSize: Appearance.font.pixelSize.smallest
-                            font.family: Appearance.font.family.monospace
-                            color: Appearance.colors.colSubtext
-                            Layout.preferredWidth: 35
-                            horizontalAlignment: Text.AlignRight
-                        }
-                    }
-                }
-            }
 
             ContentSubsection {
                 title: Translation.tr("Blur Quality")

--- a/modules/settings/NiriConfig.qml
+++ b/modules/settings/NiriConfig.qml
@@ -1528,7 +1528,7 @@ ContentPage {
                     StyledComboBox {
                         id: refreshRateCombo
                         Layout.fillWidth: true
-                        enabled: !root.displayControlsLocked && !(BlurService.ready && BlurService.options.refresh_rate_efficiency)
+                        enabled: !root.displayControlsLocked && !(root.windowRulesReady && root.windowRulesData?.refresh_rate_efficiency)
                         model: root.refreshOptions
                         textRole: "displayName"
                         onActivated: root.safeApplyOutput("mode", "mode", `${root.currentResolution}@${model[currentIndex].rateString}`)
@@ -1539,10 +1539,10 @@ ContentPage {
                         enabled: !root.displayControlsLocked
                         buttonIcon: "battery_saver"
                         text: Translation.tr("Auto Refresh Rate Efficiency")
-                        checked: BlurService.ready && BlurService.options.refresh_rate_efficiency
+                        checked: root.windowRulesData?.refresh_rate_efficiency ?? false
                         onCheckedChanged: {
-                            if (BlurService.ready && BlurService.options.refresh_rate_efficiency !== checked) {
-                                BlurService.options.refresh_rate_efficiency = checked
+                            if (root.windowRulesReady && (root.windowRulesData?.refresh_rate_efficiency ?? false) !== checked) {
+                                root.setConfig("window-rules", "refresh-rate-efficiency", checked ? "true" : "false")
                             }
                         }
                     }
@@ -2173,7 +2173,7 @@ ContentPage {
         SettingsGroup {
             StyledText {
                 Layout.fillWidth: true
-                text: Translation.tr("Blur is managed through Niri's global blur block plus dedicated window and layer rules. The blur opacities below only apply to matched app IDs and namespaces, which avoids conflicting with the global inactive-opacity rule above.")
+                text: Translation.tr("Blur is managed globally for windows and layer surfaces. Configured values are written directly to your Niri configuration files.")
                 color: Appearance.colors.colOnSurfaceVariant
                 font.pixelSize: Appearance.font.pixelSize.small
                 wrapMode: Text.WordWrap
@@ -2183,21 +2183,22 @@ ContentPage {
                 title: Translation.tr("Blur Mode")
 
                 ConfigSelectionArray {
-                    currentValue: BlurService.ready ? BlurService.options.mode : "auto"
+                    currentValue: root.windowRulesReady ? (root.windowRulesData?.blur_mode ?? "auto") : "auto"
                     options: [
                         { displayName: Translation.tr("Always On"), icon: "blur_on", value: "on" },
                         { displayName: Translation.tr("Always Off"), icon: "blur_off", value: "off" },
                         { displayName: Translation.tr("Auto (On Charge)"), icon: "blur_circular", value: "auto" }
                     ]
                     onSelected: newValue => {
-                        BlurService.options.mode = newValue;
+                        if (root.windowRulesReady)
+                            root.setConfig("window-rules", "blur-mode", newValue);
                     }
                 }
             }
 
             ContentSubsection {
-                title: Translation.tr("Managed Window Rules")
-                visible: BlurService.ready && BlurService.options.mode !== "off"
+                title: Translation.tr("Window Blur")
+                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -2206,28 +2207,18 @@ ContentPage {
                     SettingsSwitch {
                         Layout.fillWidth: true
                         buttonIcon: "check_box"
-                        text: Translation.tr("Apply blur to matching windows")
-                        checked: BlurService.ready && BlurService.options.window_rules_enabled
+                        text: Translation.tr("Enable window background blur")
+                        checked: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
                         onCheckedChanged: {
-                            if (BlurService.ready)
-                                BlurService.options.window_rules_enabled = checked;
-                        }
-                    }
-
-                    MaterialTextField {
-                        Layout.fillWidth: true
-                        enabled: BlurService.ready && BlurService.options.window_rules_enabled
-                        placeholderText: Translation.tr("Window app-id regex, for example ^(Alacritty|kitty|foot)$")
-                        text: BlurService.ready ? BlurService.options.window_matcher : ""
-                        onEditingFinished: {
-                            if (BlurService.ready)
-                                BlurService.options.window_matcher = text.trim();
+                            if (root.windowRulesReady && (root.windowRulesData?.window_blur ?? true) !== checked)
+                                root.setConfig("window-rules", "window-blur", checked ? "true" : "false");
                         }
                     }
 
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: 8
+                        visible: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
 
                         StyledText {
                             text: Translation.tr("Active opacity:")
@@ -2238,17 +2229,18 @@ ContentPage {
                         StyledSlider {
                             id: activeBlurOpacitySlider
                             Layout.fillWidth: true
-                            enabled: BlurService.ready && BlurService.options.window_rules_enabled
+                            enabled: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
                             from: 10
                             to: 100
-                            value: Math.round((BlurService.ready ? BlurService.options.active_opacity : 0.95) * 100)
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.active_opacity ?? 0.95) : 0.95) * 100)
                             stepSize: 5
                             configuration: StyledSlider.Configuration.S
 
                             onMoved: {
+                                if (pressed) return
                                 const val = value / 100.0
-                                if (BlurService.ready && val !== BlurService.options.active_opacity)
-                                    BlurService.options.active_opacity = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.active_opacity ?? 0.95))
+                                    root.setConfig("window-rules", "active-opacity", String(val))
                             }
                         }
 
@@ -2265,6 +2257,7 @@ ContentPage {
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: 8
+                        visible: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
 
                         StyledText {
                             text: Translation.tr("Inactive opacity:")
@@ -2275,17 +2268,18 @@ ContentPage {
                         StyledSlider {
                             id: inactiveBlurOpacitySlider
                             Layout.fillWidth: true
-                            enabled: BlurService.ready && BlurService.options.window_rules_enabled
+                            enabled: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
                             from: 10
                             to: 100
-                            value: Math.round((BlurService.ready ? BlurService.options.inactive_opacity : 0.70) * 100)
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.inactive_opacity ?? 0.70) : 0.70) * 100)
                             stepSize: 5
                             configuration: StyledSlider.Configuration.S
 
                             onMoved: {
+                                if (pressed) return
                                 const val = value / 100.0
-                                if (BlurService.ready && val !== BlurService.options.inactive_opacity)
-                                    BlurService.options.inactive_opacity = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.inactive_opacity ?? 0.70))
+                                    root.setConfig("window-rules", "inactive-opacity", String(val))
                             }
                         }
 
@@ -2302,8 +2296,8 @@ ContentPage {
             }
 
             ContentSubsection {
-                title: Translation.tr("Managed Layer Rules")
-                visible: BlurService.ready && BlurService.options.mode !== "off"
+                title: Translation.tr("Layer Blur")
+                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -2312,28 +2306,18 @@ ContentPage {
                     SettingsSwitch {
                         Layout.fillWidth: true
                         buttonIcon: "layers"
-                        text: Translation.tr("Apply blur to matching layer-shell surfaces")
-                        checked: BlurService.ready && BlurService.options.layer_rules_enabled
+                        text: Translation.tr("Enable layer surface background blur")
+                        checked: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
                         onCheckedChanged: {
-                            if (BlurService.ready)
-                                BlurService.options.layer_rules_enabled = checked;
-                        }
-                    }
-
-                    MaterialTextField {
-                        Layout.fillWidth: true
-                        enabled: BlurService.ready && BlurService.options.layer_rules_enabled
-                        placeholderText: Translation.tr("Layer namespace regex, for example ^(launcher|waybar|walker|fuzzel)$")
-                        text: BlurService.ready ? BlurService.options.layer_namespace : ""
-                        onEditingFinished: {
-                            if (BlurService.ready)
-                                BlurService.options.layer_namespace = text.trim();
+                            if (root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true) !== checked)
+                                root.setConfig("window-rules", "layer-blur", checked ? "true" : "false");
                         }
                     }
 
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: 8
+                        visible: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
 
                         StyledText {
                             text: Translation.tr("Layer opacity:")
@@ -2344,17 +2328,18 @@ ContentPage {
                         StyledSlider {
                             id: layerBlurOpacitySlider
                             Layout.fillWidth: true
-                            enabled: BlurService.ready && BlurService.options.layer_rules_enabled
+                            enabled: root.windowRulesReady && (root.windowRulesData?.layer_blur ?? true)
                             from: 10
                             to: 100
-                            value: Math.round((BlurService.ready ? BlurService.options.layer_opacity : 0.85) * 100)
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.layer_opacity ?? 0.85) : 0.85) * 100)
                             stepSize: 5
                             configuration: StyledSlider.Configuration.S
 
                             onMoved: {
+                                if (pressed) return
                                 const val = value / 100.0
-                                if (BlurService.ready && val !== BlurService.options.layer_opacity)
-                                    BlurService.options.layer_opacity = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.layer_opacity ?? 0.85))
+                                    root.setConfig("window-rules", "layer-opacity", String(val))
                             }
                         }
 
@@ -2372,7 +2357,7 @@ ContentPage {
 
             ContentSubsection {
                 title: Translation.tr("Blur Quality")
-                visible: BlurService.ready && BlurService.options.mode !== "off"
+                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -2382,10 +2367,10 @@ ContentPage {
                         Layout.fillWidth: true
                         buttonIcon: "visibility"
                         text: Translation.tr("Enable xray blur for better performance")
-                        checked: BlurService.ready && BlurService.options.xray
+                        checked: root.windowRulesReady && (root.windowRulesData?.blur_xray ?? true)
                         onCheckedChanged: {
-                            if (BlurService.ready)
-                                BlurService.options.xray = checked;
+                            if (root.windowRulesReady && (root.windowRulesData?.blur_xray ?? true) !== checked)
+                                root.setConfig("window-rules", "blur-xray", checked ? "true" : "false");
                         }
                     }
 
@@ -2403,14 +2388,15 @@ ContentPage {
                             id: blurPassesSlider
                             Layout.fillWidth: true
                             from: 1
-                            to: 6
+                            to: 8
                             stepSize: 1
-                            value: BlurService.ready ? BlurService.options.passes : 3
+                            value: root.windowRulesReady ? (root.windowRulesData?.blur_passes ?? 3) : 3
                             configuration: StyledSlider.Configuration.S
                             onMoved: {
+                                if (pressed) return
                                 const val = Math.round(value)
-                                if (BlurService.ready && val !== BlurService.options.passes)
-                                    BlurService.options.passes = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.blur_passes ?? 3))
+                                    root.setConfig("window-rules", "blur-passes", String(val))
                             }
                         }
 
@@ -2437,15 +2423,16 @@ ContentPage {
                         StyledSlider {
                             id: blurOffsetSlider
                             Layout.fillWidth: true
-                            from: 100
-                            to: 500
+                            from: 50
+                            to: 800
                             stepSize: 25
-                            value: Math.round((BlurService.ready ? BlurService.options.offset : 3.0) * 100)
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.blur_offset ?? 3.0) : 3.0) * 100)
                             configuration: StyledSlider.Configuration.S
                             onMoved: {
+                                if (pressed) return
                                 const val = value / 100.0
-                                if (BlurService.ready && val !== BlurService.options.offset)
-                                    BlurService.options.offset = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.blur_offset ?? 3.0))
+                                    root.setConfig("window-rules", "blur-offset", String(val))
                             }
                         }
 
@@ -2475,12 +2462,13 @@ ContentPage {
                             from: 0
                             to: 100
                             stepSize: 1
-                            value: Math.round((BlurService.ready ? BlurService.options.noise : 0.02) * 1000)
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.blur_noise ?? 0.02) : 0.02) * 1000)
                             configuration: StyledSlider.Configuration.S
                             onMoved: {
+                                if (pressed) return
                                 const val = value / 1000.0
-                                if (BlurService.ready && val !== BlurService.options.noise)
-                                    BlurService.options.noise = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.blur_noise ?? 0.02))
+                                    root.setConfig("window-rules", "blur-noise", String(val))
                             }
                         }
 
@@ -2510,12 +2498,13 @@ ContentPage {
                             from: 50
                             to: 250
                             stepSize: 5
-                            value: Math.round((BlurService.ready ? BlurService.options.saturation : 1.5) * 100)
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.blur_saturation ?? 1.5) : 1.5) * 100)
                             configuration: StyledSlider.Configuration.S
                             onMoved: {
+                                if (pressed) return
                                 const val = value / 100.0
-                                if (BlurService.ready && val !== BlurService.options.saturation)
-                                    BlurService.options.saturation = val
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.blur_saturation ?? 1.5))
+                                    root.setConfig("window-rules", "blur-saturation", String(val))
                             }
                         }
 

--- a/modules/settings/NiriConfig.qml
+++ b/modules/settings/NiriConfig.qml
@@ -2291,6 +2291,10 @@ ContentPage {
                             Layout.preferredWidth: 35
                             horizontalAlignment: Text.AlignRight
                         }
+                    }
+                }
+            }
+
             ContentSubsection {
                 title: Translation.tr("Layer Blur")
                 visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"

--- a/modules/settings/NiriConfig.qml
+++ b/modules/settings/NiriConfig.qml
@@ -2116,41 +2116,7 @@ ContentPage {
                 }
             }
 
-            SettingsDivider {}
 
-            ContentSubsection {
-                title: Translation.tr("Global inactive window opacity")
-                tooltip: Translation.tr("Transparency of unfocused windows before any app-specific blur rule overrides (1.0 = fully opaque)")
-
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: 8
-
-                    StyledSlider {
-                        id: inactiveOpacitySlider
-                        Layout.fillWidth: true
-                        from: 0
-                        to: 100
-                        value: Math.round((root.windowRulesData?.inactive_opacity ?? 0.9) * 100)
-                        stepSize: 5
-                        configuration: StyledSlider.Configuration.S
-
-                        onMoved: {
-                            if (pressed) return
-                            root.setConfig("window-rules", "inactive-opacity", (value / 100.0).toFixed(2))
-                        }
-                    }
-
-                    StyledText {
-                        text: (inactiveOpacitySlider.value / 100.0).toFixed(2)
-                        font.pixelSize: Appearance.font.pixelSize.smallest
-                        font.family: Appearance.font.family.monospace
-                        color: Appearance.colors.colSubtext
-                        Layout.preferredWidth: 35
-                        horizontalAlignment: Text.AlignRight
-                    }
-                }
-            }
 
             SettingsSwitch {
                 Layout.fillWidth: true
@@ -2168,37 +2134,104 @@ ContentPage {
     SettingsCardSection {
         expanded: false
         icon: "blur_on"
-        title: Translation.tr("Window Blur")
+        title: Translation.tr("Window Blur & Opacity")
 
         SettingsGroup {
             StyledText {
                 Layout.fillWidth: true
-                text: Translation.tr("Blur is managed globally for windows and layer surfaces. Configured values are written directly to your Niri configuration files.")
+                text: Translation.tr("Blur and opacity are managed globally for windows. Configured values are written directly to your Niri configuration files.")
                 color: Appearance.colors.colOnSurfaceVariant
                 font.pixelSize: Appearance.font.pixelSize.small
                 wrapMode: Text.WordWrap
             }
 
             ContentSubsection {
-                title: Translation.tr("Blur Mode")
+                title: Translation.tr("Window Opacity")
 
-                ConfigSelectionArray {
-                    currentValue: root.windowRulesReady ? (root.windowRulesData?.blur_mode ?? "auto") : "auto"
-                    options: [
-                        { displayName: Translation.tr("Always On"), icon: "blur_on", value: "on" },
-                        { displayName: Translation.tr("Always Off"), icon: "blur_off", value: "off" },
-                        { displayName: Translation.tr("Auto (On Charge)"), icon: "blur_circular", value: "auto" }
-                    ]
-                    onSelected: newValue => {
-                        if (root.windowRulesReady)
-                            root.setConfig("window-rules", "blur-mode", newValue);
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Active opacity:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: activeOpacitySlider
+                            Layout.fillWidth: true
+                            from: 10
+                            to: 100
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.active_opacity ?? 1.0) : 1.0) * 100)
+                            stepSize: 5
+                            configuration: StyledSlider.Configuration.S
+
+                            onMoved: {
+                                if (pressed) return
+                                const val = value / 100.0
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.active_opacity ?? 1.0))
+                                    root.setConfig("window-rules", "active-opacity", String(val))
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(activeOpacitySlider.value) + "%"
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 35
+                            horizontalAlignment: Text.AlignRight
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        StyledText {
+                            text: Translation.tr("Inactive opacity:")
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
+
+                        StyledSlider {
+                            id: inactiveOpacitySlider
+                            Layout.fillWidth: true
+                            from: 10
+                            to: 100
+                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.inactive_opacity ?? 0.70) : 0.70) * 100)
+                            stepSize: 5
+                            configuration: StyledSlider.Configuration.S
+
+                            onMoved: {
+                                if (pressed) return
+                                const val = value / 100.0
+                                if (root.windowRulesReady && val !== (root.windowRulesData?.inactive_opacity ?? 0.70))
+                                    root.setConfig("window-rules", "inactive-opacity", String(val))
+                            }
+                        }
+
+                        StyledText {
+                            text: Math.round(inactiveOpacitySlider.value) + "%"
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.family: Appearance.font.family.monospace
+                            color: Appearance.colors.colSubtext
+                            Layout.preferredWidth: 35
+                            horizontalAlignment: Text.AlignRight
+                        }
                     }
                 }
             }
 
+            SettingsDivider {}
+
             ContentSubsection {
                 title: Translation.tr("Window Blur")
-                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -2215,91 +2248,30 @@ ContentPage {
                         }
                     }
 
-                    RowLayout {
+                    ContentSubsection {
+                        title: Translation.tr("Blur Mode")
                         Layout.fillWidth: true
-                        spacing: 8
                         visible: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
 
-                        StyledText {
-                            text: Translation.tr("Active opacity:")
-                            font.pixelSize: Appearance.font.pixelSize.smallest
-                            color: Appearance.colors.colSubtext
-                        }
-
-                        StyledSlider {
-                            id: activeBlurOpacitySlider
-                            Layout.fillWidth: true
-                            enabled: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
-                            from: 10
-                            to: 100
-                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.active_opacity ?? 0.95) : 0.95) * 100)
-                            stepSize: 5
-                            configuration: StyledSlider.Configuration.S
-
-                            onMoved: {
-                                if (pressed) return
-                                const val = value / 100.0
-                                if (root.windowRulesReady && val !== (root.windowRulesData?.active_opacity ?? 0.95))
-                                    root.setConfig("window-rules", "active-opacity", String(val))
+                        ConfigSelectionArray {
+                            currentValue: root.windowRulesReady ? (root.windowRulesData?.blur_mode ?? "auto") : "auto"
+                            options: [
+                                { displayName: Translation.tr("Always On"), icon: "blur_on", value: "on" },
+                                { displayName: Translation.tr("Always Off"), icon: "blur_off", value: "off" },
+                                { displayName: Translation.tr("Auto (On Charge)"), icon: "blur_circular", value: "auto" }
+                            ]
+                            onSelected: newValue => {
+                                if (root.windowRulesReady)
+                                    root.setConfig("window-rules", "blur-mode", newValue);
                             }
-                        }
-
-                        StyledText {
-                            text: Math.round(activeBlurOpacitySlider.value) + "%"
-                            font.pixelSize: Appearance.font.pixelSize.smallest
-                            font.family: Appearance.font.family.monospace
-                            color: Appearance.colors.colSubtext
-                            Layout.preferredWidth: 35
-                            horizontalAlignment: Text.AlignRight
-                        }
-                    }
-
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 8
-                        visible: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
-
-                        StyledText {
-                            text: Translation.tr("Inactive opacity:")
-                            font.pixelSize: Appearance.font.pixelSize.smallest
-                            color: Appearance.colors.colSubtext
-                        }
-
-                        StyledSlider {
-                            id: inactiveBlurOpacitySlider
-                            Layout.fillWidth: true
-                            enabled: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true)
-                            from: 10
-                            to: 100
-                            value: Math.round((root.windowRulesReady ? (root.windowRulesData?.inactive_opacity ?? 0.70) : 0.70) * 100)
-                            stepSize: 5
-                            configuration: StyledSlider.Configuration.S
-
-                            onMoved: {
-                                if (pressed) return
-                                const val = value / 100.0
-                                if (root.windowRulesReady && val !== (root.windowRulesData?.inactive_opacity ?? 0.70))
-                                    root.setConfig("window-rules", "inactive-opacity", String(val))
-                            }
-                        }
-
-                        StyledText {
-                            text: Math.round(inactiveBlurOpacitySlider.value) + "%"
-                            font.pixelSize: Appearance.font.pixelSize.smallest
-                            font.family: Appearance.font.family.monospace
-                            color: Appearance.colors.colSubtext
-                            Layout.preferredWidth: 35
-                            horizontalAlignment: Text.AlignRight
                         }
                     }
                 }
             }
 
-
-
             ContentSubsection {
-                title: Translation.tr("Blur Quality")
-                visible: root.windowRulesReady && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
+                title: Translation.tr("Blur Quality & Tweaks")
+                visible: root.windowRulesReady && (root.windowRulesData?.window_blur ?? true) && (root.windowRulesData?.blur_mode ?? "auto") !== "off"
 
                 ColumnLayout {
                     Layout.fillWidth: true

--- a/modules/verticalBar/VerticalBar.qml
+++ b/modules/verticalBar/VerticalBar.qml
@@ -268,8 +268,7 @@ Scope {
                                             sourceSize.height: barRoot.screen?.height ?? 1080
                                             asynchronous: true
 
-                                            // See #159 — skip QML blur when compositor blur covers this layer
-                                            layer.enabled: Appearance.effectsEnabled && Appearance.auroraEverywhere && !Appearance.compositorBlurActive
+                                            layer.enabled: Appearance.effectsEnabled && Appearance.auroraEverywhere
                                             layer.effect: MultiEffect {
                                                 source: blurImg
                                                 anchors.fill: source

--- a/modules/verticalBar/VerticalBarContent.qml
+++ b/modules/verticalBar/VerticalBarContent.qml
@@ -123,15 +123,11 @@ Item { // Bar content region
         color: {
             if (root.angelEverywhere) {
                 const base = root.blendedColors?.colLayer0 ?? Appearance.colors.colLayer0
-                if (Appearance.compositorBlurActive)
-                    return ColorUtils.transparentize(base, Appearance.angel.compositorPanelTransparentize)
                 return ColorUtils.applyAlpha(base, 1)
             }
             if (root.inirEverywhere) return Appearance.inir.colLayer0
             if (root.auroraEverywhere) {
                 const base = root.blendedColors?.colLayer0 ?? Appearance.colors.colLayer0
-                if (Appearance.compositorBlurActive)
-                    return ColorUtils.transparentize(base, Appearance.aurora.compositorOverlayTransparentize)
                 return ColorUtils.applyAlpha(base, 1)
             }
             return root.cardStyleEverywhere ? Appearance.colors.colLayer1 : ((Config.options?.bar?.cornerStyle ?? 0) === 3 ? Appearance.colors.colLayer1 : Appearance.colors.colLayer0)
@@ -170,7 +166,7 @@ Item { // Bar content region
         id: auroraBlurLayer
         anchors.fill: barBackground
         visible: root.auroraEverywhere && !root.inirEverywhere && !root.gameModeMinimal
-            && (Config.options?.bar?.showBackground ?? true) && !Appearance.compositorBlurActive
+            && (Config.options?.bar?.showBackground ?? true)
 
         // Clip + mask to barBackground shape
         clip: true
@@ -194,14 +190,14 @@ Item { // Bar content region
             y: -barMargin
             width: root.screen?.width ?? 1920
             height: root.screen?.height ?? 1080
-            source: Appearance.compositorBlurActive ? "" : root.wallpaperUrl
+            source: root.wallpaperUrl
             fillMode: Image.PreserveAspectCrop
             cache: true
             sourceSize.width: root.screen?.width ?? 1920
             sourceSize.height: root.screen?.height ?? 1080
             asynchronous: true
 
-            layer.enabled: Appearance.effectsEnabled && root.auroraEverywhere && !root.inirEverywhere && !Appearance.compositorBlurActive
+            layer.enabled: Appearance.effectsEnabled && root.auroraEverywhere && !root.inirEverywhere
             layer.effect: MultiEffect {
                 source: blurredWallpaper
                 anchors.fill: source

--- a/scripts/lib/ipc-registry.sh
+++ b/scripts/lib/ipc-registry.sh
@@ -271,7 +271,7 @@ declare -gA IPC_FUNCTION_DESC=(
   ["region:ocr"]="OCR text recognition"
   ["region:record"]="Record region (no audio)"
   ["region:recordWithSound"]="Record region with audio"
-  ["region:menu"]="Open the unified snip menu (pick action/scope inline)"
+  ["region:menu"]=""
   ["search:toggle"]="Open/close start menu"
   ["search:close"]="Close start menu"
   ["search:open"]="Open start menu"
@@ -376,8 +376,7 @@ bind "Mod+Alt+P" { spawn "inir" "mpris" "previous"; }'
   [panelFamily]='bind "Mod+Shift+W" { spawn "inir" "panelFamily" "cycle"; }'
   [region]='bind "Super+Shift+S" { spawn "inir" "region" "screenshot"; }
 bind "Super+Shift+X" { spawn "inir" "region" "ocr"; }
-bind "Super+Shift+A" { spawn "inir" "region" "search"; }
-bind "Ctrl+Shift+S" { spawn "inir" "region" "menu"; }'
+bind "Super+Shift+A" { spawn "inir" "region" "search"; }'
   [session]='bind "Super+Shift+E" { spawn "inir" "session" "toggle"; }'
   [settings]='bind "Super+Comma" { spawn "inir" "settings"; }'
   [voiceSearch]='bind "Super+Shift+V" { spawn "inir" "voiceSearch" "toggle"; }'

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -953,51 +953,37 @@ def cmd_get_window_rules():
         "blur": True,
     }
 
-    if not rules_file.exists():
-        print(json.dumps(result))
-        return 0
+    if rules_file.exists():
+        content = rules_file.read_text()
+        pos = 0
+        while True:
+            match = re.search(r"window-rule\s*\{", content[pos:])
+            if not match:
+                break
+            block_start = pos + match.end()
+            depth = 1
+            i = block_start
+            while i < len(content) and depth > 0:
+                if content[i] == "{":
+                    depth += 1
+                elif content[i] == "}":
+                    depth -= 1
+                i += 1
+            block = content[block_start : i - 1] if depth == 0 else ""
+            pos = i
 
-    content = rules_file.read_text()
+            if not re.search(r"match\s+", block):
+                m = re.search(r"geometry-corner-radius\s+(\d+)", block)
+                if m:
+                    result["corner_radius"] = int(m.group(1))
+                m = re.search(r"clip-to-geometry\s+(true|false)", block)
+                if m:
+                    result["clip_to_geometry"] = m.group(1) == "true"
 
-    # Find all window-rule blocks
-    pos = 0
-    while True:
-        match = re.search(r"window-rule\s*\{", content[pos:])
-        if not match:
-            break
-        block_start = pos + match.end()
-        depth = 1
-        i = block_start
-        while i < len(content) and depth > 0:
-            if content[i] == "{":
-                depth += 1
-            elif content[i] == "}":
-                depth -= 1
-            i += 1
-        block = content[block_start : i - 1] if depth == 0 else ""
-        pos = i
-
-        # Check if this is the inactive-opacity rule (has match is-active=false)
-        if re.search(r"match\s+is-active\s*=\s*false", block):
-            m = re.search(r"opacity\s+([\d.]+)", block)
-            if m:
-                result["inactive_opacity"] = float(m.group(1))
-        # Check if this is the active-opacity rule (has match is-active=true)
-        elif re.search(r"match\s+is-active\s*=\s*true", block):
-            m = re.search(r"opacity\s+([\d.]+)", block)
-            if m:
-                result["active_opacity"] = float(m.group(1))
-        else:
-            # General rule — corner radius / clip / blur
-            m = re.search(r"geometry-corner-radius\s+(\d+)", block)
-            if m:
-                result["corner_radius"] = int(m.group(1))
-            m = re.search(r"clip-to-geometry\s+(true|false)", block)
-            if m:
-                result["clip_to_geometry"] = m.group(1) == "true"
-            m = re.search(r"background-effect\s*\{[^}]*blur\s+(true|false)", block, re.DOTALL)
-            if m:
-                result["blur"] = m.group(1) == "true"
+    settings = _parse_blur_settings()
+    result.update(settings)
+    result["inactive_opacity"] = settings["inactive_opacity"]
+    result["active_opacity"] = settings["active_opacity"]
 
     print(json.dumps(result))
     return 0
@@ -1281,6 +1267,13 @@ def cmd_set(args):
     elif section == "animations":
         return _set_animations(config_dir, key, value)
     elif section == "window-rules":
+        blur_keys = {
+            "blur-mode", "refresh-rate-efficiency", "window-blur", "layer-blur", "blur-xray",
+            "blur-passes", "blur-offset", "blur-noise", "blur-saturation",
+            "active-opacity", "inactive-opacity", "layer-opacity"
+        }
+        if key in blur_keys:
+            return cmd_set_blur_param(key, value)
         return _set_window_rules(config_dir, key, value)
     elif section == "output":
         # output HDMI-A-2.mode 1920x1080@74.973
@@ -2727,61 +2720,294 @@ def _upsert_blur_config(content, blur_enabled, passes, offset, noise, saturation
     return block + "\n"
 
 
+def _parse_blur_settings():
+    rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
+    layer_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+    config_file = get_niri_config_path()
+
+    settings = {
+        "blur_mode": "auto",
+        "refresh_rate_efficiency": False,
+        "window_blur": True,
+        "layer_blur": True,
+        "active_opacity": 0.95,
+        "inactive_opacity": 0.70,
+        "layer_opacity": 0.85,
+        "blur_passes": 3,
+        "blur_offset": 3.0,
+        "blur_noise": 0.02,
+        "blur_saturation": 1.5,
+        "blur_xray": True
+    }
+
+    if rules_file.exists():
+        content = rules_file.read_text()
+        m = re.search(r"//\s*ii-blur-mode:\s*(\w+)", content)
+        if m:
+            settings["blur_mode"] = m.group(1)
+        m = re.search(r"//\s*ii-refresh-rate-efficiency:\s*(\w+)", content)
+        if m:
+            settings["refresh_rate_efficiency"] = m.group(1).lower() == "true"
+        m = re.search(r"//\s*ii-window-blur:\s*(\w+)", content)
+        if m:
+            settings["window_blur"] = m.group(1).lower() == "true"
+        m = re.search(r"//\s*ii-layer-blur:\s*(\w+)", content)
+        if m:
+            settings["layer_blur"] = m.group(1).lower() == "true"
+        m = re.search(r"//\s*ii-blur-xray:\s*(\w+)", content)
+        if m:
+            settings["blur_xray"] = m.group(1).lower() == "true"
+
+        managed_pattern = r"// ii-managed-blur-window-rules:start(.*?)// ii-managed-blur-window-rules:end"
+        managed_match = re.search(managed_pattern, content, re.DOTALL)
+        if managed_match:
+            managed_content = managed_match.group(1)
+            active_m = re.search(r"match\s+is-active\s*=\s*true[^}]*opacity\s+([\d.]+)", managed_content, re.DOTALL)
+            if active_m:
+                settings["active_opacity"] = float(active_m.group(1))
+            inactive_m = re.search(r"match\s+is-active\s*=\s*false[^}]*opacity\s+([\d.]+)", managed_content, re.DOTALL)
+            if inactive_m:
+                settings["inactive_opacity"] = float(inactive_m.group(1))
+
+    if layer_file.exists():
+        content = layer_file.read_text()
+        managed_pattern = r"// ii-managed-blur-layer-rules:start(.*?)// ii-managed-blur-layer-rules:end"
+        managed_match = re.search(managed_pattern, content, re.DOTALL)
+        if managed_match:
+            managed_content = managed_match.group(1)
+            opacity_m = re.search(r"opacity\s+([\d.]+)", managed_content)
+            if opacity_m:
+                settings["layer_opacity"] = float(opacity_m.group(1))
+
+    if config_file.exists():
+        content = config_file.read_text()
+        bounds = _find_block_bounds(content, "blur", top_level=True)
+        if bounds:
+            _, start, end, _ = bounds
+            blur_block = content[start:end]
+            m = re.search(r"passes\s+(\d+)", blur_block)
+            if m:
+                settings["blur_passes"] = int(m.group(1))
+            m = re.search(r"offset\s+([\d.]+)", blur_block)
+            if m:
+                settings["blur_offset"] = float(m.group(1))
+            m = re.search(r"noise\s+([\d.]+)", blur_block)
+            if m:
+                settings["blur_noise"] = float(m.group(1))
+            m = re.search(r"saturation\s+([\d.]+)", blur_block)
+            if m:
+                settings["blur_saturation"] = float(m.group(1))
+
+    return settings
+
+
+def _write_blur_settings(config_dir, settings):
+    rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
+    layer_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+    config_file = get_niri_config_path()
+
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    layer_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # 1. Update config.kdl
+    if config_file.exists():
+        content = config_file.read_text()
+    else:
+        content = ""
+    blur_block = (
+        "blur {\n"
+        f"    passes {int(settings['blur_passes'])}\n"
+        f"    offset {_format_float(settings['blur_offset'], 2)}\n"
+        f"    noise {_format_float(settings['blur_noise'], 3)}\n"
+        f"    saturation {_format_float(settings['blur_saturation'], 2)}\n"
+        "}"
+    )
+    bounds = _find_block_bounds(content, "blur", top_level=True)
+    if bounds:
+        start, _, _, end = bounds
+        lead = "\n" if content[start] == "\n" else ""
+        content = content[:start] + lead + blur_block + content[end:]
+    else:
+        anchor_match = re.search(r"(?:^|\n)\s*environment\s*\{", content)
+        if anchor_match:
+            insert_at = anchor_match.start()
+            prefix = content[:insert_at].rstrip()
+            suffix = content[insert_at:].lstrip("\n")
+            join = "\n\n" if prefix else ""
+            content = f"{prefix}{join}{blur_block}\n\n{suffix}"
+        else:
+            if content.strip():
+                content = content.rstrip() + "\n\n" + blur_block + "\n"
+            else:
+                content = blur_block + "\n"
+    config_file.write_text(content)
+
+    # 2. Update 30-window-rules.kdl
+    if rules_file.exists():
+        content = rules_file.read_text()
+    else:
+        content = ""
+
+    # Strip existing metadata comments
+    for key in ["ii-blur-mode", "ii-refresh-rate-efficiency", "ii-window-blur", "ii-layer-blur", "ii-blur-xray"]:
+        content = re.sub(rf"//\s*{key}:\s*\w+\n", "", content)
+
+    metadata_comments = (
+        f"// ii-blur-mode: {settings['blur_mode']}\n"
+        f"// ii-refresh-rate-efficiency: {'true' if settings['refresh_rate_efficiency'] else 'false'}\n"
+        f"// ii-window-blur: {'true' if settings['window_blur'] else 'false'}\n"
+        f"// ii-layer-blur: {'true' if settings['layer_blur'] else 'false'}\n"
+        f"// ii-blur-xray: {'true' if settings['blur_xray'] else 'false'}\n"
+    )
+    content = metadata_comments + content.lstrip()
+
+    is_plugged = True
+    try:
+        for ps in Path("/sys/class/power_supply").glob("*"):
+            type_file = ps / "type"
+            online_file = ps / "online"
+            if type_file.exists() and online_file.exists():
+                if type_file.read_text().strip() == "Mains":
+                    is_plugged = online_file.read_text().strip() == "1"
+                    break
+    except Exception:
+        pass
+
+    blur_mode = settings["blur_mode"]
+    effective_blur_enabled = (
+        settings["window_blur"]
+        if blur_mode == "on"
+        else (settings["window_blur"] and is_plugged)
+        if blur_mode == "auto"
+        else False
+    )
+
+    effect_block = (
+        "    background-effect {\n"
+        f"        blur {'true' if effective_blur_enabled else 'false'}\n"
+        f"        xray {'true' if settings['blur_xray'] else 'false'}\n"
+        f"        noise {_format_float(settings['blur_noise'], 3)}\n"
+        f"        saturation {_format_float(settings['blur_saturation'], 2)}\n"
+        "    }"
+    )
+
+    window_rules_block = (
+        "window-rule {\n"
+        "    match is-active=true\n"
+        f"    opacity {_format_float(settings['active_opacity'], 2)}\n"
+        f"{effect_block}\n"
+        "}\n\n"
+        "window-rule {\n"
+        "    match is-active=false\n"
+        f"    opacity {_format_float(settings['inactive_opacity'], 2)}\n"
+        f"{effect_block}\n"
+        "}"
+    )
+
+    content = _replace_managed_region(
+        content, "// ii-managed-blur-window-rules:start", "// ii-managed-blur-window-rules:end", window_rules_block
+    )
+
+    # Disable conflicting global inactive opacity rule if present
+    unmanaged_pattern_robust = r"(?<!//\s)(window-rule\s*\{\s*match\s+is-active\s*=\s*false\s*\n\s*opacity\s+[\d.]+\s*\n\s*\})"
+    def comment_out(match_obj):
+        block_text = match_obj.group(1)
+        commented = "\n".join(f"// {line}" for line in block_text.splitlines())
+        return f"// Disabled conflicting global opacity rule:\n{commented}"
+    content = re.sub(unmanaged_pattern_robust, comment_out, content)
+
+    rules_file.write_text(content)
+
+    # 3. Update 80-layer-rules.kdl
+    if layer_file.exists():
+        content = layer_file.read_text()
+    else:
+        content = ""
+
+    effective_layer_blur_enabled = (
+        settings["layer_blur"]
+        if blur_mode == "on"
+        else (settings["layer_blur"] and is_plugged)
+        if blur_mode == "auto"
+        else False
+    )
+
+    layer_effect_block = (
+        "    background-effect {\n"
+        f"        blur {'true' if effective_layer_blur_enabled else 'false'}\n"
+        f"        xray {'true' if settings['blur_xray'] else 'false'}\n"
+        f"        noise {_format_float(settings['blur_noise'], 3)}\n"
+        f"        saturation {_format_float(settings['blur_saturation'], 2)}\n"
+        "    }"
+    )
+
+    layer_rules_block = (
+        "layer-rule {\n"
+        f"    opacity {_format_float(settings['layer_opacity'], 2)}\n"
+        f"{layer_effect_block}\n"
+        "}"
+    )
+
+    content = _replace_managed_region(
+        content, "// ii-managed-blur-layer-rules:start", "// ii-managed-blur-layer-rules:end", layer_rules_block
+    )
+    layer_file.write_text(content)
+
+
 def _upsert_window_blur_rules(
     content,
     enabled,
-    matcher,
     active_opacity,
     inactive_opacity,
     xray,
     noise,
     saturation,
 ):
-    if enabled:
-        matcher = _kdl_escape_string(matcher)
-        effect_block = _render_background_effect_block(
-            "    ", xray=xray, noise=noise, saturation=saturation
-        )
-        block = (
-            "window-rule {\n"
-            f'    match app-id="{matcher}"\n'
-            "    match is-active=true\n"
-            f"    opacity {_format_float(active_opacity, 2)}\n"
-            f"{effect_block}\n"
-            "}\n\n"
-            "window-rule {\n"
-            f'    match app-id="{matcher}"\n'
-            "    match is-active=false\n"
-            f"    opacity {_format_float(inactive_opacity, 2)}\n"
-            f"{effect_block}\n"
-            "}"
-        )
-    else:
-        block = "// Managed blur window rules disabled."
-
+    effect_block = _render_background_effect_block(
+        "    ", xray=xray, noise=noise, saturation=saturation
+    )
+    effect_lines = (
+        "    background-effect {\n"
+        f"        blur {'true' if enabled else 'false'}\n"
+        f"        xray {'true' if xray else 'false'}\n"
+        f"        noise {_format_float(noise, 3)}\n"
+        f"        saturation {_format_float(saturation, 2)}\n"
+        "    }"
+    )
+    block = (
+        "window-rule {\n"
+        "    match is-active=true\n"
+        f"    opacity {_format_float(active_opacity, 2)}\n"
+        f"{effect_lines}\n"
+        "}\n\n"
+        "window-rule {\n"
+        "    match is-active=false\n"
+        f"    opacity {_format_float(inactive_opacity, 2)}\n"
+        f"{effect_lines}\n"
+        "}"
+    )
     return _replace_managed_region(
         content, BLUR_WINDOW_RULES_START, BLUR_WINDOW_RULES_END, block
     )
 
 
 def _upsert_layer_blur_rules(
-    content, enabled, namespace, opacity, xray, noise, saturation
+    content, enabled, opacity, xray, noise, saturation
 ):
-    if enabled:
-        namespace = _kdl_escape_string(namespace)
-        effect_block = _render_background_effect_block(
-            "    ", xray=xray, noise=noise, saturation=saturation
-        )
-        block = (
-            "layer-rule {\n"
-            f'    match namespace="{namespace}"\n'
-            f"    opacity {_format_float(opacity, 2)}\n"
-            f"{effect_block}\n"
-            "}"
-        )
-    else:
-        block = "// Managed blur layer rules disabled."
-
+    effect_lines = (
+        "    background-effect {\n"
+        f"        blur {'true' if enabled else 'false'}\n"
+        f"        xray {'true' if xray else 'false'}\n"
+        f"        noise {_format_float(noise, 3)}\n"
+        f"        saturation {_format_float(saturation, 2)}\n"
+        "    }"
+    )
+    block = (
+        "layer-rule {\n"
+        f"    opacity {_format_float(opacity, 2)}\n"
+        f"{effect_lines}\n"
+        "}"
+    )
     return _replace_managed_region(
         content, BLUR_LAYER_RULES_START, BLUR_LAYER_RULES_END, block
     )
@@ -2798,90 +3024,199 @@ def cmd_set_blur_rules(args):
         print(json.dumps({"error": f"Invalid blur payload: {exc}"}))
         return 1
 
-    blur_mode = str(payload.get("mode", "auto"))
-    blur_enabled = bool(payload.get("blur_enabled", True)) and blur_mode != "off"
-    xray_enabled = bool(payload.get("xray", True))
-    passes = max(1, min(8, int(payload.get("passes", 3))))
-    offset = max(0.5, min(8.0, float(payload.get("offset", 3.0))))
-    noise = max(0.0, min(1.0, float(payload.get("noise", 0.02))))
-    saturation = max(0.0, min(4.0, float(payload.get("saturation", 1.5))))
+    config_dir = get_niri_config_dir()
+    settings = _parse_blur_settings()
 
-    window_rules_enabled = bool(payload.get("window_rules_enabled", True))
-    window_matcher = str(payload.get("window_matcher", "")).strip()
-    active_val = max(0.05, min(1.0, float(payload.get("active_opacity", 0.95))))
-    inactive_val = max(0.05, min(1.0, float(payload.get("inactive_opacity", 0.70))))
+    if "mode" in payload:
+        settings["blur_mode"] = str(payload["mode"])
+    if "refresh_rate_efficiency" in payload:
+        settings["refresh_rate_efficiency"] = bool(payload["refresh_rate_efficiency"])
+    if "blur_enabled" in payload:
+        settings["window_blur"] = bool(payload["blur_enabled"])
+        settings["layer_blur"] = bool(payload["blur_enabled"])
+    if "window_rules_enabled" in payload:
+        settings["window_blur"] = bool(payload["window_rules_enabled"])
+    if "layer_rules_enabled" in payload:
+        settings["layer_blur"] = bool(payload["layer_rules_enabled"])
+    if "active_opacity" in payload:
+        settings["active_opacity"] = float(payload["active_opacity"])
+    if "inactive_opacity" in payload:
+        settings["inactive_opacity"] = float(payload["inactive_opacity"])
+    if "layer_opacity" in payload:
+        settings["layer_opacity"] = float(payload["layer_opacity"])
+    if "xray" in payload:
+        settings["blur_xray"] = bool(payload["xray"])
+    if "passes" in payload:
+        settings["blur_passes"] = int(payload["passes"])
+    if "offset" in payload:
+        settings["blur_offset"] = float(payload["offset"])
+    if "noise" in payload:
+        settings["blur_noise"] = float(payload["noise"])
+    if "saturation" in payload:
+        settings["blur_saturation"] = float(payload["saturation"])
 
-    layer_rules_enabled = bool(payload.get("layer_rules_enabled", False))
-    layer_namespace = str(payload.get("layer_namespace", "")).strip()
-    layer_opacity = max(0.05, min(1.0, float(payload.get("layer_opacity", 0.85))))
-
-    config_file = get_niri_config_path()
     rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
-    layer_rules_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+    layer_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+    config_file = get_niri_config_path()
 
-    config_file.parent.mkdir(parents=True, exist_ok=True)
-    rules_file.parent.mkdir(parents=True, exist_ok=True)
-    layer_rules_file.parent.mkdir(parents=True, exist_ok=True)
-
-    unique_files = []
     originals = {}
-    for path in [config_file, rules_file, layer_rules_file]:
-        if path not in originals:
-            originals[path] = path.read_text() if path.exists() else ""
-            unique_files.append(path)
-
-    updated = dict(originals)
-
-    updated[config_file] = _upsert_blur_config(
-        updated[config_file],
-        blur_enabled=blur_enabled,
-        passes=passes,
-        offset=offset,
-        noise=noise,
-        saturation=saturation,
-    )
-    updated[rules_file] = _upsert_window_blur_rules(
-        updated[rules_file],
-        enabled=blur_enabled and window_rules_enabled and bool(window_matcher),
-        matcher=window_matcher,
-        active_opacity=active_val,
-        inactive_opacity=inactive_val,
-        xray=xray_enabled,
-        noise=noise,
-        saturation=saturation,
-    )
-    updated[layer_rules_file] = _upsert_layer_blur_rules(
-        updated[layer_rules_file],
-        enabled=blur_enabled and layer_rules_enabled and bool(layer_namespace),
-        namespace=layer_namespace,
-        opacity=layer_opacity,
-        xray=xray_enabled,
-        noise=noise,
-        saturation=saturation,
-    )
+    for path in [config_file, rules_file, layer_file]:
+        originals[path] = path.read_text() if path.exists() else None
 
     try:
-        for path in unique_files:
-            path.write_text(updated[path])
+        _write_blur_settings(config_dir, settings)
     except Exception as exc:
-        print(json.dumps({"error": f"Failed to update blur config: {exc}"}))
+        print(json.dumps({"error": f"Failed to write blur settings: {exc}"}))
+        for path, backup in originals.items():
+            if backup is not None:
+                path.write_text(backup)
         return 1
 
     valid, err = _validate_config()
     if not valid:
-        for path in unique_files:
-            _restore_text_file(path, originals[path])
+        for path, backup in originals.items():
+            if backup is not None:
+                path.write_text(backup)
         print(json.dumps({"success": False, "error": f"Validation failed: {err}"}))
         return 1
 
-    print(
-        json.dumps(
-            {
-                "success": True,
-                "files": [str(path) for path in unique_files],
-            }
-        )
-    )
+    is_plugged = True
+    try:
+        for ps in Path("/sys/class/power_supply").glob("*"):
+            type_file = ps / "type"
+            online_file = ps / "online"
+            if type_file.exists() and online_file.exists():
+                if type_file.read_text().strip() == "Mains":
+                    is_plugged = online_file.read_text().strip() == "1"
+                    break
+    except Exception:
+        pass
+    
+    if settings["refresh_rate_efficiency"]:
+        cmd_sync_refresh_rate([str(is_plugged)])
+    else:
+        cmd_sync_refresh_rate(["true"])
+
+    print(json.dumps({"success": True}))
+    return 0
+
+
+def cmd_set_blur_param(key, value):
+    config_dir = get_niri_config_dir()
+    settings = _parse_blur_settings()
+
+    if key == "blur-mode":
+        settings["blur_mode"] = str(value)
+    elif key == "refresh-rate-efficiency":
+        settings["refresh_rate_efficiency"] = str(value).lower() in ("true", "on")
+    elif key == "window-blur":
+        settings["window_blur"] = str(value).lower() in ("true", "on")
+    elif key == "layer-blur":
+        settings["layer_blur"] = str(value).lower() in ("true", "on")
+    elif key == "blur-xray":
+        settings["blur_xray"] = str(value).lower() in ("true", "on")
+    elif key == "blur-passes":
+        settings["blur_passes"] = max(1, min(8, int(value)))
+    elif key == "blur-offset":
+        settings["blur_offset"] = max(0.5, min(8.0, float(value)))
+    elif key == "blur-noise":
+        settings["blur_noise"] = max(0.0, min(1.0, float(value)))
+    elif key == "blur-saturation":
+        settings["blur_saturation"] = max(0.0, min(4.0, float(value)))
+    elif key == "active-opacity":
+        settings["active_opacity"] = max(0.05, min(1.0, float(value)))
+    elif key == "inactive-opacity":
+        settings["inactive_opacity"] = max(0.05, min(1.0, float(value)))
+    elif key == "layer-opacity":
+        settings["layer_opacity"] = max(0.05, min(1.0, float(value)))
+    else:
+        print(json.dumps({"error": f"Unknown blur setting key: {key}"}))
+        return 1
+
+    rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
+    layer_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+    config_file = get_niri_config_path()
+
+    originals = {}
+    for path in [config_file, rules_file, layer_file]:
+        originals[path] = path.read_text() if path.exists() else None
+
+    try:
+        _write_blur_settings(config_dir, settings)
+    except Exception as exc:
+        print(json.dumps({"error": f"Failed to write blur settings: {exc}"}))
+        for path, backup in originals.items():
+            if backup is not None:
+                path.write_text(backup)
+        return 1
+
+    valid, err = _validate_config()
+    if not valid:
+        for path, backup in originals.items():
+            if backup is not None:
+                path.write_text(backup)
+        print(json.dumps({"success": False, "error": f"Validation failed: {err}"}))
+        return 1
+
+    if key in ("refresh-rate-efficiency", "blur-mode"):
+        is_plugged = True
+        try:
+            for ps in Path("/sys/class/power_supply").glob("*"):
+                type_file = ps / "type"
+                online_file = ps / "online"
+                if type_file.exists() and online_file.exists():
+                    if type_file.read_text().strip() == "Mains":
+                        is_plugged = online_file.read_text().strip() == "1"
+                        break
+        except Exception:
+            pass
+        
+        if settings["refresh_rate_efficiency"]:
+            cmd_sync_refresh_rate([str(is_plugged)])
+        else:
+            cmd_sync_refresh_rate(["true"])
+
+    print(json.dumps({"success": True}))
+    return 0
+
+
+def cmd_sync_power_state(args):
+    if len(args) < 1:
+        print(json.dumps({"error": "Usage: sync-power-state <is_plugged_in>"}))
+        return 1
+
+    is_plugged = args[0].lower() == "true"
+    config_dir = get_niri_config_dir()
+    settings = _parse_blur_settings()
+
+    if settings["refresh_rate_efficiency"]:
+        cmd_sync_refresh_rate([str(is_plugged)])
+    else:
+        cmd_sync_refresh_rate(["true"])
+
+    rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
+    layer_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+    config_file = get_niri_config_path()
+
+    originals = {}
+    for path in [config_file, rules_file, layer_file]:
+        originals[path] = path.read_text() if path.exists() else None
+
+    try:
+        _write_blur_settings(config_dir, settings)
+    except Exception as exc:
+        print(json.dumps({"error": f"Failed to sync power state: {exc}"}))
+        return 1
+
+    valid, err = _validate_config()
+    if not valid:
+        for path, backup in originals.items():
+            if backup is not None:
+                path.write_text(backup)
+        print(json.dumps({"success": False, "error": f"Validation failed: {err}"}))
+        return 1
+
+    print(json.dumps({"success": True}))
     return 0
 
 
@@ -2978,6 +3313,7 @@ def main():
         "set": lambda: cmd_set(args),
         "set-blur-rules": lambda: cmd_set_blur_rules(args),
         "sync-refresh-rate": lambda: cmd_sync_refresh_rate(args),
+        "sync-power-state": lambda: cmd_sync_power_state(args),
         "get-binds": lambda: cmd_get_binds(),
         "set-bind": lambda: cmd_set_bind(args),
         "remove-bind": lambda: cmd_remove_bind(args),

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -2730,7 +2730,7 @@ def _parse_blur_settings():
         "refresh_rate_efficiency": False,
         "window_blur": True,
         "layer_blur": True,
-        "active_opacity": 0.95,
+        "active_opacity": 1.0,
         "inactive_opacity": 0.70,
         "layer_opacity": 0.85,
         "blur_passes": 3,

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -2924,29 +2924,7 @@ def _write_blur_settings(config_dir, settings):
     else:
         content = ""
 
-    effective_layer_blur_enabled = (
-        settings["layer_blur"]
-        if blur_mode == "on"
-        else (settings["layer_blur"] and is_plugged)
-        if blur_mode == "auto"
-        else False
-    )
-
-    layer_effect_block = (
-        "    background-effect {\n"
-        f"        blur {'true' if effective_layer_blur_enabled else 'false'}\n"
-        f"        xray {'true' if settings['blur_xray'] else 'false'}\n"
-        f"        noise {_format_float(settings['blur_noise'], 3)}\n"
-        f"        saturation {_format_float(settings['blur_saturation'], 2)}\n"
-        "    }"
-    )
-
-    layer_rules_block = (
-        "layer-rule {\n"
-        f"    opacity {_format_float(settings['layer_opacity'], 2)}\n"
-        f"{layer_effect_block}\n"
-        "}"
-    )
+    layer_rules_block = "// Managed blur layer rules disabled."
 
     content = _replace_managed_region(
         content, "// ii-managed-blur-layer-rules:start", "// ii-managed-blur-layer-rules:end", layer_rules_block

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -2924,7 +2924,32 @@ def _write_blur_settings(config_dir, settings):
     else:
         content = ""
 
-    layer_rules_block = "// Managed blur layer rules disabled."
+    effective_layer_blur_enabled = (
+        settings["layer_blur"]
+        if blur_mode == "on"
+        else (settings["layer_blur"] and is_plugged)
+        if blur_mode == "auto"
+        else False
+    )
+
+    if settings["layer_blur"]:
+        layer_effect_block = (
+            "    background-effect {\n"
+            f"        blur {'true' if effective_layer_blur_enabled else 'false'}\n"
+            f"        xray {'true' if settings['blur_xray'] else 'false'}\n"
+            f"        noise {_format_float(settings['blur_noise'], 3)}\n"
+            f"        saturation {_format_float(settings['blur_saturation'], 2)}\n"
+            "    }"
+        )
+        layer_rules_block = (
+            "layer-rule {\n"
+            '    match namespace="^(launcher|waybar|walker|fuzzel|wofi|tofi|rofi|yofi|ags|swaync|mako)$"\n'
+            f"    opacity {_format_float(settings['layer_opacity'], 2)}\n"
+            f"{layer_effect_block}\n"
+            "}"
+        )
+    else:
+        layer_rules_block = "// Managed blur layer rules disabled."
 
     content = _replace_managed_region(
         content, "// ii-managed-blur-layer-rules:start", "// ii-managed-blur-layer-rules:end", layer_rules_block

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -18,6 +18,7 @@ Commands:
   validate             Validate current Niri config via niri validate
   detect-customizations Report Niri files that differ from shipped iNiR defaults
   set SECTION KEY VAL  Surgical edit of a single config value
+  set-blur-rules JSON  Sync managed blur config/window/layer rules from settings UI
   get-binds            JSON of all keybinds from 70-binds.kdl with categories/metadata
   set-bind KEY ACTION  Add or update a keybind in 70-binds.kdl (surgical edit)
   remove-bind KEY      Comment out a keybind in 70-binds.kdl (surgical edit)
@@ -948,6 +949,8 @@ def cmd_get_window_rules():
         "corner_radius": 16,
         "clip_to_geometry": True,
         "inactive_opacity": 0.9,
+        "active_opacity": 1.0,
+        "blur": True,
     }
 
     if not rules_file.exists():
@@ -979,14 +982,22 @@ def cmd_get_window_rules():
             m = re.search(r"opacity\s+([\d.]+)", block)
             if m:
                 result["inactive_opacity"] = float(m.group(1))
+        # Check if this is the active-opacity rule (has match is-active=true)
+        elif re.search(r"match\s+is-active\s*=\s*true", block):
+            m = re.search(r"opacity\s+([\d.]+)", block)
+            if m:
+                result["active_opacity"] = float(m.group(1))
         else:
-            # General rule — corner radius / clip
+            # General rule — corner radius / clip / blur
             m = re.search(r"geometry-corner-radius\s+(\d+)", block)
             if m:
                 result["corner_radius"] = int(m.group(1))
             m = re.search(r"clip-to-geometry\s+(true|false)", block)
             if m:
                 result["clip_to_geometry"] = m.group(1) == "true"
+            m = re.search(r"background-effect\s*\{[^}]*blur\s+(true|false)", block, re.DOTALL)
+            if m:
+                result["blur"] = m.group(1) == "true"
 
     print(json.dumps(result))
     return 0
@@ -1735,6 +1746,41 @@ def _set_window_rules(config_dir, key, value):
             content = (
                 content.rstrip()
                 + f"\n\nwindow-rule {{\n    match is-active=false\n    opacity {value}\n}}\n"
+            )
+
+    elif key == "active-opacity":
+        # Find the active rule block (has match is-active=true)
+        active_pattern = r"(window-rule\s*\{[^}]*match\s+is-active\s*=\s*true[^}]*)(opacity\s+[\d.]+)"
+        if re.search(active_pattern, content, re.DOTALL):
+            content = re.sub(
+                r"(match\s+is-active\s*=\s*true\s*\n\s*)(opacity\s+)[\d.]+",
+                rf"\g<1>\g<2>{value}",
+                content,
+                count=1,
+            )
+        else:
+            # No active rule exists — append one
+            content = (
+                content.rstrip()
+                + f"\n\nwindow-rule {{\n    match is-active=true\n    opacity {value}\n}}\n"
+            )
+
+    elif key == "blur":
+        # Enable/disable background blur
+        if re.search(r"background-effect\s*\{[^}]*blur\s+(true|false)", content, re.DOTALL):
+            content = re.sub(
+                r"(background-effect\s*\{[^}]*blur\s+)(true|false)",
+                rf"\g<1>{value}",
+                content,
+                count=1,
+            )
+        else:
+            # Insert in first window-rule block
+            content = re.sub(
+                r"(window-rule\s*\{)\s*\n",
+                rf"\g<1>\n    background-effect {{\n        blur {value}\n    }}\n",
+                content,
+                count=1,
             )
 
     elif key == "clip-to-geometry":
@@ -2602,6 +2648,305 @@ def cmd_remove_bind(args):
     return _write_validated(binds_file, new_content)
 
 
+BLUR_WINDOW_RULES_START = "// ii-managed-blur-window-rules:start"
+BLUR_WINDOW_RULES_END = "// ii-managed-blur-window-rules:end"
+BLUR_LAYER_RULES_START = "// ii-managed-blur-layer-rules:start"
+BLUR_LAYER_RULES_END = "// ii-managed-blur-layer-rules:end"
+
+
+def _format_float(value, digits=2):
+    text = f"{float(value):.{digits}f}"
+    return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+def _kdl_escape_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _restore_text_file(path: Path, text: str):
+    if text:
+        path.write_text(text)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _render_background_effect_block(indent, xray, noise, saturation):
+    inner = indent + "    "
+    lines = [
+        f"{indent}background-effect {{",
+        f"{inner}blur true",
+        f"{inner}xray {'true' if xray else 'false'}",
+        f"{inner}noise {_format_float(noise, 3)}",
+        f"{inner}saturation {_format_float(saturation, 2)}",
+        f"{indent}}}",
+    ]
+    return "\n".join(lines)
+
+
+def _replace_managed_region(content, start_marker, end_marker, replacement):
+    region = f"{start_marker}\n{replacement}\n{end_marker}"
+    pattern = rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}"
+    if re.search(pattern, content, re.DOTALL):
+        return re.sub(
+            pattern, lambda _match: region, content, count=1, flags=re.DOTALL
+        )
+
+    if content.strip():
+        return content.rstrip() + "\n\n" + region + "\n"
+    return region + "\n"
+
+
+def _upsert_blur_config(content, blur_enabled, passes, offset, noise, saturation):
+    off_line = "" if blur_enabled else "    off\n"
+    block = (
+        "blur {\n"
+        f"{off_line}"
+        f"    passes {int(passes)}\n"
+        f"    offset {_format_float(offset, 2)}\n"
+        f"    noise {_format_float(noise, 3)}\n"
+        f"    saturation {_format_float(saturation, 2)}\n"
+        "}"
+    )
+
+    bounds = _find_block_bounds(content, "blur", top_level=True)
+    if bounds:
+        start, _, _, end = bounds
+        lead = "\n" if content[start] == "\n" else ""
+        return content[:start] + lead + block + content[end:]
+
+    anchor_match = re.search(r"(?:^|\n)\s*environment\s*\{", content)
+    if anchor_match:
+        insert_at = anchor_match.start()
+        prefix = content[:insert_at].rstrip()
+        suffix = content[insert_at:].lstrip("\n")
+        join = "\n\n" if prefix else ""
+        return f"{prefix}{join}{block}\n\n{suffix}"
+
+    if content.strip():
+        return content.rstrip() + "\n\n" + block + "\n"
+    return block + "\n"
+
+
+def _upsert_window_blur_rules(
+    content,
+    enabled,
+    matcher,
+    active_opacity,
+    inactive_opacity,
+    xray,
+    noise,
+    saturation,
+):
+    if enabled:
+        matcher = _kdl_escape_string(matcher)
+        effect_block = _render_background_effect_block(
+            "    ", xray=xray, noise=noise, saturation=saturation
+        )
+        block = (
+            "window-rule {\n"
+            f'    match app-id="{matcher}"\n'
+            "    match is-active=true\n"
+            f"    opacity {_format_float(active_opacity, 2)}\n"
+            f"{effect_block}\n"
+            "}\n\n"
+            "window-rule {\n"
+            f'    match app-id="{matcher}"\n'
+            "    match is-active=false\n"
+            f"    opacity {_format_float(inactive_opacity, 2)}\n"
+            f"{effect_block}\n"
+            "}"
+        )
+    else:
+        block = "// Managed blur window rules disabled."
+
+    return _replace_managed_region(
+        content, BLUR_WINDOW_RULES_START, BLUR_WINDOW_RULES_END, block
+    )
+
+
+def _upsert_layer_blur_rules(
+    content, enabled, namespace, opacity, xray, noise, saturation
+):
+    if enabled:
+        namespace = _kdl_escape_string(namespace)
+        effect_block = _render_background_effect_block(
+            "    ", xray=xray, noise=noise, saturation=saturation
+        )
+        block = (
+            "layer-rule {\n"
+            f'    match namespace="{namespace}"\n'
+            f"    opacity {_format_float(opacity, 2)}\n"
+            f"{effect_block}\n"
+            "}"
+        )
+    else:
+        block = "// Managed blur layer rules disabled."
+
+    return _replace_managed_region(
+        content, BLUR_LAYER_RULES_START, BLUR_LAYER_RULES_END, block
+    )
+
+
+def cmd_set_blur_rules(args):
+    if len(args) < 1:
+        print(json.dumps({"error": "Usage: set-blur-rules <json_payload>"}))
+        return 1
+
+    try:
+        payload = json.loads(args[0])
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"error": f"Invalid blur payload: {exc}"}))
+        return 1
+
+    blur_mode = str(payload.get("mode", "auto"))
+    blur_enabled = bool(payload.get("blur_enabled", True)) and blur_mode != "off"
+    xray_enabled = bool(payload.get("xray", True))
+    passes = max(1, min(8, int(payload.get("passes", 3))))
+    offset = max(0.5, min(8.0, float(payload.get("offset", 3.0))))
+    noise = max(0.0, min(1.0, float(payload.get("noise", 0.02))))
+    saturation = max(0.0, min(4.0, float(payload.get("saturation", 1.5))))
+
+    window_rules_enabled = bool(payload.get("window_rules_enabled", True))
+    window_matcher = str(payload.get("window_matcher", "")).strip()
+    active_val = max(0.05, min(1.0, float(payload.get("active_opacity", 0.95))))
+    inactive_val = max(0.05, min(1.0, float(payload.get("inactive_opacity", 0.70))))
+
+    layer_rules_enabled = bool(payload.get("layer_rules_enabled", False))
+    layer_namespace = str(payload.get("layer_namespace", "")).strip()
+    layer_opacity = max(0.05, min(1.0, float(payload.get("layer_opacity", 0.85))))
+
+    config_file = get_niri_config_path()
+    rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
+    layer_rules_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
+
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    layer_rules_file.parent.mkdir(parents=True, exist_ok=True)
+
+    unique_files = []
+    originals = {}
+    for path in [config_file, rules_file, layer_rules_file]:
+        if path not in originals:
+            originals[path] = path.read_text() if path.exists() else ""
+            unique_files.append(path)
+
+    updated = dict(originals)
+
+    updated[config_file] = _upsert_blur_config(
+        updated[config_file],
+        blur_enabled=blur_enabled,
+        passes=passes,
+        offset=offset,
+        noise=noise,
+        saturation=saturation,
+    )
+    updated[rules_file] = _upsert_window_blur_rules(
+        updated[rules_file],
+        enabled=blur_enabled and window_rules_enabled and bool(window_matcher),
+        matcher=window_matcher,
+        active_opacity=active_val,
+        inactive_opacity=inactive_val,
+        xray=xray_enabled,
+        noise=noise,
+        saturation=saturation,
+    )
+    updated[layer_rules_file] = _upsert_layer_blur_rules(
+        updated[layer_rules_file],
+        enabled=blur_enabled and layer_rules_enabled and bool(layer_namespace),
+        namespace=layer_namespace,
+        opacity=layer_opacity,
+        xray=xray_enabled,
+        noise=noise,
+        saturation=saturation,
+    )
+
+    try:
+        for path in unique_files:
+            path.write_text(updated[path])
+    except Exception as exc:
+        print(json.dumps({"error": f"Failed to update blur config: {exc}"}))
+        return 1
+
+    valid, err = _validate_config()
+    if not valid:
+        for path in unique_files:
+            _restore_text_file(path, originals[path])
+        print(json.dumps({"success": False, "error": f"Validation failed: {err}"}))
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "files": [str(path) for path in unique_files],
+            }
+        )
+    )
+    return 0
+
+
+def cmd_sync_refresh_rate(args):
+    if len(args) < 1:
+        print(json.dumps({"error": "Usage: sync-refresh-rate <is_plugged_in>"}))
+        return 1
+
+    is_plugged = args[0].lower() == "true"
+    stdout, rc = run_niri("-j", "outputs")
+    if rc != 0:
+        print(json.dumps({"error": "Failed to query outputs"}))
+        return 1
+
+    try:
+        outputs_data = json.loads(stdout)
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to parse outputs JSON: {e}"}))
+        return 1
+
+    results = []
+    for output_name, output_info in outputs_data.items():
+        modes = output_info.get("modes", [])
+        curr_idx = output_info.get("current_mode")
+        if curr_idx is None or curr_idx < 0 or curr_idx >= len(modes):
+            continue
+
+        current_mode = modes[curr_idx]
+        target_width = current_mode.get("width")
+        target_height = current_mode.get("height")
+
+        matching_modes = [m for m in modes if m.get("width") == target_width and m.get("height") == target_height]
+        if not matching_modes:
+            continue
+
+        # Sort by refresh_rate ascending
+        matching_modes.sort(key=lambda m: m.get("refresh_rate", 0))
+
+        if is_plugged:
+            target_mode = matching_modes[-1]
+        else:
+            target_mode = matching_modes[0]
+
+        target_rate = target_mode.get("refresh_rate")
+        rate_hz = target_rate / 1000.0
+
+        if current_mode.get("refresh_rate") == target_rate:
+            results.append({"output": output_name, "status": "already_set", "rate": rate_hz})
+            continue
+
+        rate_str = f"{rate_hz:.3f}".rstrip("0").rstrip(".")
+        mode_str = f"{target_width}x{target_height}@{rate_str}"
+
+        out, apply_rc = run_niri("output", output_name, "mode", mode_str)
+        results.append({
+            "output": output_name,
+            "mode": mode_str,
+            "success": apply_rc == 0,
+            "output_msg": out
+        })
+
+    print(json.dumps({"results": results}))
+    return 0
+
+
 # ─── Main ─────────────────────────────────────────────────────────────
 
 
@@ -2610,7 +2955,7 @@ def main():
         print(
             json.dumps(
                 {
-                    "error": "No command. Use: outputs, apply-output, persist-output, get-input, get-layout, get-animations, get-window-rules, list-cursor-themes, validate, detect-customizations, set, get-binds, set-bind, remove-bind"
+                    "error": "No command. Use: outputs, apply-output, persist-output, get-input, get-layout, get-animations, get-window-rules, list-cursor-themes, validate, detect-customizations, set, set-blur-rules, sync-refresh-rate, get-binds, set-bind, remove-bind"
                 }
             )
         )
@@ -2631,6 +2976,8 @@ def main():
         "validate": lambda: cmd_validate(),
         "detect-customizations": lambda: cmd_detect_customizations(),
         "set": lambda: cmd_set(args),
+        "set-blur-rules": lambda: cmd_set_blur_rules(args),
+        "sync-refresh-rate": lambda: cmd_sync_refresh_rate(args),
         "get-binds": lambda: cmd_get_binds(),
         "set-bind": lambda: cmd_set_bind(args),
         "remove-bind": lambda: cmd_remove_bind(args),

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -2745,14 +2745,6 @@ def _upsert_window_blur_rules(
         block = (
             "window-rule {\n"
             f'    match app-id="{matcher}"\n'
-            "    match is-active=true\n"
-            f"    opacity {_format_float(active_opacity, 2)}\n"
-            f"{effect_block}\n"
-            "}\n\n"
-            "window-rule {\n"
-            f'    match app-id="{matcher}"\n'
-            "    match is-active=false\n"
-            f"    opacity {_format_float(inactive_opacity, 2)}\n"
             f"{effect_block}\n"
             "}"
         )

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -2745,6 +2745,14 @@ def _upsert_window_blur_rules(
         block = (
             "window-rule {\n"
             f'    match app-id="{matcher}"\n'
+            "    match is-active=true\n"
+            f"    opacity {_format_float(active_opacity, 2)}\n"
+            f"{effect_block}\n"
+            "}\n\n"
+            "window-rule {\n"
+            f'    match app-id="{matcher}"\n'
+            "    match is-active=false\n"
+            f"    opacity {_format_float(inactive_opacity, 2)}\n"
             f"{effect_block}\n"
             "}"
         )

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -2649,7 +2649,10 @@ BLUR_LAYER_RULES_END = "// ii-managed-blur-layer-rules:end"
 
 def _format_float(value, digits=2):
     text = f"{float(value):.{digits}f}"
-    return text.rstrip("0").rstrip(".") if "." in text else text
+    formatted = text.rstrip("0")
+    if formatted.endswith("."):
+        formatted += "0"
+    return formatted
 
 
 def _kdl_escape_string(value: str) -> str:

--- a/scripts/niri-config.py
+++ b/scripts/niri-config.py
@@ -3019,6 +3019,119 @@ def _upsert_layer_blur_rules(
     )
 
 
+def _parse_mode_str(mode_str):
+    width, height, rate = None, None, None
+    try:
+        if "@" in mode_str:
+            res_part, rate_part = mode_str.split("@", 1)
+            rate = float(rate_part)
+        else:
+            res_part = mode_str
+        
+        if "x" in res_part:
+            w_part, h_part = res_part.split("x", 1)
+            width = int(w_part)
+            height = int(h_part)
+    except Exception:
+        pass
+    return width, height, rate
+
+
+def get_configured_mode(output_name):
+    outputs_file = resolve_niri_section_file("config.d/15-outputs.kdl")
+    if not outputs_file.exists():
+        return None
+    try:
+        content = outputs_file.read_text()
+        pattern = rf'output\s+"{re.escape(output_name)}"\s*\{{(.*?)(\}})'
+        match = re.search(pattern, content, re.DOTALL)
+        if match:
+            block_content = match.group(1)
+            mode_match = re.search(r'mode\s+"([^"]+)"', block_content)
+            if mode_match:
+                return mode_match.group(1)
+    except Exception:
+        pass
+    return None
+
+
+def cmd_apply_configured_refresh_rates():
+    stdout, rc = run_niri("-j", "outputs")
+    if rc != 0:
+        print(json.dumps({"error": "Failed to query outputs"}))
+        return 1
+
+    try:
+        outputs_data = json.loads(stdout)
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to parse outputs JSON: {e}"}))
+        return 1
+
+    results = []
+    for output_name, output_info in outputs_data.items():
+        configured_mode = get_configured_mode(output_name)
+        if configured_mode:
+            modes = output_info.get("modes", [])
+            curr_idx = output_info.get("current_mode")
+            if curr_idx is not None and 0 <= curr_idx < len(modes):
+                current_mode = modes[curr_idx]
+                conf_width, conf_height, conf_rate = _parse_mode_str(configured_mode)
+                
+                curr_width = current_mode.get("width")
+                curr_height = current_mode.get("height")
+                curr_rate = current_mode.get("refresh_rate") / 1000.0
+                
+                width_match = (conf_width is None or conf_width == curr_width)
+                height_match = (conf_height is None or conf_height == curr_height)
+                rate_match = True
+                if conf_rate is not None:
+                    rate_match = abs(conf_rate - curr_rate) < 0.1
+                
+                if width_match and height_match and rate_match:
+                    results.append({"output": output_name, "status": "already_set", "mode": configured_mode})
+                    continue
+            
+            out, apply_rc = run_niri("output", output_name, "mode", configured_mode)
+            results.append({
+                "output": output_name,
+                "mode": configured_mode,
+                "success": apply_rc == 0,
+                "output_msg": out
+            })
+        else:
+            modes = output_info.get("modes", [])
+            curr_idx = output_info.get("current_mode")
+            if curr_idx is not None and 0 <= curr_idx < len(modes):
+                current_mode = modes[curr_idx]
+                target_width = current_mode.get("width")
+                target_height = current_mode.get("height")
+
+                matching_modes = [m for m in modes if m.get("width") == target_width and m.get("height") == target_height]
+                if matching_modes:
+                    matching_modes.sort(key=lambda m: m.get("refresh_rate", 0))
+                    target_mode = matching_modes[-1]
+                    target_rate = target_mode.get("refresh_rate")
+                    rate_hz = target_rate / 1000.0
+
+                    if current_mode.get("refresh_rate") == target_rate:
+                        results.append({"output": output_name, "status": "already_set", "rate": rate_hz})
+                        continue
+
+                    rate_str = f"{rate_hz:.3f}".rstrip("0").rstrip(".")
+                    mode_str = f"{target_width}x{target_height}@{rate_str}"
+
+                    out, apply_rc = run_niri("output", output_name, "mode", mode_str)
+                    results.append({
+                        "output": output_name,
+                        "mode": mode_str,
+                        "success": apply_rc == 0,
+                        "output_msg": out
+                    })
+
+    print(json.dumps({"results": results}))
+    return 0
+
+
 def cmd_set_blur_rules(args):
     if len(args) < 1:
         print(json.dumps({"error": "Usage: set-blur-rules <json_payload>"}))
@@ -3101,7 +3214,7 @@ def cmd_set_blur_rules(args):
     if settings["refresh_rate_efficiency"]:
         cmd_sync_refresh_rate([str(is_plugged)])
     else:
-        cmd_sync_refresh_rate(["true"])
+        cmd_apply_configured_refresh_rates()
 
     print(json.dumps({"success": True}))
     return 0
@@ -3180,7 +3293,7 @@ def cmd_set_blur_param(key, value):
         if settings["refresh_rate_efficiency"]:
             cmd_sync_refresh_rate([str(is_plugged)])
         else:
-            cmd_sync_refresh_rate(["true"])
+            cmd_apply_configured_refresh_rates()
 
     print(json.dumps({"success": True}))
     return 0
@@ -3198,7 +3311,7 @@ def cmd_sync_power_state(args):
     if settings["refresh_rate_efficiency"]:
         cmd_sync_refresh_rate([str(is_plugged)])
     else:
-        cmd_sync_refresh_rate(["true"])
+        cmd_apply_configured_refresh_rates()
 
     rules_file = resolve_niri_section_file("config.d/30-window-rules.kdl")
     layer_file = resolve_niri_section_file("config.d/80-layer-rules.kdl")
@@ -3320,6 +3433,7 @@ def main():
         "set-blur-rules": lambda: cmd_set_blur_rules(args),
         "sync-refresh-rate": lambda: cmd_sync_refresh_rate(args),
         "sync-power-state": lambda: cmd_sync_power_state(args),
+        "apply-configured-refresh-rates": lambda: cmd_apply_configured_refresh_rates(),
         "get-binds": lambda: cmd_get_binds(),
         "set-bind": lambda: cmd_set_bind(args),
         "remove-bind": lambda: cmd_remove_bind(args),

--- a/services/Battery.qml
+++ b/services/Battery.qml
@@ -16,8 +16,8 @@ Singleton {
         if (Quickshell.env("QS_DEBUG") === "1") console.log(...args);
     }
 
-    property bool available: UPower.displayDevice.isLaptopBattery
-    property var chargeState: UPower.displayDevice.state
+    property bool available: UPower.displayDevice?.isLaptopBattery ?? false
+    property var chargeState: UPower.displayDevice?.state ?? null
     property bool isCharging: chargeState == UPowerDeviceState.Charging
     property bool isPluggedIn: isCharging || chargeState == UPowerDeviceState.PendingCharge
     property real percentage: UPower.displayDevice?.percentage ?? 1
@@ -34,9 +34,9 @@ Singleton {
     property bool isSuspendingAndNotCharging: allowAutomaticSuspend && isSuspending && !isCharging
     property bool isFullAndCharging: isFull && isCharging
 
-    property real energyRate: UPower.displayDevice.changeRate
-    property real timeToEmpty: UPower.displayDevice.timeToEmpty
-    property real timeToFull: UPower.displayDevice.timeToFull
+    property real energyRate: UPower.displayDevice?.changeRate ?? 0
+    property real timeToEmpty: UPower.displayDevice?.timeToEmpty ?? 0
+    property real timeToFull: UPower.displayDevice?.timeToFull ?? 0
 
     // ─── Charge limit ───
     readonly property bool chargeLimitEnabled: Config.options?.battery?.chargeLimit?.enable ?? false

--- a/services/BlurService.qml
+++ b/services/BlurService.qml
@@ -5,190 +5,24 @@ import Quickshell
 import Quickshell.Io
 import qs.services
 import qs.modules.common
-import qs.modules.common.functions
 
 Singleton {
     id: root
 
-    property string filePath: FileUtils.trimFileProtocol(Directories.home + "/.config/bluri/settings.json")
-    property alias options: blurOptionsJsonAdapter
-    property bool ready: false
-    property bool lastRefreshRateEfficiencyState: false
+    property bool ready: true
 
-    property var _cmdQueue: []
-    property bool _running: false
-
-    function _runNext() {
-        if (root._running || root._cmdQueue.length === 0) return;
-        root._running = true;
-        const cmd = root._cmdQueue.shift();
-        syncProcess.command = cmd;
-        syncProcess.running = true;
-    }
-
-    Process {
-        id: syncProcess
-        stdout: StdioCollector { id: syncOut }
-        stderr: StdioCollector { id: syncErr }
-        onExited: (exitCode) => {
-            if (exitCode !== 0) {
-                console.warn("[BlurService] syncProcess failed:", syncErr.text || syncOut.text);
-            }
-            root._running = false;
-            root._runNext();
-        }
-    }
-
-    function runCommand(args) {
-        const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
-        const fullCmd = ["python3", scriptPath].concat(args);
-
-        // Filter out any pending commands of the same type in the queue
-        if (args[0] === "set-blur-rules") {
-            root._cmdQueue = root._cmdQueue.filter(cmd => cmd[2] !== "set-blur-rules");
-        } else if (args[0] === "sync-refresh-rate") {
-            root._cmdQueue = root._cmdQueue.filter(cmd => cmd[2] !== "sync-refresh-rate");
-        }
-
-        root._cmdQueue.push(fullCmd);
-        root._runNext();
-    }
-
-    function queueSync() {
-        syncDebounceTimer.restart();
-    }
-
-    function triggerSync() {
-        if (!root.ready) return;
-
-        const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
-        const isPlugged = !Battery.available || Battery.isPluggedIn;
-
-        const effectiveBlurEnabled = root.options.mode === "on"
-            ? root.options.blur_enabled
-            : root.options.mode === "auto"
-                ? (isPlugged && root.options.blur_enabled)
-                : false;
-
-        const payload = {
-            mode: root.options.mode,
-            blur_enabled: effectiveBlurEnabled,
-            active_opacity: root.options.active_opacity,
-            inactive_opacity: root.options.inactive_opacity,
-            xray: root.options.xray,
-            refresh_rate_efficiency: root.options.refresh_rate_efficiency,
-            passes: root.options.passes,
-            offset: root.options.offset,
-            noise: root.options.noise,
-            saturation: root.options.saturation,
-            window_rules_enabled: root.options.window_rules_enabled,
-            window_matcher: root.options.window_matcher,
-            layer_rules_enabled: root.options.layer_rules_enabled,
-            layer_namespace: root.options.layer_namespace,
-            layer_opacity: root.options.layer_opacity
-        };
-
-        console.log("[BlurService] Syncing blur payload to Niri config:", JSON.stringify(payload));
-        root.runCommand(["set-blur-rules", JSON.stringify(payload)]);
-
-        // Sync refresh rate if efficiency mode is active, or if it was just turned off!
-        const efficiencyActive = root.options.refresh_rate_efficiency;
-        if (efficiencyActive || root.lastRefreshRateEfficiencyState !== efficiencyActive) {
-            const targetPlugged = efficiencyActive ? isPlugged : true;
-            console.log("[BlurService] Syncing refresh rate: targetPlugged=" + targetPlugged);
-            root.runCommand(["sync-refresh-rate", String(targetPlugged)]);
-            root.lastRefreshRateEfficiencyState = efficiencyActive;
-        }
-    }
-
-    FileView {
-        id: blurFileView
-        path: root.filePath
-        watchChanges: true
-        onFileChanged: fileReloadTimer.restart()
-        onAdapterUpdated: {
-            fileWriteTimer.restart()
-        }
-        onLoaded: {
-            root.ready = true
-            root.queueSync()
-        }
-        onLoadFailed: error => {
-            if (error == FileViewError.FileNotFound) {
-                console.log("[BlurService] File not found, creating new file.")
-                const parentDir = root.filePath.substring(0, root.filePath.lastIndexOf('/'))
-                Process.exec(["/usr/bin/mkdir", "-p", parentDir])
-                blurFileView.writeAdapter()
-            }
-            root.ready = true
-            root.queueSync()
-        }
-
-        JsonAdapter {
-            id: blurOptionsJsonAdapter
-            property string mode: "auto"
-            property real active_opacity: 0.95
-            property real inactive_opacity: 0.70
-            property bool blur_enabled: true
-            property bool xray: true
-            property int passes: 3
-            property real offset: 3.0
-            property real noise: 0.02
-            property real saturation: 1.5
-            property bool window_rules_enabled: true
-            property string window_matcher: "^(Alacritty|Foot|foot|kitty|org\\.wezfurlong\\.wezterm|com\\.mitchellh\\.ghostty)$"
-            property bool layer_rules_enabled: true
-            property string layer_namespace: "^(launcher|waybar|walker|fuzzel|wofi)$"
-            property real layer_opacity: 0.85
-            property bool refresh_rate_efficiency: false
-
-            onModeChanged: root.queueSync()
-            onActive_opacityChanged: root.queueSync()
-            onInactive_opacityChanged: root.queueSync()
-            onBlur_enabledChanged: root.queueSync()
-            onXrayChanged: root.queueSync()
-            onPassesChanged: root.queueSync()
-            onOffsetChanged: root.queueSync()
-            onNoiseChanged: root.queueSync()
-            onSaturationChanged: root.queueSync()
-            onWindow_rules_enabledChanged: root.queueSync()
-            onWindow_matcherChanged: root.queueSync()
-            onLayer_rules_enabledChanged: root.queueSync()
-            onLayer_namespaceChanged: root.queueSync()
-            onLayer_opacityChanged: root.queueSync()
-            onRefresh_rate_efficiencyChanged: root.queueSync()
-        }
-    }
-
-    Timer {
-        id: fileReloadTimer
-        interval: 50
-        repeat: false
-        onTriggered: blurFileView.reload()
-    }
-
-    Timer {
-        id: fileWriteTimer
-        interval: 50
-        repeat: false
-        onTriggered: blurFileView.writeAdapter()
-    }
-
-    Timer {
-        id: syncDebounceTimer
-        interval: 200
-        repeat: false
-        onTriggered: root.triggerSync()
-    }
-
-    // Monitor Battery.isPluggedIn so that if mode is "auto" or refresh_rate_efficiency is enabled, we trigger sync
-    // immediately when power status changes (plugged in / unplugged)!
     Connections {
         target: Battery
         function onIsPluggedInChanged() {
-            if (root.options.mode === "auto" || root.options.refresh_rate_efficiency) {
-                root.queueSync();
-            }
+            const isPlugged = !Battery.available || Battery.isPluggedIn;
+            const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
+            Process.exec(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
         }
+    }
+
+    Component.onCompleted: {
+        const isPlugged = !Battery.available || Battery.isPluggedIn;
+        const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
+        Process.exec(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
     }
 }

--- a/services/BlurService.qml
+++ b/services/BlurService.qml
@@ -1,0 +1,183 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+import qs.modules.common
+import qs.modules.common.functions
+
+Singleton {
+    id: root
+
+    property string filePath: FileUtils.trimFileProtocol(Directories.home + "/.config/bluri/settings.json")
+    property alias options: blurOptionsJsonAdapter
+    property bool ready: false
+    property bool lastRefreshRateEfficiencyState: false
+
+    property var _cmdQueue: []
+    property bool _running: false
+
+    function _runNext() {
+        if (root._running || root._cmdQueue.length === 0) return;
+        root._running = true;
+        const cmd = root._cmdQueue.shift();
+        syncProcess.command = cmd;
+        syncProcess.running = true;
+    }
+
+    Process {
+        id: syncProcess
+        stdout: StdioCollector { id: syncOut }
+        stderr: StdioCollector { id: syncErr }
+        onExited: (exitCode) => {
+            if (exitCode !== 0) {
+                console.warn("[BlurService] syncProcess failed:", syncErr.text || syncOut.text);
+            }
+            root._running = false;
+            root._runNext();
+        }
+    }
+
+    function runCommand(args) {
+        const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
+        const fullCmd = ["python3", scriptPath].concat(args);
+
+        // Filter out any pending commands of the same type in the queue
+        if (args[0] === "set-blur-rules") {
+            root._cmdQueue = root._cmdQueue.filter(cmd => cmd[2] !== "set-blur-rules");
+        } else if (args[0] === "sync-refresh-rate") {
+            root._cmdQueue = root._cmdQueue.filter(cmd => cmd[2] !== "sync-refresh-rate");
+        }
+
+        root._cmdQueue.push(fullCmd);
+        root._runNext();
+    }
+
+    function triggerSync() {
+        if (!root.ready) return;
+
+        const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
+        const isPlugged = !Battery.available || Battery.isPluggedIn;
+
+        const effectiveBlurEnabled = root.options.mode === "on"
+            ? root.options.blur_enabled
+            : root.options.mode === "auto"
+                ? (isPlugged && root.options.blur_enabled)
+                : false;
+
+        const payload = {
+            mode: root.options.mode,
+            blur_enabled: effectiveBlurEnabled,
+            active_opacity: root.options.active_opacity,
+            inactive_opacity: root.options.inactive_opacity,
+            xray: root.options.xray,
+            refresh_rate_efficiency: root.options.refresh_rate_efficiency,
+            passes: root.options.passes,
+            offset: root.options.offset,
+            noise: root.options.noise,
+            saturation: root.options.saturation,
+            window_rules_enabled: root.options.window_rules_enabled,
+            window_matcher: root.options.window_matcher,
+            layer_rules_enabled: root.options.layer_rules_enabled,
+            layer_namespace: root.options.layer_namespace,
+            layer_opacity: root.options.layer_opacity
+        };
+
+        console.log("[BlurService] Syncing blur payload to Niri config:", JSON.stringify(payload));
+        root.runCommand(["set-blur-rules", JSON.stringify(payload)]);
+
+        // Sync refresh rate if efficiency mode is active, or if it was just turned off!
+        const efficiencyActive = root.options.refresh_rate_efficiency;
+        if (efficiencyActive || root.lastRefreshRateEfficiencyState !== efficiencyActive) {
+            const targetPlugged = efficiencyActive ? isPlugged : true;
+            console.log("[BlurService] Syncing refresh rate: targetPlugged=" + targetPlugged);
+            root.runCommand(["sync-refresh-rate", String(targetPlugged)]);
+            root.lastRefreshRateEfficiencyState = efficiencyActive;
+        }
+    }
+
+    FileView {
+        id: blurFileView
+        path: root.filePath
+        watchChanges: true
+        onFileChanged: fileReloadTimer.restart()
+        onAdapterUpdated: {
+            fileWriteTimer.restart()
+        }
+        onLoaded: {
+            root.ready = true
+            Qt.callLater(root.triggerSync)
+        }
+        onLoadFailed: error => {
+            if (error == FileViewError.FileNotFound) {
+                console.log("[BlurService] File not found, creating new file.")
+                const parentDir = root.filePath.substring(0, root.filePath.lastIndexOf('/'))
+                Process.exec(["/usr/bin/mkdir", "-p", parentDir])
+                blurFileView.writeAdapter()
+            }
+            root.ready = true
+            Qt.callLater(root.triggerSync)
+        }
+
+        JsonAdapter {
+            id: blurOptionsJsonAdapter
+            property string mode: "auto"
+            property real active_opacity: 0.95
+            property real inactive_opacity: 0.70
+            property bool blur_enabled: true
+            property bool xray: true
+            property int passes: 3
+            property real offset: 3.0
+            property real noise: 0.02
+            property real saturation: 1.5
+            property bool window_rules_enabled: true
+            property string window_matcher: "^(Alacritty|Foot|foot|kitty|org\\.wezfurlong\\.wezterm|com\\.mitchellh\\.ghostty)$"
+            property bool layer_rules_enabled: true
+            property string layer_namespace: "^(launcher|waybar|walker|fuzzel|wofi)$"
+            property real layer_opacity: 0.85
+            property bool refresh_rate_efficiency: false
+
+            onModeChanged: Qt.callLater(root.triggerSync)
+            onActive_opacityChanged: Qt.callLater(root.triggerSync)
+            onInactive_opacityChanged: Qt.callLater(root.triggerSync)
+            onBlur_enabledChanged: Qt.callLater(root.triggerSync)
+            onXrayChanged: Qt.callLater(root.triggerSync)
+            onPassesChanged: Qt.callLater(root.triggerSync)
+            onOffsetChanged: Qt.callLater(root.triggerSync)
+            onNoiseChanged: Qt.callLater(root.triggerSync)
+            onSaturationChanged: Qt.callLater(root.triggerSync)
+            onWindow_rules_enabledChanged: Qt.callLater(root.triggerSync)
+            onWindow_matcherChanged: Qt.callLater(root.triggerSync)
+            onLayer_rules_enabledChanged: Qt.callLater(root.triggerSync)
+            onLayer_namespaceChanged: Qt.callLater(root.triggerSync)
+            onLayer_opacityChanged: Qt.callLater(root.triggerSync)
+            onRefresh_rate_efficiencyChanged: Qt.callLater(root.triggerSync)
+        }
+    }
+
+    Timer {
+        id: fileReloadTimer
+        interval: 50
+        repeat: false
+        onTriggered: blurFileView.reload()
+    }
+
+    Timer {
+        id: fileWriteTimer
+        interval: 50
+        repeat: false
+        onTriggered: blurFileView.writeAdapter()
+    }
+
+    // Monitor Battery.isPluggedIn so that if mode is "auto" or refresh_rate_efficiency is enabled, we trigger sync
+    // immediately when power status changes (plugged in / unplugged)!
+    Connections {
+        target: Battery
+        function onIsPluggedInChanged() {
+            if (root.options.mode === "auto" || root.options.refresh_rate_efficiency) {
+                Qt.callLater(root.triggerSync);
+            }
+        }
+    }
+}

--- a/services/BlurService.qml
+++ b/services/BlurService.qml
@@ -16,13 +16,13 @@ Singleton {
         function onIsPluggedInChanged() {
             const isPlugged = !Battery.available || Battery.isPluggedIn;
             const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
-            Process.exec(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
+            Quickshell.execDetached(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
         }
     }
 
     Component.onCompleted: {
         const isPlugged = !Battery.available || Battery.isPluggedIn;
         const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
-        Process.exec(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
+        Quickshell.execDetached(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
     }
 }

--- a/services/BlurService.qml
+++ b/services/BlurService.qml
@@ -54,6 +54,10 @@ Singleton {
         root._runNext();
     }
 
+    function queueSync() {
+        syncDebounceTimer.restart();
+    }
+
     function triggerSync() {
         if (!root.ready) return;
 
@@ -107,7 +111,7 @@ Singleton {
         }
         onLoaded: {
             root.ready = true
-            Qt.callLater(root.triggerSync)
+            root.queueSync()
         }
         onLoadFailed: error => {
             if (error == FileViewError.FileNotFound) {
@@ -117,7 +121,7 @@ Singleton {
                 blurFileView.writeAdapter()
             }
             root.ready = true
-            Qt.callLater(root.triggerSync)
+            root.queueSync()
         }
 
         JsonAdapter {
@@ -138,21 +142,21 @@ Singleton {
             property real layer_opacity: 0.85
             property bool refresh_rate_efficiency: false
 
-            onModeChanged: Qt.callLater(root.triggerSync)
-            onActive_opacityChanged: Qt.callLater(root.triggerSync)
-            onInactive_opacityChanged: Qt.callLater(root.triggerSync)
-            onBlur_enabledChanged: Qt.callLater(root.triggerSync)
-            onXrayChanged: Qt.callLater(root.triggerSync)
-            onPassesChanged: Qt.callLater(root.triggerSync)
-            onOffsetChanged: Qt.callLater(root.triggerSync)
-            onNoiseChanged: Qt.callLater(root.triggerSync)
-            onSaturationChanged: Qt.callLater(root.triggerSync)
-            onWindow_rules_enabledChanged: Qt.callLater(root.triggerSync)
-            onWindow_matcherChanged: Qt.callLater(root.triggerSync)
-            onLayer_rules_enabledChanged: Qt.callLater(root.triggerSync)
-            onLayer_namespaceChanged: Qt.callLater(root.triggerSync)
-            onLayer_opacityChanged: Qt.callLater(root.triggerSync)
-            onRefresh_rate_efficiencyChanged: Qt.callLater(root.triggerSync)
+            onModeChanged: root.queueSync()
+            onActive_opacityChanged: root.queueSync()
+            onInactive_opacityChanged: root.queueSync()
+            onBlur_enabledChanged: root.queueSync()
+            onXrayChanged: root.queueSync()
+            onPassesChanged: root.queueSync()
+            onOffsetChanged: root.queueSync()
+            onNoiseChanged: root.queueSync()
+            onSaturationChanged: root.queueSync()
+            onWindow_rules_enabledChanged: root.queueSync()
+            onWindow_matcherChanged: root.queueSync()
+            onLayer_rules_enabledChanged: root.queueSync()
+            onLayer_namespaceChanged: root.queueSync()
+            onLayer_opacityChanged: root.queueSync()
+            onRefresh_rate_efficiencyChanged: root.queueSync()
         }
     }
 
@@ -170,13 +174,20 @@ Singleton {
         onTriggered: blurFileView.writeAdapter()
     }
 
+    Timer {
+        id: syncDebounceTimer
+        interval: 200
+        repeat: false
+        onTriggered: root.triggerSync()
+    }
+
     // Monitor Battery.isPluggedIn so that if mode is "auto" or refresh_rate_efficiency is enabled, we trigger sync
     // immediately when power status changes (plugged in / unplugged)!
     Connections {
         target: Battery
         function onIsPluggedInChanged() {
             if (root.options.mode === "auto" || root.options.refresh_rate_efficiency) {
-                Qt.callLater(root.triggerSync);
+                root.queueSync();
             }
         }
     }

--- a/services/BlurService.qml
+++ b/services/BlurService.qml
@@ -11,17 +11,14 @@ Singleton {
 
     property bool ready: true
 
-    Connections {
-        target: Battery
-        function onIsPluggedInChanged() {
-            const isPlugged = !Battery.available || Battery.isPluggedIn;
-            const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
-            Quickshell.execDetached(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
-        }
+    readonly property bool isPlugged: !Battery.available || Battery.isPluggedIn
+
+    onIsPluggedChanged: {
+        const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
+        Quickshell.execDetached(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
     }
 
     Component.onCompleted: {
-        const isPlugged = !Battery.available || Battery.isPluggedIn;
         const scriptPath = Quickshell.shellPath("scripts/niri-config.py");
         Quickshell.execDetached(["python3", scriptPath, "sync-power-state", String(isPlugged)]);
     }

--- a/services/qmldir
+++ b/services/qmldir
@@ -7,6 +7,7 @@ singleton AppSearch 1.0 AppSearch.qml
 singleton Audio 1.0 Audio.qml
 singleton Autostart 1.0 Autostart.qml
 singleton Battery 1.0 Battery.qml
+singleton BlurService 1.0 BlurService.qml
 singleton BluetoothStatus 1.0 BluetoothStatus.qml
 singleton Booru 1.0 Booru.qml
 BooruResponseData 1.0 BooruResponseData.qml

--- a/shell.qml
+++ b/shell.qml
@@ -35,6 +35,7 @@ ShellRoot {
     // Force singleton instantiation — startup-critical only
     property var _idleService: Idle
     property var _powerProfilePersistence: PowerProfilePersistence
+    property var _blurService: BlurService
 
     // Deferred singletons — initialized after first frame to reduce boot contention
     // Tier 3: T+500ms (display/interaction services)


### PR DESCRIPTION
This pull request integrates desktop window blur, targeted safe layer-surface blur, and battery-aware refresh rate scaling directly into the iNiR shell settings and Niri configurations.

### Key Changes

1. ** Window Blur**: Window blur toggle, active/inactive opacities, and blur settings are dynamically written directly into Niri KDL configuration files, removing dependencies on arbitrary configuration files (like `settings.json`) and keeping settings unified.

2. **Auto refresh Rate toggle**: Adds an efficiency setting that dynamically toggles compositor blur effects and syncs display refresh rates (e.g., scaling screen rate to battery state) when plugged in versus on battery.

## Testing

* [x] `inir restart && inir logs` — no errors
* [x] Tested the specific feature path that changed
* [x] Both panel families checked (if shared code changed)

## Notes

Closes #
