### PR TITLE
Fix resilience bugs (wifi retry crash, stale wifi icon, brightness leak, daemon crash, script hardening)

### DIFF
--- a/scripts/ai/gemini-categorize-wallpaper.sh
+++ b/scripts/ai/gemini-categorize-wallpaper.sh
@@ -29,17 +29,23 @@ fi
 B64DATA="$(base64 $B64FLAGS $RESIZED_IMG_PATH)"
 # echo $B64DATA
 
-# Prepare request data
-payload='{
+# Prepare request data.
+# Built with jq, not string concatenation: PROMPT embeds the wallpaper's file name,
+# and a name containing a quote or backslash (my "best" wall.jpg) produced malformed
+# JSON, a 400 from the API, and a silent "null" written as the category.
+payload=$(jq -n \
+    --arg b64 "$B64DATA" \
+    --arg prompt "$PROMPT" \
+    '{
     "contents": [{
         "parts":[
             {
                 "inline_data": {
                 "mime_type":"image/jpeg",
-                "data": "'"$B64DATA"'"
+                "data": $b64
                 }
             },
-            {"text": "'"$PROMPT"'"}
+            {"text": $prompt}
         ]
     }],
     "generationConfig": {
@@ -50,7 +56,7 @@ payload='{
         },
         "temperature": 0
     }
-}'
+}')
 # echo "$payload" | jq
 
 # Make the request

--- a/scripts/daemon/inir_super_overview_daemon.py
+++ b/scripts/daemon/inir_super_overview_daemon.py
@@ -164,110 +164,121 @@ async def monitor_device(path):
         interaction_since_super_down, \
         last_toggle_time, \
         tap_handled
-    dev = InputDevice(path)
     super_down = False
     chord = False
 
-    async for event in dev.async_read_loop():
-        if event.type != ecodes.EV_KEY:
-            continue
+    try:
+        dev = InputDevice(path)
+        async for event in dev.async_read_loop():
+            if event.type != ecodes.EV_KEY:
+                continue
 
-        key_event = categorize(event)
-        code = key_event.scancode
-        value = key_event.keystate  # 1=down, 2=hold, 0=up
+            key_event = categorize(event)
+            code = key_event.scancode
+            value = key_event.keystate  # 1=down, 2=hold, 0=up
 
-        if code in SUPER_CODES:
-            if value == key_event.key_down:
-                super_down = True
-                chord = False
-                super_down_global = True
-                interaction_since_super_down = False
-                tap_handled = False
-            elif value == key_event.key_up:
-                if (
-                    super_down
-                    and not chord
-                    and not interaction_since_super_down
-                    and not tap_handled
-                ):
-                    # Tap of Super with no other keys or clicks: toggle inir overview
-                    # with a global debounce so multiple devices don't double-trigger.
-                    now = time.monotonic()
-                    if now - last_toggle_time >= DEBOUNCE_SEC:
-                        last_toggle_time = now
-                        tap_handled = True
-                        print(
-                            "[inir-super-daemon] Super tap detected, toggling inir overview",
-                            flush=True,
-                        )
-                        try:
-                            inir_env = get_inir_env()
-                            if not inir_env:
-                                print(
-                                    "[inir-super-daemon] No inir env available, skipping toggle",
-                                    flush=True,
-                                )
-                                super_down = False
-                                super_down_global = False
-                                interaction_since_super_down = False
-                                continue
-
-                            env = os.environ.copy()
-                            env.update(inir_env)
-
-                            # Resolve the inir launcher for the IPC call
-                            inir_bin = os.environ.get(
-                                "INIR_LAUNCHER_PATH",
-                                shutil.which("inir") or "inir",
-                            )
-                            subprocess.Popen(
-                                [inir_bin, "overview", "toggle"],
-                                env=env,
-                                stdout=subprocess.DEVNULL,
-                                stderr=subprocess.DEVNULL,
-                            )
-                        except Exception as e:
+            if code in SUPER_CODES:
+                if value == key_event.key_down:
+                    super_down = True
+                    chord = False
+                    super_down_global = True
+                    interaction_since_super_down = False
+                    tap_handled = False
+                elif value == key_event.key_up:
+                    if (
+                        super_down
+                        and not chord
+                        and not interaction_since_super_down
+                        and not tap_handled
+                    ):
+                        # Tap of Super with no other keys or clicks: toggle inir overview
+                        # with a global debounce so multiple devices don't double-trigger.
+                        now = time.monotonic()
+                        if now - last_toggle_time >= DEBOUNCE_SEC:
+                            last_toggle_time = now
+                            tap_handled = True
                             print(
-                                f"[inir-super-daemon] Error running toggle command: {e}",
+                                "[inir-super-daemon] Super tap detected, toggling inir overview",
                                 flush=True,
                             )
