### PR TITLE
Fix memfd leak counter reading /proc/self of the wrong process (Related to #194)

### DIFF
--- a/services/MemoryPressureService.qml
+++ b/services/MemoryPressureService.qml
@@ -106,7 +106,10 @@ Singleton {
     // ── Maps reader ───────────────────────────────────────────────────────
     Process {
         id: _mapsReader
-        command: ["sh", "-c", "grep -c 'JSGCHeap.*deleted' /proc/self/maps 2>/dev/null || echo 0; grep -c JSGCHeap /proc/self/maps 2>/dev/null || echo 0"]
+        // /proc/$PPID, not /proc/self: this runs in an sh child of the shell, so
+        // /proc/self is that sh process (zero JSGCHeap mappings) and the counter
+        // always read 0 — the threshold could never trip. $PPID is the shell.
+        command: ["sh", "-c", "grep -c 'JSGCHeap.*deleted' /proc/$PPID/maps 2>/dev/null || echo 0; grep -c JSGCHeap /proc/$PPID/maps 2>/dev/null || echo 0"]
         stdout: SplitParser {
             property int lineNum: 0
             onRead: line => {
@@ -143,6 +146,10 @@ Singleton {
         if (!root.enabled) return
         Qt.callLater(() => {
             _checkTimer.start()
+            // Prime it once: the timer's first tick is a full interval away, so
+            // without this the service reports 0 mappings for the first 5 minutes
+            // after every restart.
+            root._checkMemoryPressure()
         })
     }
 }


### PR DESCRIPTION
**Related to #194** — this does *not* fix the underlying leak. It makes the existing memory-pressure warning able to fire at all.

### What's broken
`MemoryPressureService` counts JSGCHeap `(deleted)` mappings to detect the Qt V4 memfd leak, but the grep runs via `sh -c` against `/proc/self/maps` — and under `sh -c`, `/proc/self` is the **sh child's** maps, not the shell's. It always counts **0**. So `deletedMappings` stays 0, the threshold (300) can never be reached, and the warning can never fire no matter how far the leak grows.

Fix: point the grep at `/proc/$PPID` (the shell that spawned the sh). Also prime the check once in `Component.onCompleted` — the poll timer's first tick is a full 5-minute interval away, so the service reported 0 for the first five minutes after every restart regardless.

### Verified (live niri session)
- Before: `inir memory stats` returned a constant `{"deletedMappings":0,"totalMappings":0}`.
- After: it tracks the real count in `/proc/<shell>/maps` (e.g. reported 14, matching `grep -c 'JSGCHeap.*deleted'`), and reports non-zero within seconds of startup instead of after 5 minutes.
- I verified the counter now reads the true value; I did **not** drive it to 300 to watch the notification render, so: the threshold can now be *reached* (was impossible before).

### Dependency
The warning this counter feeds is shown via the `notify-send` path fixed in #199 (`Notifications.send()` doesn't exist). This detector fix is only end-user-visible once #199 lands — worth sequencing them.

---

### Characterization of the leak itself (not fixed here)
I reproduced it in-session by driving Loader teardown (open/close overview + sidebar ~70×): JSGCHeap memfd mappings climbed monotonically 26 → 97 and did not recede. Forcing GC (`inir memory collect`) did **not** reclaim them — the count went *up* (71 → 97). So it's a true unmap leak in Qt's V4 engine, not deferred GC, and a shell restart is the only reclaim — which is what this service's restart path already provides. Rooting it out is upstream Qt work; this PR just makes the "time to restart" signal functional. (Fuller notes posted as a comment on #194.)
