### PR TITLE
Use individual Nix files instead of monolithic flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+{
+  package =
+    {
+      pkgs ? import <nixpkgs> { },
+    }:
+    pkgs.callPackage ./distro/nixos/package.nix { };
+
+  nixosModule = { pkgs, lib, ... }: {
+    imports = [ ./distro/nixos/nixos-module.nix ];
+    programs.inir.package = lib.mkDefault (pkgs.callPackage ./distro/nixos/package.nix { });
+  };
+
+  homeManagerModule = { pkgs, lib, ... }: {
+    imports = [ ./distro/nixos/home-manager-module.nix ];
+    programs.inir.package = lib.mkDefault (pkgs.callPackage ./distro/nixos/package.nix { });
+  };
+}

--- a/distro/nixos/home-manager-module.nix
+++ b/distro/nixos/home-manager-module.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.inir;
+in
+{
+  imports = [ ./modules-common-options.nix ];
+
+  options.programs.inir.configSymlink = {
+    enable = lib.options.mkEnableOption "creating a symlink to the quickshell config for tools that expect the traditional path";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+
+    xdg.configFile = lib.mkIf cfg.configSymlink.enable {
+      "quickshell/inir".source = "${cfg.package}/share/quickshell/inir";
+    };
+
+    systemd.user.services.inir = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "iNiR shell";
+        PartOf = [ "graphical-session.target" ];
+        After = [ "graphical-session.target" ];
+        Requisite = [ "graphical-session.target" ];
+        StartLimitIntervalSec = 30;
+        StartLimitBurst = 3;
+      };
+
+      Service = {
+        Type = "simple";
+        Environment = ''
+          INIR_SYSTEM_RUNTIME_DIR=${cfg.package}/share/quickshell/inir
+          INIR_FALLBACK_SYSTEM_RUNTIME_DIR=${cfg.package}/share/quickshell/inir
+          QS_DISABLE_CRASH_HANDLER=1
+          QT_LOGGING_RULES=quickshell.dbus.properties=false;qt.qml.settings.warning=false;qt.core.qsettings.warning=false;kf.xmlgui=false;kf.coreaddons=false;kf.config.core=false;kf.iconthemes=false
+          QT_SCALE_FACTOR=1
+          QT_SCALE_FACTOR_ROUNDING_POLICY=RoundPreferFloor
+        '';
+        ExecStart = "${lib.getExe cfg.package} run --session";
+        ExecStopPost = "-${lib.getExe cfg.package} cleanup-orphans";
+        SuccessExitStatus = 143;
+        KillMode = "process";
+        KillSignal = "SIGTERM";
+        Restart = "on-failure";
+        RestartSec = 5;
+        TimeoutStopSec = 15;
+        LimitCORE = 0;
+        IOSchedulingPriority = 2;
+      };
+
+      Install.WantedBy = lib.optional (cfg.systemd.wantedUnit != null) cfg.systemd.wantedUnit;
+    };
+  };
+}

--- a/distro/nixos/modules-common-options.nix
+++ b/distro/nixos/modules-common-options.nix
@@ -1,0 +1,45 @@
+{ lib, ... }:
+{
+  imports = [
+    # systemd.enable is consistent with option names of other NixOS modules
+    (lib.modules.mkRenamedOptionModule
+      [ "programs" "inir" "service" "enable" ]
+      [ "programs" "inir" "systemd" "enable" ]
+    )
+    # An option for a unit name is more flexible than the enum that programs.inir.service.compositor
+    # accepted. For example, the compositor could use a different unit name not accounted for by the
+    # enum.
+    (lib.modules.mkRemovedOptionModule [ "programs" "inir" "service" "compositor" ] ''
+      Use programs.inir.systemd.wantedUnit instead, which can be set to a specific unit name.
+    '')
+  ];
+
+  options.programs.inir = {
+    enable = lib.options.mkEnableOption "iNiR desktop shell";
+
+    package = lib.options.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "The iNiR package to install.";
+    };
+
+    extraPackages = lib.options.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra runtime packages made available to the iNiR service.";
+    };
+
+    systemd = {
+      enable = lib.options.mkEnableOption "the systemd user service for iNiR" // {
+        default = true;
+      };
+
+      wantedUnit = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = "niri.service";
+        example = "wayland-wm@Hyprland.service";
+        description = "Compositor user unit that should want inir.service. Set null to create the unit without auto-start wiring.";
+      };
+    };
+  };
+}

