### PR TITLE
feat(bluetooth): persist adapter state across sessions

### DIFF
--- a/defaults/config.json
+++ b/defaults/config.json
@@ -286,6 +286,10 @@
             "maxAllowedIncrease": 10
         }
     },
+    "bluetooth": {
+        "persistState": true,
+        "lastState": false
+    },
     "compositor": {
         "autoExpandSingleTilingWindow": false
     },

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -288,7 +288,8 @@
     },
     "bluetooth": {
         "persistState": true,
-        "lastState": false
+        "lastState": false,
+        "lastBootId": ""
     },
     "compositor": {
         "autoExpandSingleTilingWindow": false

--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -772,6 +772,7 @@ Singleton {
             property JsonObject bluetooth: JsonObject {
                 property bool persistState: true
                 property bool lastState: false
+                property string lastBootId: ""
             }
 
             property JsonObject compositor: JsonObject {

--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -769,6 +769,11 @@ Singleton {
                 }
             }
 
+            property JsonObject bluetooth: JsonObject {
+                property bool persistState: true
+                property bool lastState: false
+            }
+
             property JsonObject compositor: JsonObject {
                 property bool autoExpandSingleTilingWindow: false
             }

--- a/services/BluetoothStatus.qml
+++ b/services/BluetoothStatus.qml
@@ -5,12 +5,48 @@ import Quickshell
 import Quickshell.Bluetooth
 import Quickshell.Io
 import QtQuick
+import qs.modules.common
 
 /**
  * Bluetooth status service.
  */
 Singleton {
     id: root
+
+    property bool _restored: false
+
+    function _restoreBluetoothState() {
+        if (Bluetooth.defaultAdapter && !root._restored) {
+            root._restored = true;
+            const persist = Config.options?.bluetooth?.persistState ?? true;
+            const savedState = Config.options?.bluetooth?.lastState;
+            if (persist && savedState !== undefined && savedState !== Bluetooth.defaultAdapter.enabled) {
+                Bluetooth.defaultAdapter.enabled = savedState;
+            }
+        }
+    }
+
+    Component.onCompleted: _restoreBluetoothState()
+
+    Connections {
+        target: Bluetooth
+        function onDefaultAdapterChanged() {
+            root._restoreBluetoothState();
+        }
+    }
+
+    Connections {
+        target: Bluetooth.defaultAdapter ?? null
+        ignoreUnknownSignals: true
+        function onEnabledChanged() {
+            if (Bluetooth.defaultAdapter && root._restored) {
+                const persist = Config.options?.bluetooth?.persistState ?? true;
+                if (persist) {
+                    Config.setNestedValue("bluetooth.lastState", Bluetooth.defaultAdapter.enabled);
+                }
+            }
+        }
+    }
 
     readonly property bool available: Bluetooth.adapters.values.length > 0
     readonly property bool enabled: Bluetooth.defaultAdapter?.enabled ?? false

--- a/services/BluetoothStatus.qml
+++ b/services/BluetoothStatus.qml
@@ -14,19 +14,51 @@ Singleton {
     id: root
 
     property bool _restored: false
+    property string _bootId: ""
 
+    // Only force-apply the saved on/off state once per actual system boot.
+    // Without this, every `inir restart` (or any shell reload) would recreate
+    // this singleton and re-force the last saved state onto the adapter,
+    // overriding whatever the user (or another process) had set in between.
     function _restoreBluetoothState() {
-        if (Bluetooth.defaultAdapter && !root._restored) {
-            root._restored = true;
-            const persist = Config.options?.bluetooth?.persistState ?? true;
-            const savedState = Config.options?.bluetooth?.lastState;
-            if (persist && savedState !== undefined && savedState !== Bluetooth.defaultAdapter.enabled) {
-                Bluetooth.defaultAdapter.enabled = savedState;
-            }
+        if (!Bluetooth.defaultAdapter || root._restored || root._bootId === "") {
+            return;
         }
+        root._restored = true;
+
+        const persist = Config.options?.bluetooth?.persistState ?? true;
+        if (!persist) return;
+
+        const savedBootId = Config.options?.bluetooth?.lastBootId ?? "";
+        if (savedBootId === root._bootId) {
+            return;
+        }
+
+        const savedState = Config.options?.bluetooth?.lastState;
+        if (savedState !== undefined && savedState !== Bluetooth.defaultAdapter.enabled) {
+            Bluetooth.defaultAdapter.enabled = savedState;
+        }
+        Config.setNestedValue("bluetooth.lastBootId", root._bootId);
     }
 
     Component.onCompleted: _restoreBluetoothState()
+
+    FileView {
+        id: bootIdReader
+        path: "/proc/sys/kernel/random/boot_id"
+
+        onLoaded: {
+            root._bootId = bootIdReader.text().trim();
+            root._restoreBluetoothState();
+        }
+
+        onLoadFailed: (error) => {
+            // No reliable boot id available; fall back to old per-launch
+            // behavior rather than never restoring at all.
+            root._bootId = "unknown";
+            root._restoreBluetoothState();
+        }
+    }
 
     Connections {
         target: Bluetooth


### PR DESCRIPTION
## Summary

This PR adds support for persisting the Bluetooth adapter state (on/off) across system restarts, shutdowns, logouts, and shell reloads.
It introduces configuration keys:
- `bluetooth.persistState`: determines if the state should be saved/restored (defaults to `true`).
- `bluetooth.lastState`: stores the last state of the default Bluetooth adapter.
- `bluetooth.lastBootId`: tracks the system boot (`/proc/sys/kernel/random/boot_id`) the state was last restored on.

It dynamically monitors the default adapter status and updates the configuration in real-time, restoring the last saved state when the Bluetooth service starts up.

## Fix: only restore once per boot

Initial version re-forced `lastState` onto the adapter on every shell reload (`inir restart`), not just on an actual reboot — so if you'd manually toggled Bluetooth after a shell reload happened to be in flight, or just ran `inir restart` for unrelated reasons, it could get flipped back to whatever was last saved. That's what looked like Bluetooth "turning on by itself."

Fix compares the current boot id against the one stored at last restore:
- Same boot id (regular `inir restart`) → state is left alone.
- Different boot id (real reboot) → saved state is restored, then the new boot id is recorded.

## Testing

- [x] `inir restart && inir logs` — no errors
- [x] Toggled Bluetooth, verified config update, and confirmed state persistence on reload
- [x] Same-boot `inir restart` after manually toggling Bluetooth off — adapter stayed off, state not re-forced
- [x] Simulated a different boot id with a stale saved `lastState: true` — adapter was correctly force-restored to on, `lastBootId` updated to the real boot id
