### PR TITLE
fix(windows): resolve shared app identities per window

### DIFF
--- a/defaults/config.json
+++ b/defaults/config.json
@@ -1812,7 +1812,8 @@
     },
     "windows": {
         "centerTitle": true,
-        "showTitlebar": true
+        "showTitlebar": true,
+        "appIdentityRules": []
     },
     "workSafety": {
         "enable": {

--- a/docs/CONFIG_SYSTEM.md
+++ b/docs/CONFIG_SYSTEM.md
@@ -120,6 +120,34 @@ The full schema is `modules/common/Config.qml`. The full defaults are `defaults/
 
 ## Common keys people actually ask about
 
+### Per-window app identity
+
+Some applications give every window the same compositor `app_id`, even when
+the windows represent separate desktop applications (browser PWAs are a
+common example). `windows.appIdentityRules` can map those windows to the
+desktop entry that should own them:
+
+```json
+{
+  "windows": {
+    "appIdentityRules": [
+      {
+        "appIdRegex": "^browser$",
+        "titleRegex": "^Example PWA(?: |$)",
+        "desktopId": "example-pwa"
+      }
+    ]
+  }
+}
+```
+
+Rules are case-insensitive, the first matching rule wins, and at least one of
+`appIdRegex` or `titleRegex` is required. Malformed rules are ignored. The
+setting is empty by default and is intentionally advanced: the compositor
+does not expose enough metadata to distinguish every PWA from a normal tab
+automatically. `desktopId` should match an installed `.desktop` entry so the
+matching icon, name, launcher, and taskbar grouping are used.
+
 ### Bar layout
 
 `bar.layout` controls the modular ii bar:

--- a/modules/altSwitcher/AltSwitcher.qml
+++ b/modules/altSwitcher/AltSwitcher.qml
@@ -206,8 +206,11 @@ Scope {
 
         for (let i = 0; i < windows.length; i++) {
             const w = windows[i]
-            const appId = w.app_id || ""
+            const appId = AppSearch.resolveWindowIdentity(w)
             let appName = appId
+            const resolvedEntry = AppSearch.lookupDesktopEntry(appId)
+            if (resolvedEntry?.name)
+                appName = resolvedEntry.name
             if (appName && appName.indexOf(".") !== -1) {
                 const parts = appName.split(".")
                 appName = parts[parts.length - 1]
@@ -1906,9 +1909,9 @@ Scope {
             const wins = NiriService.windows || []
             for (let i = 0; i < wins.length; i++) {
                 const w = wins[i]
-                const key = w.app_id || ""
+                const key = AppSearch.resolveWindowIdentity(w)
                 if (key && root.iconCache[key] === undefined) {
-                    root.getCachedIcon(w.app_id, "", w.title)
+                    root.getCachedIcon(key, "", w.title)
                 }
             }
         }

--- a/modules/altSwitcher/AltSwitcherNoVisual.qml
+++ b/modules/altSwitcher/AltSwitcherNoVisual.qml
@@ -76,7 +76,7 @@ Scope {
         const itemsById = ({})
         for (let i = 0; i < windows.length; ++i) {
             const window = windows[i]
-            const appId = window.app_id ?? ""
+            const appId = AppSearch.resolveWindowIdentity(window)
             const item = {
                 id: window.id,
                 appId: appId,

--- a/modules/bar/BarTaskbar.qml
+++ b/modules/bar/BarTaskbar.qml
@@ -199,7 +199,8 @@ Item {
         const runningAppsMap = new Map();
         for (const toplevel of allToplevels) {
             if (!toplevel.appId || toplevel.appId === "" || toplevel.appId === "null") continue;
-            if (ignoredRegexes.some(re => re.test(toplevel.appId))) continue;
+            const effectiveId = AppSearch.resolveWindowIdentity(toplevel);
+            if (ignoredRegexes.some(re => re.test(effectiveId))) continue;
             if (crossCheck) {
                 const key = root._toplevelLiveKey(toplevel);
                 const count = liveToplevelCounts.get(key) ?? 0;
@@ -207,10 +208,10 @@ Item {
                 liveToplevelCounts.set(key, count - 1);
             }
 
-            const lowerAppId = toplevel.appId.toLowerCase();
+            const lowerAppId = effectiveId.toLowerCase();
             if (!runningAppsMap.has(lowerAppId)) {
                 runningAppsMap.set(lowerAppId, {
-                    appId: toplevel.appId,
+                    appId: effectiveId,
                     toplevels: [],
                     pinned: false
                 });
@@ -355,6 +356,10 @@ Item {
         target: Config.options?.dock
         function onPinnedAppsChanged() { root.rebuildDockItems() }
         function onIgnoredAppRegexesChanged() { root.rebuildDockItems() }
+    }
+    Connections {
+        target: Config.options?.windows
+        function onAppIdentityRulesChanged() { root.rebuildDockItems() }
     }
     Component.onCompleted: {
         CompositorService.acquireSortingConsumer()

--- a/modules/bar/BarTaskbarPreview.qml
+++ b/modules/bar/BarTaskbarPreview.qml
@@ -77,7 +77,10 @@ PopupWindow {
             const allToplevels = CompositorService.sortedToplevels && CompositorService.sortedToplevels.length
                     ? CompositorService.sortedToplevels
                     : ToplevelManager.toplevels.values;
-            const current = allToplevels.filter(t => t.appId && t.appId.toLowerCase() === appId)
+            const current = allToplevels.filter(t => {
+                const id = AppSearch.resolveWindowIdentity(t)
+                return id && id.toLowerCase() === appId
+            })
             if (current.length === 0) {
                 root.close()
             } else {

--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -3069,6 +3069,12 @@ Singleton {
             property JsonObject windows: JsonObject {
                 property bool showTitlebar: true // Client-side decoration for shell apps
                 property bool centerTitle: true
+                // Optional per-window identity remapping for apps whose windows
+                // all share one app_id (e.g. browser PWA windows). Each entry:
+                // { appIdRegex, titleRegex, desktopId } — both regexes are
+                // optional but at least one is required. The first matching
+                // rule wins; malformed rules are ignored; empty = no changes.
+                property list<var> appIdentityRules: []
             }
 
             property JsonObject settingsUi: JsonObject {

--- a/modules/dock/DockApps.qml
+++ b/modules/dock/DockApps.qml
@@ -409,15 +409,16 @@ Item {
                 if (count <= 0) continue;
                 liveToplevelCounts.set(key, count - 1);
             }
-            const lowerAppId = toplevel.appId.toLowerCase();
+            const effectiveId = AppSearch.resolveWindowIdentity(toplevel);
+            const lowerAppId = effectiveId.toLowerCase();
 
-            if (ignoredRegexes.some(re => re.test(toplevel.appId))) {
+            if (ignoredRegexes.some(re => re.test(effectiveId))) {
                 continue;
             }
 
             if (!runningAppsMap.has(lowerAppId)) {
                 runningAppsMap.set(lowerAppId, {
-                    appId: toplevel.appId,
+                    appId: effectiveId,
                     toplevels: [],
                     pinned: false
                 });
@@ -592,6 +593,13 @@ Item {
             root.rebuildDockItems()
         }
         function onIgnoredAppRegexesChanged() {
+            root.rebuildDockItems()
+        }
+    }
+    Connections {
+        target: Config.options?.windows
+        enabled: root.enabled
+        function onAppIdentityRulesChanged() {
             root.rebuildDockItems()
         }
     }

--- a/modules/dock/DockWindowPreview.qml
+++ b/modules/dock/DockWindowPreview.qml
@@ -66,7 +66,7 @@ Button {
                 id: appIcon
                 Layout.alignment: Qt.AlignVCenter
                 source: {
-                    const appId = root.toplevel?.appId ?? "";
+                    const appId = AppSearch.resolveWindowIdentity(root.toplevel);
                     const de = AppSearch.lookupDesktopEntry(appId);
                     const icon = de?.icon || AppSearch.guessIcon(appId);
                     const resolved = IconThemeService.smartIconName(icon, appId);

--- a/modules/waffle/taskview/WaffleTaskViewContent.qml
+++ b/modules/waffle/taskview/WaffleTaskViewContent.qml
@@ -51,7 +51,7 @@ Item {
         const query = searchQuery.toLowerCase()
         return cachedWindowItems.filter(w => {
             const title = (w.window.title ?? "").toLowerCase()
-            const appId = (w.window.app_id ?? "").toLowerCase()
+            const appId = (AppSearch.resolveWindowIdentity(w.window) ?? "").toLowerCase()
             return title.includes(query) || appId.includes(query)
         })
     }
@@ -216,7 +216,7 @@ Item {
                 result.push({
                     window: {
                         id: win.id,
-                        app_id: win.app_id,
+                        app_id: AppSearch.resolveWindowIdentity(win),
                         title: win.title,
                         workspace_id: win.workspace_id,
                         is_focused: win.is_focused

--- a/services/AppSearch.qml
+++ b/services/AppSearch.qml
@@ -528,6 +528,67 @@ Singleton {
         return null;
     }
 
+    // Optional per-window identity rules (Config.options.windows.appIdentityRules).
+    // Apps whose windows all report the same app_id (e.g. browser PWA windows)
+    // can be grouped and displayed under a different desktop entry. Each rule:
+    //   { appIdRegex, titleRegex, desktopId }
+    // Both regexes are optional but at least one is required; the first
+    // matching rule wins; malformed rules are silently ignored. Empty rules
+    // leave every window's identity untouched. The configured desktopId is
+    // intentionally not resolved during parsing: desktop entries can load
+    // after the first window event.
+    property var _identityRules: []
+    property var _identityRulesKey: null
+
+    function _parseIdentityRules(): var {
+        const rules = Config.options?.windows?.appIdentityRules ?? []
+        const key = JSON.stringify(rules)
+        if (root._identityRulesKey === key)
+            return root._identityRules
+        const parsed = []
+        for (const rule of rules) {
+            if (!rule || typeof rule !== "object") continue
+            const desktopId = String(rule.desktopId ?? "").trim()
+            if (desktopId.length === 0) continue
+            const wantsAppIdRe = rule.appIdRegex !== undefined && rule.appIdRegex !== null
+                && String(rule.appIdRegex).length > 0
+            const wantsTitleRe = rule.titleRegex !== undefined && rule.titleRegex !== null
+                && String(rule.titleRegex).length > 0
+            if (!wantsAppIdRe && !wantsTitleRe) continue
+            let appIdRe = null
+            let titleRe = null
+            let valid = true
+            if (wantsAppIdRe) {
+                try { appIdRe = new RegExp(String(rule.appIdRegex), "i") } catch (e) { valid = false }
+            }
+            if (wantsTitleRe) {
+                try { titleRe = new RegExp(String(rule.titleRegex), "i") } catch (e) { valid = false }
+            }
+            if (!valid) continue
+            parsed.push({ appIdRe: appIdRe, titleRe: titleRe, desktopId: desktopId })
+        }
+        root._identityRules = parsed
+        root._identityRulesKey = key
+        return parsed
+    }
+
+    // Resolve the display identity of a running window. Accepts foreign-toplevel
+    // handles (appId) and Niri window objects (app_id) alike. Returns the
+    // window's reported app_id unless a configured rule remaps it.
+    function resolveWindowIdentity(toplevel): string {
+        const appId = String(toplevel?.appId ?? toplevel?.app_id ?? "")
+        if (appId.length === 0) return appId
+        const rules = root._parseIdentityRules()
+        if (rules.length === 0) return appId
+        const title = String(toplevel?.title ?? "")
+        for (const rule of rules) {
+            if (rule.appIdRe && !rule.appIdRe.test(appId)) continue
+            if (rule.titleRe && !rule.titleRe.test(title)) continue
+            return rule.desktopId
+        }
+        return appId
+    }
+
     function guessIcon(str) {
         if (!str || str.length == 0) return "image-missing";
 

--- a/services/TaskbarApps.qml
+++ b/services/TaskbarApps.qml
@@ -11,6 +11,14 @@ Singleton {
 
     readonly property bool sortingEnabled:
         (Config.options?.panelFamily ?? "ii") === "waffle"
+    property int _identityRulesRevision: 0
+
+    Connections {
+        target: Config.options?.windows
+        function onAppIdentityRulesChanged() {
+            root._identityRulesRevision++
+        }
+    }
 
     function syncSortingDemand(): void {
         CompositorService.setSortingConsumer("waffleTaskbar",
@@ -30,6 +38,7 @@ Singleton {
     }
 
     property list<var> apps: {
+        const identityRulesRevision = root._identityRulesRevision;
         var map = new Map();
 
         // Pinned apps
@@ -70,7 +79,7 @@ Singleton {
 
         // Open windows
         for (const toplevel of sourceToplevels) {
-            const appId = String(toplevel?.appId ?? "");
+            const appId = AppSearch.resolveWindowIdentity(toplevel);
             if (appId.length === 0 || ignoredRegexes.some(re => re.test(appId)))
                 continue;
             const lowerAppId = appId.toLowerCase();


### PR DESCRIPTION
## Summary

Add opt-in `windows.appIdentityRules` for applications whose windows share one compositor `app_id` but represent different desktop applications, such as browser PWAs.

The resolver is applied consistently to ii and Waffle taskbars, dock grouping, previews, task view search data, Alt+Tab, icons, and launch identity. Alt+Tab uses the matched desktop entry name and icon instead of exposing a generated desktop ID.

The default rule list is empty. No application-specific IDs or titles are included in the project.

## Testing

- [x] `bash scripts/test-local-distribution.sh`: all local distribution checks passed
- [x] `qmllint -I .` on all changed QML files: passed
- [x] `node /tmp/opencode/identity-rules.test.js`: 13 assertions passed, including malformed regex and both Niri/foreign-toplevel shapes
- [x] Real niri smoke test: shared Thorium windows resolved into browser, WhatsApp, and Suwayomi identities
- [x] ii panel family checked with dock and Alt+Tab screenshot
- [x] Waffle panel family switched and restored; no new QML errors
- [x] `inir restart` and service health checked; only pre-existing PipeWire warning remained

## AI usage

- [x] AI-assisted (OpenCode / GPT-5.6 Luna)
- [x] I removed AI attributions and boilerplate (co-author trailers, "generated with" footers, narrating comments)
- [x] I reviewed and understand every line of this diff myself

## Notes

No linked issue. A local screenshot was captured while verifying Alt+Tab labels and icons.
