### PR TITLE
fix(fish): fix greedy argument parsing in eza alias

### DIFF
--- a/dots/.config/fish/config.fish
+++ b/dots/.config/fish/config.fish
@@ -17,7 +17,7 @@ if status is-interactive
     alias celar "printf '\033[2J\033[3J\033[1;1H'"
     alias claer "printf '\033[2J\033[3J\033[1;1H'"
     if command -v eza &>/dev/null
-        alias ls 'eza --icons'
+        alias ls 'eza --icons=auto'
     end
     alias q 'qs -c ii'
 end


### PR DESCRIPTION
## Summary

Because --icon accepts an additional value, the clap parser greedily consumes the trailing dir as an argument for the icon flag but fails as only 'always', 'auto', and 'never' are allowed.  

While --icons defaults to =auto, it's the fault of the rust parser clap

## Example

ls ~/
error: invalid value '/home/apologizes/' for '--icons [<WHEN>]'
  [possible values: always, auto, never]

For more information, try '--help'.