--- a/distro/nixos/nixos-module.nix
+++ b/distro/nixos/nixos-module.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.inir;
+in
+{
+  imports = [ ./modules-common-options.nix ];
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = lib.optional (cfg.package != null) cfg.package;
+
+    systemd.user.services.inir = lib.mkIf cfg.systemd.enable {
+      description = "iNiR shell";
+      wantedBy = lib.optional (cfg.systemd.wantedUnit != null) cfg.systemd.wantedUnit;
+      partOf = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      path = [ cfg.package ] ++ cfg.extraPackages;
+      environment = {
+        INIR_SYSTEM_RUNTIME_DIR = "${cfg.package}/share/quickshell/inir";
+        INIR_FALLBACK_SYSTEM_RUNTIME_DIR = "${cfg.package}/share/quickshell/inir";
+        QS_DISABLE_CRASH_HANDLER = "1";
+        QT_LOGGING_RULES = "quickshell.dbus.properties=false;qt.qml.settings.warning=false;qt.core.qsettings.warning=false;kf.xmlgui=false;kf.coreaddons=false;kf.config.core=false;kf.iconthemes=false";
+        QT_SCALE_FACTOR = "1";
+        QT_SCALE_FACTOR_ROUNDING_POLICY = "RoundPreferFloor";
+      };
+      unitConfig = {
+        Requisite = "graphical-session.target";
+        StartLimitIntervalSec = 30;
+        StartLimitBurst = 3;
+      };
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package} run --session";
+        ExecStopPost = "-${lib.getExe cfg.package} cleanup-orphans";
+        SuccessExitStatus = 143;
+        KillMode = "process";
+        KillSignal = "SIGTERM";
+        Restart = "on-failure";
+        RestartSec = 5;
+        TimeoutStopSec = 15;
+        LimitCORE = 0;
+        IOSchedulingPriority = 2;
+      };
+    };
+  };
+}

--- a/distro/nixos/package.nix
+++ b/distro/nixos/package.nix
@@ -61,6 +61,9 @@
   xwayland-satellite,
   ydotool,
 
+  makeFontsConf,
+  material-symbols,
+
   kdePackages,
   qt6,
 }:
@@ -175,6 +178,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         qt6.qtvirtualkeyboard
         qt6.qtwayland
       ];
+      fontconfig = makeFontsConf {
+        fontDirectories = [ material-symbols ];
+      };
     in
     ''
       runHook preInstall
@@ -213,6 +219,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         --prefix PATH : "${lib.makeBinPath deps}" \
         --prefix QML2_IMPORT_PATH : "${lib.makeSearchPath "lib/qt-6/qml" qml}" \
         --prefix QT_PLUGIN_PATH : "${lib.makeSearchPath "lib/qt-6/plugins" qml}" \
+        --set FONTCONFIG_FILE "${fontconfig}" \
         --set-default INIR_SYSTEM_RUNTIME_DIR "$runtime" \
         --set-default INIR_FALLBACK_SYSTEM_RUNTIME_DIR "$runtime"
 

--- a/distro/nixos/package.nix
+++ b/distro/nixos/package.nix
@@ -85,85 +85,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase =
     let
