### PR TITLE
fix(doc): fix docstring typo for dashboard config

### DIFF
--- a/modules/settings/DashboardConfig.qml
+++ b/modules/settings/DashboardConfig.qml
@@ -117,7 +117,7 @@ ContentPage {
                 }
                 StyledText {
                     Layout.fillWidth: true
-                    text: Translation.tr("Toggle with a keybinding running: %1").arg("inir ipc call dashboard toggle")
+                    text: Translation.tr("Toggle with a keybinding running: %1").arg("inir ipc dashboard toggle")
                     color: Appearance.colors.colSubtext
                     font.pixelSize: Appearance.font.pixelSize.smaller
                     wrapMode: Text.WordWrap


### PR DESCRIPTION
<!-- PRs target the `prerelease` branch (development). `main` is the stable branch users install from. -->

## Summary

The tiniest fix in a docstring (`inir ipc call dashboard toggle` -> `inir ipc dashboard toggle`).

## Testing

Describe what you ran and what you observed, not just "it works".

- [x] `inir restart && inir logs`: no new errors
- [x] Exercised the exact flow that changed
- [x] Both panel families checked (if shared code changed)
- [ ] Screenshots or a recording attached (if the change is visual)

## AI usage

Most of us use AI tools now, that's fine, just be upfront so review can
focus on the right things:

- [ ] AI-assisted (tool/model: <!-- e.g. Claude Code / Cursor / Copilot -->)
- [ ] I removed AI attributions and boilerplate (co-author trailers, "generated with" footers, narrating comments)
- [ ] I reviewed and understand every line of this diff myself

## Notes

the very tiniest smallest fix, however experiment on my end has shown that running `inir ipc call dashboard toggle` lead to an `Unknown target.` error, and when confirming with how the ipc calls are treated, the `call` keyword is extraneous and takes the place of the target supposed to receive the call, leading to errors. Once i've removed the keyword from my keybind, it worked flawlessly.