-                super_down = False
-                chord = False
-                super_down_global = False
-                interaction_since_super_down = False
-            continue
+                            try:
+                                inir_env = get_inir_env()
+                                if not inir_env:
+                                    print(
+                                        "[inir-super-daemon] No inir env available, skipping toggle",
+                                        flush=True,
+                                    )
+                                    super_down = False
+                                    super_down_global = False
+                                    interaction_since_super_down = False
+                                    continue
 
-        # Any other key while Super is down marks this as a chord.
-        if super_down and value == key_event.key_down:
-            chord = True
-        if super_down_global and value == key_event.key_down:
-            interaction_since_super_down = True
+                                env = os.environ.copy()
+                                env.update(inir_env)
+
+                                # Resolve the inir launcher for the IPC call
+                                inir_bin = os.environ.get(
+                                    "INIR_LAUNCHER_PATH",
+                                    shutil.which("inir") or "inir",
+                                )
+                                subprocess.Popen(
+                                    [inir_bin, "overview", "toggle"],
+                                    env=env,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.DEVNULL,
+                                )
+                            except Exception as e:
+                                print(
+                                    f"[inir-super-daemon] Error running toggle command: {e}",
+                                    flush=True,
+                                )
+                    super_down = False
+                    chord = False
+                    super_down_global = False
+                    interaction_since_super_down = False
+                continue
+
+            # Any other key while Super is down marks this as a chord.
+            if super_down and value == key_event.key_down:
+                chord = True
+            if super_down_global and value == key_event.key_down:
+                interaction_since_super_down = True
+    except asyncio.CancelledError:
+        return
+    except OSError:
+        # Device vanished (unplug, suspend/resume). Returning lets the supervisor
+        # in main() re-adopt it on the next rescan instead of killing the daemon.
+        return
 
 
 async def monitor_pointer_device(path):
-    dev = InputDevice(path)
+    global interaction_since_super_down
 
-    async for event in dev.async_read_loop():
-        if event.type != ecodes.EV_KEY:
-            continue
+    try:
+        dev = InputDevice(path)
+        async for event in dev.async_read_loop():
+            if event.type != ecodes.EV_KEY:
+                continue
 
-        key_event = categorize(event)
-        code = key_event.scancode
-        value = key_event.keystate
+            key_event = categorize(event)
+            code = key_event.scancode
+            value = key_event.keystate
 
-        if code in POINTER_BUTTON_CODES and value == key_event.key_down:
-            global interaction_since_super_down
-            if super_down_global:
-                interaction_since_super_down = True
+            if code in POINTER_BUTTON_CODES and value == key_event.key_down:
+                if super_down_global:
+                    interaction_since_super_down = True
+    except asyncio.CancelledError:
+        return
+    except OSError:
+        return
 
 
 async def main():
     # Retry keyboard detection until we have at least one device with Super,
     # so the service still works if it starts before the session is fully up.
     keyboard_paths = []
-    pointer_paths = []
     while not keyboard_paths:
-        keyboard_paths, pointer_paths = find_keyboard_devices()
+        keyboard_paths, _ = find_keyboard_devices()
         if keyboard_paths:
             break
         print(
@@ -276,9 +287,21 @@ async def main():
         )
         await asyncio.sleep(5)
 
-    tasks = [asyncio.create_task(monitor_device(p)) for p in keyboard_paths]
-    tasks.extend(asyncio.create_task(monitor_pointer_device(p)) for p in pointer_paths)
-    await asyncio.gather(*tasks)
+    # Supervise: a monitor returns when its device disappears, so rescan on a
+    # tick and (re)adopt anything unmonitored. Without this, unplugging a
+    # keyboard left the daemon alive but deaf, and one plugged in after startup
+    # was never watched at all.
+    tasks = {}
+    while True:
+        keyboard_paths, pointer_paths = find_keyboard_devices()
+        for path, monitor in [
+            *((p, monitor_device) for p in keyboard_paths),
+            *((p, monitor_pointer_device) for p in pointer_paths),
+        ]:
+            task = tasks.get(path)
+            if task is None or task.done():
+                tasks[path] = asyncio.create_task(monitor(path))
+        await asyncio.sleep(5)
 
 
 if __name__ == "__main__":