-      deps = [
-        bash
-        bc
-        coreutils
-        curl
-        findutils
-        gawk
-        git
-        gnugrep
-        gnused
-        jq
-        procps
-        python3
-        ripgrep
-        rsync
-        systemd
-        wget
-        xdg-utils
-        quickshell
-        wl-clipboard
-        cliphist
-        grim
-        slurp
-        playerctl
-        libnotify
-        glib
-        pipewire
-        pulseaudio
-        wireplumber
-
-        brightnessctl
-        cava
-        ddcutil
-        ffmpeg
-        fish
-        foot
-        fuzzel
-        geoclue2
-        hyprland
-        hyprpicker
-        gum
-        imagemagick
-        kitty
-        libqalculate
-        mpv
-        nautilus
-        networkmanager
-        socat
-        songrec
-        swappy
-        tesseract
-        translate-shell
-        upower
-        wf-recorder
-        wlsunset
-        wtype
-        xwayland-satellite
-        ydotool
-
-        kdePackages.breeze-icons
-        kdePackages.kdialog
-        kdePackages.kirigami
-        kdePackages.kconfig
-        kdePackages.plasma-integration
-        kdePackages.syntax-highlighting
-        qt6.qt5compat
-        qt6.qtbase
-        qt6.qtdeclarative
-        qt6.qtimageformats
-        qt6.qtmultimedia
-        qt6.qtpositioning
-        qt6.qtquicktimeline
-        qt6.qtsensors
-        qt6.qtsvg
-        qt6.qttools
-        qt6.qttranslations
-        qt6.qtvirtualkeyboard
-        qt6.qtwayland
-      ];
       qml = [
         kdePackages.kirigami.passthru.unwrapped
         kdePackages.syntax-highlighting
@@ -216,7 +137,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         -exec sed -i '1!s#/usr/bin/##g' {} +
 
       makeWrapper "$runtime/scripts/inir" "$out/bin/inir" \
-        --prefix PATH : "${lib.makeBinPath deps}" \
+        --prefix PATH : "${lib.makeBinPath finalAttrs.passthru.runtimeDependencies}" \
         --prefix QML2_IMPORT_PATH : "${lib.makeSearchPath "lib/qt-6/qml" qml}" \
         --prefix QT_PLUGIN_PATH : "${lib.makeSearchPath "lib/qt-6/plugins" qml}" \
         --set FONTCONFIG_FILE "${fontconfig}" \
@@ -225,4 +146,92 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
       runHook postInstall
     '';
+
+  passthru.runtimeDependencies = [
+    bash
+    bc
+    coreutils
+    curl
+    findutils
+    gawk
+    git
+    gnugrep
+    gnused
+    jq
+    procps
+    python3
+    ripgrep
+    rsync
+    systemd
+    wget
+    xdg-utils
+    quickshell
+    wl-clipboard
+    cliphist
+    grim
+    slurp
+    playerctl
+    libnotify
+    glib
+    pipewire
+    pulseaudio
+    wireplumber
+
+    brightnessctl
+    cava
+    ddcutil
+    ffmpeg
+    fish
+    foot
+    fuzzel
+    geoclue2
+    hyprland
+    hyprpicker
+    gum
+    imagemagick
+    kitty
+    libqalculate
+    mpv
+    nautilus
+    networkmanager
+    socat
+    songrec
+    swappy
+    tesseract
+    translate-shell
+    upower
+    wf-recorder
+    wlsunset
+    wtype
+    xwayland-satellite
+    ydotool
+
+    kdePackages.breeze-icons
+    kdePackages.kdialog
+    kdePackages.kirigami
+    kdePackages.kconfig
+    kdePackages.plasma-integration
+    kdePackages.syntax-highlighting
+    qt6.qt5compat
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtimageformats
+    qt6.qtmultimedia
+    qt6.qtpositioning
+    qt6.qtquicktimeline
+    qt6.qtsensors
+    qt6.qtsvg
+    qt6.qttools
+    qt6.qttranslations
+    qt6.qtvirtualkeyboard
+    qt6.qtwayland
+  ];
+
+  meta = {
+    description = "Complete desktop shell for Niri, built on Quickshell";
+    homepage = "https://github.com/snowarch/inir";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "inir";
+  };
 })

