### PR TITLE
Fix six correctness bugs (thumbnail hash, qalc loop, workspace switch, dead notify calls, mic binding)

### DIFF
--- a/modules/bar/Workspaces.qml
+++ b/modules/bar/Workspaces.qml
@@ -44,6 +44,17 @@ Item {
         const ws = workspaceForSlot(slotNumber)
         return ws?.idx ?? slotNumber
     }
+    // This bar renders its own output's workspaces, but a niri Index reference
+    // resolves against the *focused* output and idx repeats across outputs — so
+    // clicking slot 1 here switched the other monitor whenever focus was
+    // elsewhere. Ids are globally unique; fall back to idx only when unavailable.
+    function switchToSlot(slotNumber) {
+        const ws = root.workspaceForSlot(slotNumber)
+        if (ws?.id !== undefined)
+            NiriService.switchToWorkspaceId(ws.id)
+        else
+            NiriService.switchToWorkspace(root.workspaceIndexForSlot(slotNumber))
+    }
 
     // Scroll behavior: "workspace" = switch workspaces, "column" = cycle windows left/right in same workspace
     readonly property string scrollBehavior: wsConfig.scrollBehavior ?? "workspace"
@@ -245,20 +256,25 @@ Item {
                     const wsCount = root.workspacesShown
                     const currentWs = root.currentWorkspaceNumber
                     
+                    // focusWorkspaceUp/Down act on the focused output, so scrolling
+                    // this bar moved the *other* monitor's workspaces whenever focus
+                    // was elsewhere. Step within our own slots and dispatch by id.
+                    const step = direction > 0 ? 1 : -1
+
                     if (root.wrapAround) {
                         if (direction > 0 && currentWs >= wsCount) {
                             // At last, go to first
-                            NiriService.switchToWorkspace(root.workspaceIndexForSlot(1))
+                            root.switchToSlot(1)
                         } else if (direction < 0 && currentWs <= 1) {
                             // At first, go to last
-                            NiriService.switchToWorkspace(root.workspaceIndexForSlot(wsCount))
+                            root.switchToSlot(wsCount)
                         } else {
-                            if (direction > 0) NiriService.focusWorkspaceDown()
-                            else NiriService.focusWorkspaceUp()
+                            root.switchToSlot(currentWs + step)
                         }
                     } else {
-                        if (direction > 0) NiriService.focusWorkspaceDown()
-                        else NiriService.focusWorkspaceUp()
+                        const target = currentWs + step
+                        if (target >= 1 && target <= wsCount)
+                            root.switchToSlot(target)
                     }
                 }
             } else if (CompositorService.isHyprland) {
@@ -370,7 +386,7 @@ Item {
                 implicitWidth: vertical ? Appearance.sizes.verticalBarWidth : Appearance.sizes.verticalBarWidth
                 onPressed: {
                     if (CompositorService.isNiri) {
-                        NiriService.switchToWorkspace(root.workspaceIndexForSlot(workspaceValue))
+                        root.switchToSlot(workspaceValue)
                     } else if (CompositorService.isHyprland) {
                         Hyprland.dispatch(`workspace ${workspaceValue}`)
                     }

--- a/modules/ii/overlay/notes/NotesContent.qml
+++ b/modules/ii/overlay/notes/NotesContent.qml
@@ -280,7 +280,7 @@ OverlayBackground {
                 console.log("[Overlay Notes] File not found, creating new file.")
                 // Ensure parent directory exists
                 const parentDir = Directories.notesPath.substring(0, Directories.notesPath.lastIndexOf('/'))
-                Process.exec(["/usr/bin/mkdir", "-p", parentDir])
+                Quickshell.execDetached(["/usr/bin/mkdir", "-p", parentDir])
                 root.content = "";
                 noteFile.setText(root.content);
                 if (pendingReload) {

--- a/modules/overview/SearchWidget.qml
+++ b/modules/overview/SearchWidget.qml
@@ -188,7 +188,6 @@ Item { // Wrapper
         }
 
         // Default search
-        nonAppResultsTimer.restart();
 
         // Use stable keys for non-app results to prevent unnecessary re-renders
         const mathResultObject = {
@@ -305,12 +304,28 @@ Item { // Wrapper
         root.cachedResults = result;
     }
 
+    // The default (non-prefixed) result set is the only one that shows a math row,
+    // so it is the only one worth spawning qalc for.
+    function wantsMathResult(text): bool {
+        return text !== ""
+            && !text.startsWith(root.prefixAction)
+            && !text.startsWith(root.prefixClipboard)
+            && !text.startsWith(root.prefixEmojis);
+    }
+
     Timer {
         id: searchDebounceTimer
         interval: 60
         onTriggered: {
             root.debouncedSearchText = root.searchingText;
             root.updateSearchResults();
+            // Scheduled here rather than from updateSearchResults(): qalc's stdout
+            // handler calls updateSearchResults(), so restarting the timer in there
+            // made every qalc result spawn another qalc. qalc -t prints something
+            // for any input ("firefox" -> "0 B"), so the cycle never terminated —
+            // ~33 qalc spawns/second for as long as the box had text in it.
+            if (root.wantsMathResult(root.debouncedSearchText))
+                nonAppResultsTimer.restart();
         }
     }
 

--- a/scripts/thumbnails/generate-thumbnails-magick.sh
+++ b/scripts/thumbnails/generate-thumbnails-magick.sh
@@ -29,10 +29,16 @@ md5() {
 }
 
 urlencode() {
-    # Percent-encode a string for use in a URI, but do not encode slashes
+    # Percent-encode a string for use in a URI, but do not encode slashes.
+    # LC_ALL=C is load-bearing: it makes ${#str} and ${str:i:1} walk UTF-8
+    # *bytes* rather than code points. The consumers of this hash encode bytes
+    # (thumbgen.py via urllib.parse.quote, ThumbnailImage.qml via
+    # encodeURIComponent), so encoding code points here yields a different md5
+    # and a thumbnail that nothing ever looks up.
     local str="$1"
     local encoded=""
     local c
+    local LC_ALL=C
     for ((i=0; i<${#str}; i++)); do
         c="${str:$i:1}"
         case "$c" in

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -33,11 +33,25 @@ Singleton {
     ).length > 0
 
     property bool _micMuted: false
-    property real _micVolume: source?.audio?.volume ?? 0
+    // Tracked explicitly rather than bound to source.audio.volume: setSourceVolume()
+    // assigns to this imperatively, which would destroy a declarative binding for
+    // good — after the first mic adjustment the shell would stop seeing volume
+    // changes made anywhere else (pavucontrol, another app).
+    property real _micVolume: 0
     readonly property bool micMuted: _micMuted
     readonly property real micVolume: _micVolume
 
-    onSourceChanged: _refreshMicState()
+    Connections {
+        target: root.source?.audio ?? null
+        function onVolumeChanged(): void {
+            root._micVolume = root.source?.audio?.volume ?? 0
+        }
+    }
+
+    onSourceChanged: {
+        root._micVolume = root.source?.audio?.volume ?? 0
+        _refreshMicState()
+    }
 
     function friendlyDeviceName(node) {
         return node ? (node.nickname || node.description || Translation.tr("Unknown")) : Translation.tr("Unknown");

--- a/services/MemoryPressureService.qml
+++ b/services/MemoryPressureService.qml
@@ -33,12 +33,13 @@ Singleton {
 
     function restart(): void {
         _log("user requested restart")
-        Notifications.send(
+        Quickshell.execDetached([
+            "/usr/bin/notify-send",
             "iNiR",
             Translation.tr("Restarting shell..."),
-            "system-reboot-symbolic",
-            2000, false, {}
-        )
+            "-a", "Shell",
+            "--hint=int:transient:1",
+        ])
         // Small delay so notification shows
         Qt.callLater(() => {
             Quickshell.execDetached(["systemctl", "--user", "restart", "inir.service"])
@@ -84,13 +85,14 @@ Singleton {
         
         root.notificationShown = true
         const mbEstimate = Math.round(root.currentDeletedMappings * 0.5)  // ~0.5 MB per mapping
-        
-        Notifications.send(
+
+        Quickshell.execDetached([
+            "/usr/bin/notify-send",
             "iNiR",
             Translation.tr("Memory usage is high (~%1 MB accumulated). A restart would free it. Run: inir memory restart").arg(mbEstimate),
-            "dialog-warning-symbolic",
-            0, false, {}  // persistent until dismissed
-        )
+            "-u", "critical",
+            "-a", "Shell",
+        ])
         _log("notified user, estimated leak:", mbEstimate, "MB")
     }
 

--- a/services/NiriService.qml
+++ b/services/NiriService.qml
@@ -779,6 +779,21 @@ Singleton {
                     })
     }
 
+    // Workspace ids are globally unique; idx is per-output and repeats across
+    // outputs, so an Index reference always resolves against the *focused*
+    // output. Callers targeting a specific output's workspace must use this.
+    function switchToWorkspaceId(workspaceId) {
+        return send({
+                        "Action": {
+                            "FocusWorkspace": {
+                                "reference": {
+                                    "Id": workspaceId
+                                }
+                            }
+                        }
+                    })
+    }
+
     function switchToWorkspace(workspaceIndex) {
         return send({
                         "Action": {

--- a/services/Notifications.qml
+++ b/services/Notifications.qml
@@ -632,7 +632,7 @@ Singleton {
                 console.log("[Notifications] File not found, creating new file.")
                 // Ensure parent directory exists
                 const parentDir = root.filePath.substring(0, root.filePath.lastIndexOf('/'))
-                Process.exec(["/usr/bin/mkdir", "-p", parentDir])
+                Quickshell.execDetached(["/usr/bin/mkdir", "-p", parentDir])
                 root.list = []
                 notifFileView.setText(stringifyList(root.list));
             } else {


### PR DESCRIPTION
Six independent correctness fixes, each its own commit. All were reproduced and verified on a live two-monitor niri session.

### Fixes
- **Thumbnail hash over UTF-8 bytes, not code points** — `urlencode()` in `generate-thumbnails-magick.sh` encoded code points (`café.jpg` → `%E9`), but `thumbgen.py` (`urllib.parse.quote`) and `ThumbnailImage.qml` (`encodeURIComponent`) both encode bytes (`%C3%A9`). Different md5 → thumbnail written where nothing looks for it, so non-ASCII filenames never got one. CJK (>U+00FF) produced invalid encoding entirely. *Verified: output now matches `urllib.parse.quote` on café/中文/ภาษาไทย.*
- **qalc no longer respawns itself while typing** — `updateSearchResults()` restarted the math timer, whose qalc handler called `updateSearchResults()` again; `qalc -t` prints something for any input, so the loop never terminated. *Measured typing "firefox" in the overview: **189 qalc processes over 6s before, 0 after**; math results still render (1234×5678 → 7006652).*
- **Bar workspace switches target the bar's own output** — niri `idx` is per-output and a `FocusWorkspace` `Index` reference resolves against the *focused* output, so clicking/scrolling a bar on a non-focused monitor moved the wrong monitor. Now dispatched by globally-unique `id`. *Verified against the live niri socket.*
- **`Notifications.send()` does not exist** — `MemoryPressureService` called it twice; both threw. `inir memory restart` was a no-op and the memory warning could never appear (and latched so it never retried). Switched to the repo's existing `notify-send` path.
- **`Process.exec()` called on the type, not an instance** — threw in an `onLoadFailed(FileNotFound)` handler, so on a fresh install the notification store was never created.
- **Mic volume keeps tracking the source** — `_micVolume` was a binding that `setSourceVolume()` clobbered imperatively, so after one adjustment the shell stopped seeing external volume changes. *Verified: setting `wpctl` to 35%/90% now moves the slider.*