--- a/scripts/thumbnails/thumbgen.py
+++ b/scripts/thumbnails/thumbgen.py
@@ -47,7 +47,13 @@ factory = None
 current_size = "large"
 logger.remove()
 logger.add(sys.stdout, level="INFO")
-logger.add("/tmp/thumbgen.log", level="DEBUG", rotation="100 MB")
+
+# Not /tmp/thumbgen.log: that path is predictable in a world-writable directory,
+# so on a shared host another user can pre-create it (or symlink it elsewhere) and
+# logger.add() then raises at import time, killing every thumbnail run.
+_log_dir = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "inir"
+_log_dir.mkdir(parents=True, exist_ok=True)
+logger.add(_log_dir / "thumbgen.log", level="DEBUG", rotation="100 MB")
 
 
 def get_thumbnail_path(fpath: str, size_name: str) -> str:

--- a/services/Brightness.qml
+++ b/services/Brightness.qml
@@ -20,9 +20,32 @@ Singleton {
     signal brightnessChanged()
 
     property var ddcMonitors: []
-    readonly property list<BrightnessMonitor> monitors: Quickshell.screens.map(screen => monitorComp.createObject(root, {
-        screen
-    }))
+    property list<BrightnessMonitor> monitors: []
+
+    // Rebuilt explicitly rather than bound to Quickshell.screens: createObject()
+    // parents each monitor to root, so a binding would strand a whole generation
+    // of BrightnessMonitors on every screen change (hotplug, DPMS, mode switch).
+    // Stranded ones are not inert — each still owns a Process and a Timer and
+    // still reacts to ddcMonitors, re-spawning ddcutil on every refresh.
+    function _rebuildMonitors(): void {
+        // Array.from is load-bearing: list<T> is a live view of the property, not
+        // a snapshot, so holding it directly would alias the *new* list after the
+        // assignment below and destroy the monitors we just built.
+        const stale = Array.from(root.monitors);
+        root.monitors = Quickshell.screens.map(screen => monitorComp.createObject(root, {
+            screen
+        }));
+        stale.forEach(m => m.destroy());
+    }
+
+    Component.onCompleted: root._rebuildMonitors()
+
+    Connections {
+        target: Quickshell
+        function onScreensChanged(): void {
+            root._rebuildMonitors();
+        }
+    }
 
     function getMonitorForScreen(screen: ShellScreen): var {
         return monitors.find(m => m.screen === screen);

--- a/services/Network.qml
+++ b/services/Network.qml
@@ -80,6 +80,9 @@ Singleton {
     function changePassword(network: WifiAccessPoint, password: string, username = ""): void {
         // TODO: enterprise wifi with username
         network.askingPassword = false;
+        // changePasswordProc.onExited re-runs connectProc, whose own onExited has
+        // already nulled the target — restore it so the retry can report back.
+        root.wifiConnectTarget = network;
         changePasswordProc.exec({
             "command": ["nmcli", "connection", "modify", network.ssid, "wifi-sec.psk", password]
         })
@@ -104,12 +107,15 @@ Singleton {
         stderr: SplitParser {
             onRead: line => {
                 // print("err:", line)
-                if (line.includes("Secrets were required")) {
+                if (line.includes("Secrets were required") && root.wifiConnectTarget) {
                     root.wifiConnectTarget.askingPassword = true
                 }
             }
         }
         onExited: (exitCode, exitStatus) => {
+            // Guarded: this handler nulls the target, and changePasswordProc re-runs
+            // connectProc, so a password retry lands here a second time.
+            if (!root.wifiConnectTarget) return;
             root.wifiConnectTarget.askingPassword = (exitCode !== 0)
             root.wifiConnectTarget = null
         }

--- a/services/Network.qml
+++ b/services/Network.qml
@@ -27,24 +27,31 @@ Singleton {
 
     property string networkName: ""
     property int networkStrength
+    // Gated on being *connected*, not on the radio being powered. wifiStatus is
+    // only ever "connecting"/"disconnected" while the radio is on — i.e. while
+    // wifiEnabled is true — so keying the strength icons off wifiEnabled both
+    // rendered a stale full-strength icon after disconnecting and left the
+    // "not_connected"/"wifi_find" branches permanently unreachable.
     property string materialSymbol: root.ethernet
         ? "lan"
-        : root.wifiEnabled
-            ? (
-                Network.networkStrength > 83 ? "signal_wifi_4_bar" :
-                Network.networkStrength > 67 ? "network_wifi" :
-                Network.networkStrength > 50 ? "network_wifi_3_bar" :
-                Network.networkStrength > 33 ? "network_wifi_2_bar" :
-                Network.networkStrength > 17 ? "network_wifi_1_bar" :
-                "signal_wifi_0_bar"
-            )
-            : (root.wifiStatus === "connecting")
-                ? "signal_wifi_statusbar_not_connected"
-                : (root.wifiStatus === "disconnected")
-                    ? "wifi_find"
-                    : (root.wifiStatus === "disabled")
-                        ? "signal_wifi_off"
-                        : "signal_wifi_bad"
+        : !root.wifiEnabled
+            ? "signal_wifi_off"
+            : (root.wifiStatus === "connected" || root.wifiStatus === "limited")
+                ? (
+                    Network.networkStrength > 83 ? "signal_wifi_4_bar" :
+                    Network.networkStrength > 67 ? "network_wifi" :
+                    Network.networkStrength > 50 ? "network_wifi_3_bar" :
+                    Network.networkStrength > 33 ? "network_wifi_2_bar" :
+                    Network.networkStrength > 17 ? "network_wifi_1_bar" :
+                    "signal_wifi_0_bar"
+                )
+                : (root.wifiStatus === "connecting")
+                    ? "signal_wifi_statusbar_not_connected"
+                    : (root.wifiStatus === "disconnected")
+                        ? "wifi_find"
+                        : (root.wifiStatus === "disabled")
+                            ? "signal_wifi_off"
+                            : "signal_wifi_bad"
 
     // Control
     function enableWifi(enabled = true): void {
@@ -248,6 +255,11 @@ Singleton {
             root.wifiStatus = wifiStatus;
             root.ethernet = hasEthernet;
             root.wifi = hasWifi;
+            // updateNetworkStrength's awk prints nothing when no AP is in use, so
+            // its SplitParser never fires and networkStrength would keep the value
+            // from the last connected AP. Clear it here instead.
+            if (wifiStatus !== "connected" && wifiStatus !== "limited")
+                root.networkStrength = 0;
         }
     }
 


### PR DESCRIPTION
Six resilience/hardening fixes, each its own commit. These are lower-confidence than #1 because some cannot be exercised at runtime on my machine (no NetworkManager; the Super daemon isn't enabled here) — noted per-fix below.

### Fixes
- **Guard the wifi connect handlers against a null target** — `connectProc.onExited` dereferences `wifiConnectTarget` then nulls it, but `changePasswordProc` re-runs `connectProc` without restoring it, so the ordinary wrong-password retry hit `null.askingPassword` and threw, leaving the prompt stuck. *Reasoned from code; not runtime-tested (this machine has no NetworkManager).*
- **Wifi icons reflect connection, not radio power** — strength icons were gated on `wifiEnabled`, so disconnecting left a stale full-strength icon and two branches were unreachable; `networkStrength` also never reset. *Same runtime caveat.*
- **Destroy stale `BrightnessMonitor`s on screen change** — `monitors` was a binding that built a new generation (each with a live Process + Timer) on every hotplug/DPMS/mode change and stranded the old ones, which kept spawning `ddcutil`. *Verified increment/decrement still work; the leak-on-hotplug itself was not reproduced (can't hotplug easily).*
- **Super-tap daemon survives input device removal** — `async_read_loop()` had no `try/except` and `main()` used a bare `gather()`, so unplugging any keyboard killed the daemon. Mirrors `keyboard_lock_state_daemon.py`, which already handles this. **Not runtime-tested: this daemon isn't enabled on my dev machine — passes a syntax check only. Worth exercising with a real unplug before merging.**
- **Build the Gemini request with jq** — the wallpaper filename was spliced raw into hand-built JSON; a quote/backslash produced a 400 and a silent `null` category. `gemini-translate.sh` already uses jq.
- **Log under `XDG_CACHE_HOME`, not `/tmp/thumbgen.log`** — predictable path in a world-writable dir; another user can pre-create/symlink it and break every thumbnail run at import.