--- a/distro/nixos/package.nix
+++ b/distro/nixos/package.nix
@@ -1,0 +1,221 @@
+{
+  stdenvNoCC,
+  makeWrapper,
+  lib,
+
+  bash,
+  bc,
+  coreutils,
+  curl,
+  findutils,
+  gawk,
+  git,
+  gnugrep,
+  gnused,
+  jq,
+  procps,
+  python3,
+  ripgrep,
+  rsync,
+  systemd,
+  wget,
+  xdg-utils,
+  quickshell,
+  wl-clipboard,
+  cliphist,
+  grim,
+  slurp,
+  playerctl,
+  libnotify,
+  glib,
+  pipewire,
+  pulseaudio,
+  wireplumber,
+
+  brightnessctl,
+  cava,
+  ddcutil,
+  ffmpeg,
+  fish,
+  foot,
+  fuzzel,
+  geoclue2,
+  hyprland,
+  hyprpicker,
+  gum,
+  imagemagick,
+  kitty,
+  libqalculate,
+  mpv,
+  nautilus,
+  networkmanager,
+  socat,
+  songrec,
+  swappy,
+  tesseract,
+  translate-shell,
+  upower,
+  wf-recorder,
+  wlsunset,
+  wtype,
+  xwayland-satellite,
+  ydotool,
+
+  kdePackages,
+  qt6,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "inir";
+  version = "2.28.0";
+
+  src = lib.cleanSource ./../..;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  preFixup = ''
+    find "$out/share/quickshell/inir" -type f -name '*.py' -exec chmod -x {} +
+  '';
+
+  postFixup = ''
+    find "$out/share/quickshell/inir" -type f -name '*.py' -exec chmod +x {} +
+  '';
+
+  installPhase =
+    let
+      deps = [
+        bash
+        bc
+        coreutils
+        curl
+        findutils
+        gawk
+        git
+        gnugrep
+        gnused
+        jq
+        procps
+        python3
+        ripgrep
+        rsync
+        systemd
+        wget
+        xdg-utils
+        quickshell
+        wl-clipboard
+        cliphist
+        grim
+        slurp
+        playerctl
+        libnotify
+        glib
+        pipewire
+        pulseaudio
+        wireplumber
+
+        brightnessctl
+        cava
+        ddcutil
+        ffmpeg
+        fish
+        foot
+        fuzzel
+        geoclue2
+        hyprland
+        hyprpicker
+        gum
+        imagemagick
+        kitty
+        libqalculate
+        mpv
+        nautilus
+        networkmanager
+        socat
+        songrec
+        swappy
+        tesseract
+        translate-shell
+        upower
+        wf-recorder
+        wlsunset
+        wtype
+        xwayland-satellite
+        ydotool
+
+        kdePackages.breeze-icons
+        kdePackages.kdialog
+        kdePackages.kirigami
+        kdePackages.kconfig
+        kdePackages.plasma-integration
+        kdePackages.syntax-highlighting
+        qt6.qt5compat
+        qt6.qtbase
+        qt6.qtdeclarative
+        qt6.qtimageformats
+        qt6.qtmultimedia
+        qt6.qtpositioning
+        qt6.qtquicktimeline
+        qt6.qtsensors
+        qt6.qtsvg
+        qt6.qttools
+        qt6.qttranslations
+        qt6.qtvirtualkeyboard
+        qt6.qtwayland
+      ];
+      qml = [
+        kdePackages.kirigami.passthru.unwrapped
+        kdePackages.syntax-highlighting
+        qt6.qt5compat
+        qt6.qtdeclarative
+        qt6.qtimageformats
+        qt6.qtmultimedia
+        qt6.qtpositioning
+        qt6.qtquicktimeline
+        qt6.qtsensors
+        qt6.qtsvg
+        qt6.qtvirtualkeyboard
+        qt6.qtwayland
+      ];
+    in
+    ''
+      runHook preInstall
+
+      runtime="$out/share/quickshell/inir"
+      mkdir -p "$runtime" "$out/bin"
+
+      while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        install -Dm644 "$path" "$runtime/$path"
+      done < sdata/runtime-root-files.txt
+
+      while IFS= read -r dir; do
+        [ -n "$dir" ] || continue
+        cp -R "$dir" "$runtime/$dir"
+      done < sdata/runtime-payload-dirs.txt
+
+      # Copy root-level QML entry points (shell.qml, settings.qml, etc.)
+      # which aren't listed in runtime-root-files.txt.
+      for f in *.qml; do
+        [ -f "$f" ] || continue
+        install -Dm644 "$f" "$runtime/$f"
+      done
+
+      chmod +x "$runtime/setup" "$runtime/scripts/inir"
+      find "$runtime/scripts" -type f \( -name '*.sh' -o -name '*.fish' -o -name '*.py' \) -exec chmod +x {} \;
+
+      # The source tree intentionally targets Arch, where helpers live
+      # under /usr/bin. NixOS does not provide that layout. Patch only
+      # the packaged copy and keep shebang lines intact.
+      find "$runtime/modules" "$runtime/services" "$runtime/defaults" "$runtime/scripts" \
+        -type f \( -name '*.qml' -o -name '*.js' -o -name '*.sh' -o -name '*.py' \) \
+        -exec sed -i '1!s#/usr/bin/##g' {} +
+
+      makeWrapper "$runtime/scripts/inir" "$out/bin/inir" \
+        --prefix PATH : "${lib.makeBinPath deps}" \
+        --prefix QML2_IMPORT_PATH : "${lib.makeSearchPath "lib/qt-6/qml" qml}" \
+        --prefix QT_PLUGIN_PATH : "${lib.makeSearchPath "lib/qt-6/plugins" qml}" \
+        --set-default INIR_SYSTEM_RUNTIME_DIR "$runtime" \
+        --set-default INIR_FALLBACK_SYSTEM_RUNTIME_DIR "$runtime"
+
+      runHook postInstall
+    '';
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,368 +5,47 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      lib = nixpkgs.lib;
+      inherit (nixpkgs) lib;
+
+      defaultOutputs = import ./.;
+
       systems = [
         "x86_64-linux"
         "aarch64-linux"
       ];
-
-      forAllSystems = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
-
-      optionalTop = pkgs: name:
-        lib.optional (builtins.hasAttr name pkgs) (builtins.getAttr name pkgs);
-
-      optionalKde = pkgs: name:
-        lib.optional
-          (builtins.hasAttr "kdePackages" pkgs && builtins.hasAttr name pkgs.kdePackages)
-          (builtins.getAttr name pkgs.kdePackages);
-
-      optionalQt6 = pkgs: name:
-        lib.optional
-          (builtins.hasAttr "qt6" pkgs && builtins.hasAttr name pkgs.qt6)
-          (builtins.getAttr name pkgs.qt6);
-
-      runtimeDeps = pkgs:
-        with pkgs; [
-          bash
-          bc
-          coreutils
-          curl
-          findutils
-          gawk
-          git
-          gnugrep
-          gnused
-          jq
-          procps
-          python3
-          ripgrep
-          rsync
-          systemd
-          wget
-          xdg-utils
-
-          quickshell
-          wl-clipboard
-          cliphist
-          grim
-          slurp
-          playerctl
-          libnotify
-          glib
-          pipewire
-          pulseaudio
-          wireplumber
-        ]
-        ++ optionalTop pkgs "brightnessctl"
-        ++ optionalTop pkgs "cava"
-        ++ optionalTop pkgs "ddcutil"
-        ++ optionalTop pkgs "ffmpeg"
-        ++ optionalTop pkgs "fish"
-        ++ optionalTop pkgs "foot"
-        ++ optionalTop pkgs "fuzzel"
-        ++ optionalTop pkgs "geoclue2"
-        ++ optionalTop pkgs "hyprland"
-        ++ optionalTop pkgs "hyprpicker"
-        ++ optionalTop pkgs "gum"
-        ++ optionalTop pkgs "imagemagick"
-        ++ optionalTop pkgs "kitty"
-        ++ optionalTop pkgs "libqalculate"
-        ++ optionalTop pkgs "mpv"
-        ++ optionalTop pkgs "nautilus"
-        ++ optionalTop pkgs "networkmanager"
-        ++ optionalTop pkgs "socat"
-        ++ optionalTop pkgs "songrec"
-        ++ optionalTop pkgs "swappy"
-        ++ optionalTop pkgs "tesseract"
-        ++ optionalTop pkgs "translate-shell"
-        ++ optionalTop pkgs "upower"
-        ++ optionalTop pkgs "wf-recorder"
-        ++ optionalTop pkgs "wlsunset"
-        ++ optionalTop pkgs "wtype"
-        ++ optionalTop pkgs "xwayland-satellite"
-        ++ optionalTop pkgs "ydotool"
-        ++ optionalKde pkgs "breeze-icons"
-        ++ optionalKde pkgs "kdialog"
-        ++ optionalKde pkgs "kirigami"
-        ++ optionalKde pkgs "kconfig"
-        ++ optionalKde pkgs "plasma-integration"
-        ++ optionalKde pkgs "syntax-highlighting"
-        ++ optionalKde pkgs "xembedsniproxy"
-        ++ optionalQt6 pkgs "qt5compat"
-        ++ optionalQt6 pkgs "qtbase"
-        ++ optionalQt6 pkgs "qtdeclarative"
-        ++ optionalQt6 pkgs "qtimageformats"
-        ++ optionalQt6 pkgs "qtmultimedia"
-        ++ optionalQt6 pkgs "qtpositioning"
-        ++ optionalQt6 pkgs "qtquicktimeline"
-        ++ optionalQt6 pkgs "qtsensors"
-        ++ optionalQt6 pkgs "qtsvg"
-        ++ optionalQt6 pkgs "qttools"
-        ++ optionalQt6 pkgs "qttranslations"
-        ++ optionalQt6 pkgs "qtvirtualkeyboard"
-        ++ optionalQt6 pkgs "qtwayland";
-
-      qmlDeps = pkgs:
-        # kirigami-wrapped ships no QML files, use the unwrapped version
-        (lib.optional
-          (builtins.hasAttr "kdePackages" pkgs && builtins.hasAttr "kirigami" pkgs.kdePackages)
-          pkgs.kdePackages.kirigami.passthru.unwrapped)
-        ++ optionalKde pkgs "syntax-highlighting"
-        ++ optionalQt6 pkgs "qt5compat"
-        ++ optionalQt6 pkgs "qtdeclarative"
-        ++ optionalQt6 pkgs "qtimageformats"
-        ++ optionalQt6 pkgs "qtmultimedia"
-        ++ optionalQt6 pkgs "qtpositioning"
-        ++ optionalQt6 pkgs "qtquicktimeline"
-        ++ optionalQt6 pkgs "qtsensors"
-        ++ optionalQt6 pkgs "qtsvg"
-        ++ optionalQt6 pkgs "qtvirtualkeyboard"
-        ++ optionalQt6 pkgs "qtwayland";
-
-      mkPackage = pkgs:
-        pkgs.stdenvNoCC.mkDerivation {
-          pname = "inir";
-          version = lib.removeSuffix "\n" (builtins.readFile ./VERSION);
-          src = lib.cleanSource ./.;
-
-          nativeBuildInputs = [ pkgs.makeWrapper ];
-
-          # Prevent patchShebangs from attempting to rewrite Python scripts;
-          # non-executable files are skipped during fixupPhase.
-          preFixup = ''
-            find "$out/share/quickshell/inir" -type f -name '*.py' -exec chmod -x {} +
-          '';
-
-          postFixup = ''
-            find "$out/share/quickshell/inir" -type f -name '*.py' -exec chmod +x {} +
-          '';
-
-          installPhase =
-            let
-              deps = runtimeDeps pkgs;
-              qml = qmlDeps pkgs;
-            in
-            ''
-              runHook preInstall
-
-              runtime="$out/share/quickshell/inir"
-              mkdir -p "$runtime" "$out/bin"
-
-              while IFS= read -r path; do
-                [ -n "$path" ] || continue
-                install -Dm644 "$path" "$runtime/$path"
-              done < sdata/runtime-root-files.txt
-
-              while IFS= read -r dir; do
-                [ -n "$dir" ] || continue
-                cp -R "$dir" "$runtime/$dir"
-              done < sdata/runtime-payload-dirs.txt
-
-              # Copy root-level QML entry points (shell.qml, settings.qml, etc.)
-              # which aren't listed in runtime-root-files.txt.
-              for f in *.qml; do
-                [ -f "$f" ] || continue
-                install -Dm644 "$f" "$runtime/$f"
-              done
-
-              chmod +x "$runtime/setup" "$runtime/scripts/inir"
-              find "$runtime/scripts" -type f \( -name '*.sh' -o -name '*.fish' -o -name '*.py' \) -exec chmod +x {} \;
-
-              # The source tree intentionally targets Arch, where helpers live
-              # under /usr/bin. NixOS does not provide that layout. Patch only
-              # the packaged copy and keep shebang lines intact.
-              find "$runtime/modules" "$runtime/services" "$runtime/defaults" "$runtime/scripts" \
-                -type f \( -name '*.qml' -o -name '*.js' -o -name '*.sh' -o -name '*.py' \) \
-                -exec sed -i '1!s#/usr/bin/##g' {} +
-
-              makeWrapper "$runtime/scripts/inir" "$out/bin/inir" \
-                --prefix PATH : "${lib.makeBinPath deps}" \
-                --prefix QML2_IMPORT_PATH : "${lib.makeSearchPath "lib/qt-6/qml" qml}" \
-                --prefix QT_PLUGIN_PATH : "${lib.makeSearchPath "lib/qt-6/plugins" qml}" \
-                --set-default INIR_SYSTEM_RUNTIME_DIR "$runtime" \
-                --set-default INIR_FALLBACK_SYSTEM_RUNTIME_DIR "$runtime"
-
-              runHook postInstall
-            '';
-
-          passthru.runtimeDependencies = runtimeDeps pkgs;
-
-          meta = {
-            description = "Complete desktop shell for Niri, built on Quickshell";
-            homepage = "https://github.com/snowarch/inir";
-            license = lib.licenses.gpl3Only;
-            platforms = lib.platforms.linux;
-            mainProgram = "inir";
-          };
-        };
-
-      commonOptions = { config, lib, pkgs, ... }:
-        let
-          cfg = config.programs.inir;
-          defaultPackage = self.packages.${pkgs.system}.default;
-        in
-        {
-          options.programs.inir = {
-            enable = lib.mkEnableOption "iNiR desktop shell";
-
-            package = lib.mkOption {
-              type = lib.types.package;
-              default = defaultPackage;
-              defaultText = lib.literalExpression "inputs.inir.packages.${pkgs.system}.default";
-              description = "iNiR package to install and run.";
-            };
-
-            extraPackages = lib.mkOption {
-              type = lib.types.listOf lib.types.package;
-              default = [ ];
-              description = "Extra runtime packages made available to the iNiR service.";
-            };
-
-            service = {
-              enable = lib.mkOption {
-                type = lib.types.bool;
-                default = true;
-                description = "Create the inir systemd user service.";
-              };
-
-              compositor = lib.mkOption {
-                type = lib.types.nullOr (lib.types.enum [ "niri" "hyprland" ]);
-                default = "niri";
-                description = "Compositor user unit that should want inir.service. Set null to create the unit without auto-start wiring.";
-              };
-            };
-          };
-        };
-
-      compositorUnit = compositor:
-        if compositor == "niri" then "niri.service"
-        else if compositor == "hyprland" then "wayland-wm@Hyprland.service"
-        else null;
-
-      serviceEnvironment = cfg: {
-        INIR_SYSTEM_RUNTIME_DIR = "${cfg.package}/share/quickshell/inir";
-        INIR_FALLBACK_SYSTEM_RUNTIME_DIR = "${cfg.package}/share/quickshell/inir";
-        QS_DISABLE_CRASH_HANDLER = "1";
-        QT_LOGGING_RULES = "quickshell.dbus.properties=false;qt.qml.settings.warning=false;qt.core.qsettings.warning=false;kf.xmlgui=false;kf.coreaddons=false;kf.config.core=false;kf.iconthemes=false";
-        QT_SCALE_FACTOR = "1";
-        QT_SCALE_FACTOR_ROUNDING_POLICY = "RoundPreferFloor";
-      };
-
-      mkNixosModule = { config, lib, pkgs, ... }:
-        let
-          cfg = config.programs.inir;
-          wantedUnit = compositorUnit cfg.service.compositor;
-        in
-        {
-          # commonOptions is itself a module; merging it via mkMerge would put
-          # its `options` declarations on the config side and fail evaluation.
-          imports = [ commonOptions ];
-
-          config = lib.mkIf cfg.enable {
-              environment.systemPackages = [ cfg.package ];
-
-              systemd.user.services.inir = lib.mkIf cfg.service.enable {
-                description = "iNiR shell";
-                wantedBy = lib.optional (wantedUnit != null) wantedUnit;
-                partOf = [ "graphical-session.target" ];
-                after = [ "graphical-session.target" ];
-                path = [ cfg.package ] ++ cfg.extraPackages;
-                environment = serviceEnvironment cfg;
-                unitConfig = {
-                  Requisite = "graphical-session.target";
-                  StartLimitIntervalSec = 30;
-                  StartLimitBurst = 3;
-                };
-                serviceConfig = {
-                  Type = "simple";
-                  ExecStart = "${lib.getExe cfg.package} run --session";
-                  ExecStopPost = "-${lib.getExe cfg.package} cleanup-orphans";
-                  SuccessExitStatus = 143;
-                  KillMode = "process";
-                  KillSignal = "SIGTERM";
-                  Restart = "on-failure";
-                  RestartSec = 5;
-                  TimeoutStopSec = 15;
-                  LimitCORE = 0;
-                  IOSchedulingPriority = 2;
-                };
-              };
-            };
-          };
-
-      mkHomeModule = { config, lib, pkgs, ... }:
-        let
-          cfg = config.programs.inir;
-          wantedUnit = compositorUnit cfg.service.compositor;
-          env = serviceEnvironment cfg;
-        in
-        {
-          imports = [ commonOptions ];
-
-          options.programs.inir.configSymlink = {
-              enable = lib.mkOption {
-                type = lib.types.bool;
-                default = false;
-                description = "Expose the packaged shell at ~/.config/quickshell/inir for tools that expect the traditional path.";
-              };
-            };
-
-            config = lib.mkIf cfg.enable {
-              home.packages = [ cfg.package ];
-
-              xdg.configFile = lib.mkIf cfg.configSymlink.enable {
-                "quickshell/inir".source = "${cfg.package}/share/quickshell/inir";
-              };
-
-              systemd.user.services.inir = lib.mkIf cfg.service.enable {
-                Unit = {
-                  Description = "iNiR shell";
-                  PartOf = [ "graphical-session.target" ];
-                  After = [ "graphical-session.target" ];
-                  Requisite = [ "graphical-session.target" ];
-                  StartLimitIntervalSec = 30;
-                  StartLimitBurst = 3;
-                };
-
-                Service = {
-                  Type = "simple";
-                  Environment = lib.mapAttrsToList (name: value: "${name}=${value}") env;
-                  ExecStart = "${lib.getExe cfg.package} run --session";
-                  ExecStopPost = "-${lib.getExe cfg.package} cleanup-orphans";
-                  SuccessExitStatus = 143;
-                  KillMode = "process";
-                  KillSignal = "SIGTERM";
-                  Restart = "on-failure";
-                  RestartSec = 5;
-                  TimeoutStopSec = 15;
-                  LimitCORE = 0;
-                  IOSchedulingPriority = 2;
-                };
-
-                Install.WantedBy = lib.optional (wantedUnit != null) wantedUnit;
-              };
-            };
-          };
+      forAllSystems = f: lib.genAttrs systems f;
     in
     {
-      packages = forAllSystems (pkgs: {
-        default = mkPackage pkgs;
-        inir = self.packages.${pkgs.system}.default;
+      packages = forAllSystems (system: {
+        inir = defaultOutputs.package { pkgs = import nixpkgs { inherit system; }; };
+        default = self.packages.${system}.inir;
       });
 
-      nixosModules.default = mkNixosModule;
-      nixosModules.inir = mkNixosModule;
+      nixosModules = {
+        inir = defaultOutputs.nixosModule;
+        default = self.nixosModules.inir;
+      };
 
-      homeModules.default = mkHomeModule;
-      homeModules.inir = mkHomeModule;
+      homeModules = {
+        inir = defaultOutputs.homeManagerModule;
+        default = self.homeModules.inir;
+      };
 
       # Conventional alias most Home Manager setups look for.
-      homeManagerModules.default = mkHomeModule;
-      homeManagerModules.inir = mkHomeModule;
+      homeManagerModules = {
+        inir = defaultOutputs.homeManagerModule;
+        default = self.homeManagerModules.inir;
+      };
 
-      formatter = forAllSystems (pkgs: pkgs.nixpkgs-fmt);
+      formatter = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.nixpkgs-fmt
+      );
     };
 }


### PR DESCRIPTION
<!-- PRs target the `prerelease` branch (development). `main` is the stable branch users install from. -->

## Summary

I broke off the Nix package, NixOS module, and Home Manager module into separate Nix files under `distro/nixos` instead of having them all defined in `flake.nix`. These files are imported in the now minimal `flake.nix`, so the outputs can still be accessed with the flake. I also added `default.nix` as an entrypoint for Nix code that doesn't use flakes.

## Testing

Describe what you ran and what you observed, not just "it works".

- [ ] `inir restart && inir logs`: no new errors
- [x] Exercised the exact flow that changed
- [ ] Both panel families checked (if shared code changed)
- [ ] Screenshots or a recording attached (if the change is visual)

I tested building the package with and without flakes. I also tested the NixOS and Home Manager modules.

## AI usage

Most of us use AI tools now, that's fine, just be upfront so review can
focus on the right things:

- [ ] AI-assisted (tool/model: <!-- e.g. Claude Code / Cursor / Copilot -->)
- [ ] I removed AI attributions and boilerplate (co-author trailers, "generated with" footers, narrating comments)
- [x] I reviewed and understand every line of this diff myself

I did not use AI tools.

## Notes

I also added a fontconfig file that searches `material-symbols` for fonts to the iNiR wrapper because iNiR requires the font. In the NixOS and Home Manager modules, I renamed the `programs.inir.service.enable` option to `programs.inir.systemd.enable` to be more consistent with other NixOS modules' option names and replaced `programs.inir.service.compositor` with `programs.inir.systemd.wantedUnit`.

Closes #216
