### PR TITLE
TLP intergrated in Quickshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,17 @@ ICON_DIR = $(SHAREDIR)/icons/hicolor/scalable/apps
 SHELL_INSTALL_DIR = $(SHAREDIR)/quickshell/inir
 DOC_DIR = $(SHAREDIR)/doc/inir-shell
 SYSTEMD_USER_DIR ?= $(PREFIX)/lib/systemd/user
+LIBEXECDIR ?= /usr/libexec
+POLKIT_ACTIONS_DIR ?= /usr/share/polkit-1/actions
+TLP_CONFDIR ?= /etc/tlp.d
+INIR_SYSTEM_SHAREDIR ?= /usr/share/inir
+BATTERY_HELPER = $(LIBEXECDIR)/inir-battery-charge-limit
+BATTERY_POLICY = $(POLKIT_ACTIONS_DIR)/org.inir.battery-charge-limit.policy
+BATTERY_DROPIN = $(TLP_CONFDIR)/99-inir-battery-charge-limit.conf
+TLP_SETTINGS_DROPIN = $(TLP_CONFDIR)/99-inir-tlp-settings.conf
+TLP_SETTINGS_SCHEMA = $(INIR_SYSTEM_SHAREDIR)/tlp-settings-schema.json
 
-.PHONY: all build test-local install install-bin install-shell install-systemd install-icon install-desktop install-docs uninstall uninstall-bin uninstall-shell uninstall-systemd uninstall-icon uninstall-desktop uninstall-docs
+.PHONY: all build test-local test-battery-helper install install-bin install-shell install-systemd install-icon install-desktop install-docs install-battery-helper uninstall uninstall-bin uninstall-shell uninstall-systemd uninstall-icon uninstall-desktop uninstall-docs uninstall-battery-helper
 
 all: build
 
@@ -19,6 +28,9 @@ build:
 
 test-local: build
 	@bash scripts/test-local-distribution.sh
+
+test-battery-helper:
+	@sh scripts/test-battery-charge-limit-helper.sh
 
 install-bin:
 	@install -Dm755 scripts/inir $(BINDIR)/inir
@@ -47,7 +59,7 @@ install-shell:
 	@rm -rf $(SHELL_INSTALL_DIR)/assets/images/mascot/frames
 	@# Strip maintainer and development tooling — useless on a user's machine
 	@rm -rf $(SHELL_INSTALL_DIR)/scripts/agents $(SHELL_INSTALL_DIR)/translations/tools $(SHELL_INSTALL_DIR)/translations/l10n
-	@rm -f $(SHELL_INSTALL_DIR)/scripts/release.sh $(SHELL_INSTALL_DIR)/scripts/wiki-sync.sh $(SHELL_INSTALL_DIR)/scripts/verify-docs.sh $(SHELL_INSTALL_DIR)/scripts/qml-check.fish $(SHELL_INSTALL_DIR)/scripts/test-local-distribution.sh $(SHELL_INSTALL_DIR)/scripts/test-mascot-pack-flow.sh
+	@rm -f $(SHELL_INSTALL_DIR)/scripts/release.sh $(SHELL_INSTALL_DIR)/scripts/wiki-sync.sh $(SHELL_INSTALL_DIR)/scripts/verify-docs.sh $(SHELL_INSTALL_DIR)/scripts/qml-check.fish $(SHELL_INSTALL_DIR)/scripts/test-local-distribution.sh $(SHELL_INSTALL_DIR)/scripts/test-mascot-pack-flow.sh $(SHELL_INSTALL_DIR)/scripts/test-battery-charge-limit-helper.sh $(SHELL_INSTALL_DIR)/scripts/test-tlp-integration-lifecycle.sh
 	@find $(SHELL_INSTALL_DIR)/scripts -type f \( -name "*.sh" -o -name "*.fish" -o -name "*.py" \) -exec chmod +x {} +
 	@printf '{\n  "version": "%s",\n  "commit": "manual",\n  "installed_at": "%s",\n  "installedAt": "%s",\n  "source": "make-install",\n  "repo_path": "",\n  "repoPath": "",\n  "install_mode": "package-managed",\n  "installMode": "package-managed",\n  "update_strategy": "package-manager",\n  "updateStrategy": "package-manager",\n  "package_manager": "manual",\n  "packageManager": "manual",\n  "package_name": "source-install",\n  "packageName": "source-install",\n  "package_update_hint": "sudo make install",\n  "packageUpdateHint": "sudo make install"\n}\n' "$$(cat VERSION)" "$$(date -Iseconds)" "$$(date -Iseconds)" > $(SHELL_INSTALL_DIR)/version.json
 
@@ -72,7 +84,12 @@ install-docs:
 	@install -Dm644 docs/SETUP.md $(DOC_DIR)/SETUP.md
 	@install -Dm644 docs/IPC.md $(DOC_DIR)/IPC.md
 
-install: build install-bin install-shell install-systemd install-icon install-desktop install-docs
+install-battery-helper:
+	@install -Dm755 assets/helpers/inir-battery-charge-limit "$(DESTDIR)$(BATTERY_HELPER)"
+	@install -Dm644 assets/polkit/org.inir.battery-charge-limit.policy "$(DESTDIR)$(BATTERY_POLICY)"
+	@install -Dm644 assets/tlp/tlp-settings-schema.json "$(DESTDIR)$(TLP_SETTINGS_SCHEMA)"
+
+install: build install-bin install-shell install-systemd install-icon install-desktop install-docs install-battery-helper
 
 uninstall-bin:
 	@rm -f $(BINDIR)/inir
@@ -94,4 +111,13 @@ uninstall-desktop:
 uninstall-docs:
 	@rm -rf $(DOC_DIR)
 
-uninstall: uninstall-systemd uninstall-desktop uninstall-icon uninstall-docs uninstall-shell uninstall-bin
+uninstall-battery-helper:
+	@if [ -z "$(DESTDIR)" ] && [ -x "$(BATTERY_HELPER)" ]; then \
+		"$(BATTERY_HELPER)" --config-reset >/dev/null 2>&1 || true; \
+		"$(BATTERY_HELPER)" --disable >/dev/null 2>&1 || true; \
+	fi
+	@rm -f "$(DESTDIR)$(BATTERY_DROPIN)"
+	@rm -f "$(DESTDIR)$(TLP_SETTINGS_DROPIN)"
+	@rm -f "$(DESTDIR)$(BATTERY_HELPER)" "$(DESTDIR)$(BATTERY_POLICY)" "$(DESTDIR)$(TLP_SETTINGS_SCHEMA)"
+
+uninstall: uninstall-systemd uninstall-desktop uninstall-icon uninstall-docs uninstall-shell uninstall-bin uninstall-battery-helper

--- a/assets/helpers/inir-battery-charge-limit
+++ b/assets/helpers/inir-battery-charge-limit
@@ -1,0 +1,1734 @@
+#!/bin/sh
+
+# iNiR owns only this TLP drop-in. Hardware access and vendor semantics remain
+# TLP's responsibility.
+config_dir=/etc/tlp.d
+config_file="$config_dir/99-inir-battery-charge-limit.conf"
+
+# General TLP settings use a separate iNiR-owned drop-in. Keeping battery-care
+# ownership separate means disabling a charge limit can never discard unrelated
+# power settings staged from the Quickshell settings page.
+tlp_settings_config_file="$config_dir/99-inir-tlp-settings.conf"
+tlp_settings_schema=/usr/share/inir/tlp-settings-schema.json
+tlp_settings_lock=/run/lock/inir-tlp-settings.lock
+
+# TLP 1.10 writes PLATFORM_PROFILE_* to this kernel ABI and TLP 1.11 reads
+# platform_profile_choices before selecting from an ordered fallback list. Keep
+# the same ABI as the runtime authority instead of maintaining a vendor list.
+# Regression tests source this helper and may replace the path with a fixture.
+platform_profile_choices_file=/sys/firmware/acpi/platform_profile_choices
+
+tlp_bin=""
+tlp_lib_dir=""
+
+managed=0
+managed_battery=""
+managed_start=""
+managed_stop=""
+
+available=0
+supported=0
+state_known=0
+active=0
+reason=""
+
+probe_version=""
+probe_enabled=""
+probe_plugin=""
+probe_method=""
+probe_variant=""
+probe_battery=""
+probe_config_battery=""
+probe_current_start=""
+probe_current_stop=""
+probe_start_values=""
+probe_stop_values=""
+
+start_kind="none"
+start_min=""
+start_max=""
+start_step=1
+start_values=""
+start_required=0
+minimum_gap=0
+
+stop_kind="none"
+stop_min=""
+stop_max=""
+stop_step=1
+stop_values=""
+fixed_limit=""
+
+tmp_file=""
+backup_file=""
+had_config=0
+
+tlp_settings_tmp_file=""
+tlp_settings_backup_file=""
+tlp_settings_had_config=0
+
+usage() {
+    printf '%s\n' 'Usage: inir-battery-charge-limit --status | --set <value> | --disable' >&2
+    printf '%s\n' '       inir-battery-charge-limit --config-status | --config-apply <operations...> | --config-reset' >&2
+    printf '%s\n' '       config operations: --set <key> <value> | --unset <key> | --charge-set <value> | --charge-disable' >&2
+    return 2
+}
+
+cleanup() {
+    [ -z "$tmp_file" ] || rm -f -- "$tmp_file"
+    [ -z "$backup_file" ] || rm -f -- "$backup_file"
+    [ -z "$tlp_settings_tmp_file" ] || rm -f -- "$tlp_settings_tmp_file"
+    [ -z "$tlp_settings_backup_file" ] || rm -f -- "$tlp_settings_backup_file"
+}
+
+is_uint() {
+    case "${1:-}" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+bool_json() {
+    if [ "${1:-0}" -eq 1 ]; then
+        printf true
+    else
+        printf false
+    fi
+}
+
+number_json() {
+    if is_uint "${1:-}"; then
+        printf '%s' "$1"
+    else
+        printf null
+    fi
+}
+
+token_json() {
+    # Values passed here are TLP version/plugin identifiers or our own reason
+    # codes. Restrict them to a JSON-safe identifier alphabet.
+    printf '"%s"' "$(printf '%s' "${1:-}" | tr -cd 'A-Za-z0-9._+:/-')"
+}
+
+number_array_json() {
+    local separator=""
+    local value
+
+    printf '['
+    for value in ${1:-}; do
+        is_uint "$value" || continue
+        printf '%s%s' "$separator" "$value"
+        separator=,
+    done
+    printf ']'
+}
+
+normalize_number_list() {
+    local output=""
+    local value
+
+    for value in ${1:-}; do
+        is_uint "$value" || continue
+        output="${output}${output:+ }${value}"
+    done
+    printf '%s' "$output"
+}
+
+read_managed_policy() {
+    local line key value
+
+    managed=0
+    managed_battery=""
+    managed_start=""
+    managed_stop=""
+
+    [ -f "$config_file" ] || return 0
+    managed=1
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        key=${line%%=*}
+        value=${line#*=}
+        case "$key" in
+            START_CHARGE_THRESH_BAT0|START_CHARGE_THRESH_BAT1)
+                is_uint "$value" || continue
+                managed_battery=${key#START_CHARGE_THRESH_}
+                managed_start=$value
+                ;;
+            STOP_CHARGE_THRESH_BAT0|STOP_CHARGE_THRESH_BAT1)
+                is_uint "$value" || continue
+                managed_battery=${key#STOP_CHARGE_THRESH_}
+                managed_stop=$value
+                ;;
+        esac
+    done < "$config_file"
+}
+
+find_tlp_runtime() {
+    local candidate library_candidates
+
+    tlp_bin=""
+    tlp_lib_dir=""
+
+    for candidate in /usr/sbin/tlp /usr/bin/tlp /usr/local/sbin/tlp /usr/local/bin/tlp; do
+        if [ -x "$candidate" ]; then
+            tlp_bin=$candidate
+            break
+        fi
+    done
+    [ -n "$tlp_bin" ] || return 1
+
+    case "$tlp_bin" in
+        /usr/local/*) library_candidates="/usr/local/share/tlp /usr/local/lib/tlp /usr/share/tlp /usr/lib/tlp" ;;
+        *) library_candidates="/usr/share/tlp /usr/lib/tlp /usr/local/share/tlp /usr/local/lib/tlp" ;;
+    esac
+
+    for candidate in $library_candidates; do
+        if [ -r "$candidate/tlp-func-base" ] \
+            && [ -r "$candidate/func.d/35-tlp-func-batt" ]; then
+            tlp_lib_dir=$candidate
+            break
+        fi
+    done
+
+    return 0
+}
+
+read_probe_thresholds() {
+    current_start=""
+    current_stop=""
+
+    case "${_batdrv_plugin:-}" in
+        huawei)
+            thresholds=$(batdrv_read_threshold stop 0 2>/dev/null)
+            # Huawei returns "start stop" from one combined sysfs attribute.
+            set -- $thresholds
+            [ "$#" -ge 2 ] && current_start=$1 && current_stop=$2
+            ;;
+        # Toshiba and ASUS predate the two-argument plugin read signature.
+        # Passing "stop" to either one selects its human-readable error path.
+        toshiba|asus)
+            current_stop=$(batdrv_read_threshold 0 2>/dev/null)
+            ;;
+        lenovo|lenovo-legacy|samsung|lg|sony)
+            current_stop=$(batdrv_read_threshold stop 0 2>/dev/null)
+            # Sony exposes 0 in sysfs for TLP's conventional disabled value 100.
+            [ "${_batdrv_plugin:-}" != sony ] || [ "$current_stop" != 0 ] || current_stop=100
+            ;;
+        cros-ec)
+            if [ "${_natacpi:-}" = 0 ]; then
+                current_start=$(batdrv_read_threshold start 0 2>/dev/null)
+            fi
+            current_stop=$(batdrv_read_threshold stop 0 2>/dev/null)
+            ;;
+        *)
+            current_start=$(batdrv_read_threshold start 0 2>/dev/null)
+            current_stop=$(batdrv_read_threshold stop 0 2>/dev/null)
+            ;;
+    esac
+}
+
+run_probe() (
+    # TLP's libraries are private shell APIs and are not written for errexit or
+    # nounset. Keep them contained in this read-only subshell.
+    set +e
+    set +u
+
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin
+    export PATH
+
+    # TLP's upstream test suite uses X_* environment hooks to simulate vendor
+    # plugins and threshold values. Never let an inherited test hook influence
+    # the status used for a real policy decision.
+    for test_hook in $(env | sed -n 's/^\(X_[A-Za-z0-9_]*\)=.*/\1/p'); do
+        unset "$test_hook"
+    done
+
+    # Plugin selection may otherwise load tp_smapi or tuxedo_keyboard. Status
+    # detection must never change the running kernel; report success only for a
+    # module which is already present.
+    modprobe() {
+        local module
+        module=$(printf '%s' "${1##*/}" | tr '-' '_')
+        [ -n "$module" ] && [ -d "/sys/module/$module" ]
+    }
+
+    # shellcheck disable=SC1090
+    . "$tlp_lib_dir/tlp-func-base" || exit 70
+    # shellcheck disable=SC1090
+    . "$tlp_lib_dir/func.d/35-tlp-func-batt" || exit 70
+
+    _nodebug=1
+    _conf_tmp=""
+    probe_cleanup() {
+        [ -z "${_conf_tmp:-}" ] || rm -f -- "$_conf_tmp"
+    }
+    trap probe_cleanup EXIT
+    trap 'probe_cleanup; exit 1' HUP INT TERM
+
+    # Respect the user's effective TLP configuration while suppressing config
+    # tracing. A broken config must not fall through to partially initialized
+    # defaults, and a deliberately disabled TLP must not probe or advertise
+    # battery-care support.
+    # read_config deliberately returns success even when tlp-readconfs fails;
+    # TLP_ENABLE is one of TLP's mandatory intrinsic defaults, so its absence
+    # is the reliable fail-closed signal for an unusable merged config.
+    unset TLP_ENABLE
+    read_config 1 >/dev/null 2>&1
+    case "${TLP_ENABLE:-}" in
+        0|1) ;;
+        *) exit 73 ;;
+    esac
+    TLP_LOAD_MODULES=n
+
+    printf 'version=%s\n' "${TLPVER:-}"
+    printf 'enabled=%s\n' "${TLP_ENABLE:-}"
+    [ "${TLP_ENABLE:-}" = 1 ] || exit 0
+
+    select_batdrv >/dev/null 2>&1 || exit 71
+
+    printf 'plugin=%s\n' "${_batdrv_plugin:-}"
+    printf 'method=%s\n' "${_bm_thresh:-none}"
+    printf 'variant=%s\n' "${_natacpi:-}"
+
+    [ "${_bm_thresh:-none}" != none ] || exit 0
+    batdrv_select_battery DEF >/dev/null 2>&1 || exit 72
+
+    printf 'battery=%s\n' "${_bat_str:-}"
+    printf 'config_battery=%s\n' "${_bt_cfg_bat:-}"
+
+    read_probe_thresholds
+
+    printf 'current_start=%s\n' "$current_start"
+    printf 'current_stop=%s\n' "$current_stop"
+    printf 'start_values=%s\n' "${_bt_set_start:-}"
+    printf 'stop_values=%s\n' "${_bt_set_stop:-}"
+)
+
+reset_probe() {
+    supported=0
+    state_known=0
+    active=0
+    reason=""
+
+    probe_version=""
+    probe_enabled=""
+    probe_plugin=""
+    probe_method=""
+    probe_variant=""
+    probe_battery=""
+    probe_config_battery=""
+    probe_current_start=""
+    probe_current_stop=""
+    probe_start_values=""
+    probe_stop_values=""
+
+    start_kind=none
+    start_min=""
+    start_max=""
+    start_step=1
+    start_values=""
+    start_required=0
+    minimum_gap=0
+
+    stop_kind=none
+    stop_min=""
+    stop_max=""
+    stop_step=1
+    stop_values=""
+    fixed_limit=""
+}
+
+tlp_version_value_supported() {
+    local major rest minor
+
+    major=${1%%.*}
+    rest=${1#*.}
+    minor=${rest%%.*}
+    is_uint "$major" && is_uint "$minor" || return 1
+
+    # This adapter is pinned to the private plugin API audited in TLP 1.10.2.
+    # The relevant interface and constraints are unchanged in TLP 1.11 alpha.
+    [ "$major" -eq 1 ] && [ "$minor" -ge 10 ] && [ "$minor" -le 11 ]
+}
+
+tlp_version_supported() {
+    tlp_version_value_supported "$probe_version"
+}
+
+set_capabilities() {
+    start_kind=none
+    start_min=""
+    start_max=""
+    start_step=1
+    start_values=""
+    start_required=0
+    minimum_gap=0
+
+    stop_kind=none
+    stop_min=""
+    stop_max=""
+    stop_step=1
+    stop_values=""
+    fixed_limit=""
+
+    case "$probe_plugin" in
+        thinkpad)
+            start_kind=continuous; start_min=0; start_max=99; start_required=1; minimum_gap=1
+            stop_kind=continuous; stop_min=1; stop_max=100
+            ;;
+        thinkpad-legacy)
+            start_kind=continuous; start_min=2; start_max=96; start_required=1; minimum_gap=4
+            stop_kind=continuous; stop_min=6; stop_max=100
+            ;;
+        huawei)
+            start_kind=continuous; start_min=0; start_max=99; start_required=1; minimum_gap=0
+            stop_kind=continuous; stop_min=1; stop_max=100
+            ;;
+        msi)
+            start_kind=derived
+            stop_kind=continuous; stop_min=10; stop_max=100
+            ;;
+        lenovo|lenovo-legacy|samsung)
+            stop_kind=mode; stop_values="0 1"; fixed_limit=1
+            ;;
+        lg|macbook|toshiba)
+            start_kind=derived
+            stop_kind=fixed; stop_values="80 100"; fixed_limit=80
+            ;;
+        sony)
+            stop_kind=discrete; stop_values="50 80 100"
+            ;;
+        system76)
+            start_kind=continuous; start_min=0; start_max=99; start_required=1; minimum_gap=1
+            stop_kind=continuous; stop_min=1; stop_max=100
+            ;;
+        cros-ec)
+            if [ "$probe_variant" = 0 ]; then
+                start_kind=continuous; start_min=0; start_max=99; start_required=1; minimum_gap=1
+            fi
+            stop_kind=continuous; stop_min=1; stop_max=100
+            ;;
+        dell|wilco-ec)
+            start_kind=continuous; start_min=50; start_max=95; start_required=1; minimum_gap=5
+            stop_kind=continuous; stop_min=55; stop_max=100
+            ;;
+        tuxedo)
+            start_kind=discrete
+            start_values=$(normalize_number_list "$probe_start_values")
+            stop_kind=discrete
+            stop_values=$(normalize_number_list "$probe_stop_values")
+            start_required=1
+            minimum_gap=1
+            [ -n "$start_values" ] && [ -n "$stop_values" ] || return 1
+            ;;
+        asus)
+            stop_kind=continuous; stop_min=1; stop_max=100
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+load_probe() {
+    local output line key value cli_version probe_rc=0
+
+    reset_probe
+    output=$(run_probe 2>/dev/null) || probe_rc=$?
+    if [ "$probe_rc" -ne 0 ]; then
+        case "$probe_rc" in
+            70) reason=tlp-internals-unavailable ;;
+            72) reason=battery-unavailable ;;
+            73) reason=tlp-config-unavailable ;;
+            *) reason=probe-failed ;;
+        esac
+        return 1
+    fi
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        key=${line%%=*}
+        value=${line#*=}
+        case "$key" in
+            version) probe_version=$value ;;
+            enabled) probe_enabled=$value ;;
+            plugin) probe_plugin=$value ;;
+            method) probe_method=$value ;;
+            variant) probe_variant=$value ;;
+            battery) probe_battery=$value ;;
+            config_battery) probe_config_battery=$value ;;
+            current_start) probe_current_start=$value ;;
+            current_stop) probe_current_stop=$value ;;
+            start_values) probe_start_values=$value ;;
+            stop_values) probe_stop_values=$value ;;
+        esac
+    done <<EOF
+$output
+EOF
+
+    cli_version=$("$tlp_bin" --version 2>/dev/null | awk '/^TLP version / { print $3; exit }')
+    if [ -n "$cli_version" ] && [ "$cli_version" != "$probe_version" ]; then
+        reason=tlp-runtime-mismatch
+        return 1
+    fi
+
+    if ! tlp_version_supported; then
+        reason=unsupported-tlp-version
+        return 1
+    fi
+    if [ "$probe_enabled" != 1 ]; then
+        reason=tlp-disabled
+        return 1
+    fi
+    if [ -z "$probe_plugin" ]; then
+        reason=probe-failed
+        return 1
+    fi
+    if [ "$probe_method" = none ] || [ "$probe_plugin" = generic ]; then
+        reason=charge-control-unsupported
+        return 1
+    fi
+    case "$probe_config_battery" in
+        BAT0|BAT1) ;;
+        *) reason=battery-unavailable; return 1 ;;
+    esac
+    if ! set_capabilities; then
+        reason=unsupported-tlp-plugin
+        return 1
+    fi
+
+    supported=1
+    if is_uint "$probe_current_stop"; then
+        state_known=1
+        case "$stop_kind" in
+            mode) [ "$probe_current_stop" -eq 1 ] && active=1 || active=0 ;;
+            *)
+                if [ "$probe_current_stop" -gt 0 ] && [ "$probe_current_stop" -lt 100 ]; then
+                    active=1
+                else
+                    active=0
+                fi
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
+emit_status_json() {
+    local adjustable=0
+    case "$stop_kind" in continuous|discrete) adjustable=1 ;; esac
+
+    printf '{'
+    printf '"schema":1,'
+    printf '"available":%s,' "$(bool_json "$available")"
+    printf '"supported":%s,' "$(bool_json "$supported")"
+    printf '"adjustable":%s,' "$(bool_json "$adjustable")"
+    printf '"stateKnown":%s,' "$(bool_json "$state_known")"
+    printf '"active":%s,' "$(bool_json "$active")"
+    printf '"managed":%s,' "$(bool_json "$managed")"
+    printf '"tlpVersion":%s,' "$(token_json "$probe_version")"
+    printf '"plugin":%s,' "$(token_json "$probe_plugin")"
+    printf '"method":%s,' "$(token_json "$probe_method")"
+    printf '"battery":%s,' "$(token_json "$probe_battery")"
+    printf '"configBattery":%s,' "$(token_json "$probe_config_battery")"
+    printf '"currentStart":%s,' "$(number_json "$probe_current_start")"
+    printf '"currentLimit":%s,' "$(number_json "$probe_current_stop")"
+    printf '"limitKind":%s,' "$(token_json "$stop_kind")"
+    printf '"minimumLimit":%s,' "$(number_json "$stop_min")"
+    printf '"maximumLimit":%s,' "$(number_json "$stop_max")"
+    printf '"stepSize":%s,' "$stop_step"
+    printf '"allowedLimits":%s,' "$(number_array_json "$stop_values")"
+    printf '"fixedLimit":%s,' "$(number_json "$fixed_limit")"
+    printf '"managedBattery":%s,' "$(token_json "$managed_battery")"
+    printf '"managedStart":%s,' "$(number_json "$managed_start")"
+    printf '"managedLimit":%s,' "$(number_json "$managed_stop")"
+    printf '"reason":%s' "$(token_json "$reason")"
+    printf '}\n'
+}
+
+status() {
+    read_managed_policy
+    available=0
+    reset_probe
+
+    if ! find_tlp_runtime; then
+        reason=tlp-unavailable
+        emit_status_json
+        return 0
+    fi
+    available=1
+
+    if [ -z "$tlp_lib_dir" ]; then
+        reason=tlp-internals-unavailable
+        emit_status_json
+        return 0
+    fi
+
+    load_probe || true
+    emit_status_json
+}
+
+value_in_list() {
+    local wanted=$1
+    local candidate
+    for candidate in ${2:-}; do
+        [ "$candidate" = "$wanted" ] && return 0
+    done
+    return 1
+}
+
+normalize_requested_stop() {
+    local requested=$1
+
+    case "$stop_kind" in
+        mode|fixed)
+            printf '%s' "$fixed_limit"
+            ;;
+        continuous)
+            if [ "$requested" -lt "$stop_min" ] || [ "$requested" -gt "$stop_max" ]; then
+                printf 'Charge limit must be between %s and %s for TLP plugin %s.\n' \
+                    "$stop_min" "$stop_max" "$probe_plugin" >&2
+                return 2
+            fi
+            printf '%s' "$requested"
+            ;;
+        discrete)
+            if ! value_in_list "$requested" "$stop_values"; then
+                printf 'Charge limit %s%% is not supported by TLP plugin %s (allowed: %s).\n' \
+                    "$requested" "$probe_plugin" "$stop_values" >&2
+                return 2
+            fi
+            printf '%s' "$requested"
+            ;;
+        *)
+            printf '%s\n' 'TLP did not expose a usable charge-limit capability.' >&2
+            return 1
+            ;;
+    esac
+}
+
+start_fits_stop() {
+    local start=$1
+    local stop=$2
+
+    is_uint "$start" || return 1
+    case "$start_kind" in
+        continuous)
+            [ "$start" -ge "$start_min" ] && [ "$start" -le "$start_max" ] || return 1
+            ;;
+        discrete)
+            value_in_list "$start" "$start_values" || return 1
+            ;;
+        *) return 1 ;;
+    esac
+
+    [ $((start + minimum_gap)) -le "$stop" ]
+}
+
+choose_start() {
+    local stop=$1
+    local candidate
+
+    [ "$start_required" -eq 1 ] || return 0
+
+    if start_fits_stop "$probe_current_start" "$stop"; then
+        printf '%s' "$probe_current_start"
+        return 0
+    fi
+
+    case "$start_kind" in
+        continuous)
+            candidate=$start_min
+            if start_fits_stop "$candidate" "$stop"; then
+                printf '%s' "$candidate"
+                return 0
+            fi
+            ;;
+        discrete)
+            for candidate in $start_values; do
+                if start_fits_stop "$candidate" "$stop"; then
+                    printf '%s' "$candidate"
+                    return 0
+                fi
+            done
+            ;;
+    esac
+
+    printf 'No valid start threshold is available for stop threshold %s with TLP plugin %s.\n' \
+        "$stop" "$probe_plugin" >&2
+    return 2
+}
+
+run_tlp_start() {
+    "$tlp_bin" start
+}
+
+run_tlp_fullcharge() {
+    "$tlp_bin" fullcharge
+}
+
+tlp_output_has_policy_error() {
+    printf '%s\n' "${1:-}" | grep -Eiq \
+        'Error in configuration|Battery skipped|Error:.*(charge|threshold|battery care)'
+}
+
+backup_policy_file() {
+    had_config=0
+    backup_file=""
+    if [ -f "$config_file" ]; then
+        backup_file=$(mktemp "$config_file.prev.XXXXXX") || return 1
+        cp -p -- "$config_file" "$backup_file" || return 1
+        had_config=1
+    fi
+}
+
+stage_policy() {
+    local target_start=$1
+    local target_stop=$2
+    local target_battery=$3
+    local target_plugin=$4
+
+    mkdir -p "$config_dir" || return 1
+    backup_policy_file || return 1
+
+    tmp_file=$(mktemp "$config_file.tmp.XXXXXX") || return 1
+    {
+        printf '%s\n' '# Managed by iNiR. Do not edit manually.'
+        printf '# Battery/backend detected by TLP: %s (%s)\n' "$target_battery" "$target_plugin"
+        if [ -n "$target_start" ]; then
+            printf 'START_CHARGE_THRESH_%s=%s\n' "$target_battery" "$target_start"
+        fi
+        printf 'STOP_CHARGE_THRESH_%s=%s\n' "$target_battery" "$target_stop"
+    } > "$tmp_file" || return 1
+    chmod 0644 "$tmp_file" || return 1
+    mv -f -- "$tmp_file" "$config_file" || return 1
+    tmp_file=""
+}
+
+stage_policy_removal() {
+    backup_policy_file || return 1
+    rm -f -- "$config_file"
+}
+
+restore_policy_file() {
+    if [ "$had_config" -eq 1 ] && [ -n "$backup_file" ] && [ -f "$backup_file" ]; then
+        mv -f -- "$backup_file" "$config_file"
+        backup_file=""
+    else
+        rm -f -- "$config_file"
+    fi
+}
+
+rollback_policy() {
+    local rollback_output="" rollback_rc=0
+
+    restore_policy_file || rollback_rc=1
+
+    rollback_output=$(run_tlp_start 2>&1) || rollback_rc=1
+    if [ "$rollback_rc" -eq 0 ] && tlp_output_has_policy_error "$rollback_output"; then
+        rollback_rc=1
+    fi
+    return "$rollback_rc"
+}
+
+set_policy() {
+    local requested=$1
+    local expected_plugin expected_battery target_start target_stop
+    local apply_output apply_rc=0 rollback_rc=0
+
+    is_uint "$requested" || {
+        printf '%s\n' 'Invalid charge limit value.' >&2
+        return 2
+    }
+    [ "$requested" -ge 1 ] && [ "$requested" -le 100 ] || {
+        printf '%s\n' 'Charge limit must be between 1 and 100.' >&2
+        return 2
+    }
+
+    if ! load_probe || [ "$supported" -ne 1 ]; then
+        printf 'TLP battery charge control is unavailable (%s).\n' "${reason:-probe-failed}" >&2
+        return 1
+    fi
+
+    target_stop=$(normalize_requested_stop "$requested") || return $?
+    target_start=$(choose_start "$target_stop") || return $?
+    expected_plugin=$probe_plugin
+    expected_battery=$probe_config_battery
+
+    stage_policy "$target_start" "$target_stop" "$expected_battery" "$expected_plugin" || {
+        printf '%s\n' 'Could not write the iNiR TLP policy.' >&2
+        return 1
+    }
+
+    apply_output=$(run_tlp_start 2>&1) || apply_rc=$?
+    [ -z "$apply_output" ] || printf '%s\n' "$apply_output" >&2
+
+    if [ "$apply_rc" -ne 0 ] || tlp_output_has_policy_error "$apply_output"; then
+        rollback_policy || rollback_rc=$?
+        printf '%s\n' 'TLP rejected the requested battery charge policy; previous configuration restored.' >&2
+        [ "$rollback_rc" -eq 0 ] || printf '%s\n' 'Warning: re-applying the previous TLP policy also failed.' >&2
+        return 1
+    fi
+
+    # TLP threshold validation failures frequently do not affect `tlp start`'s
+    # exit code. The authoritative post-write read is therefore mandatory.
+    if ! load_probe \
+        || [ "$supported" -ne 1 ] \
+        || [ "$state_known" -ne 1 ] \
+        || [ "$probe_plugin" != "$expected_plugin" ] \
+        || [ "$probe_config_battery" != "$expected_battery" ] \
+        || [ "$probe_current_stop" != "$target_stop" ] \
+        || { [ -n "$target_start" ] && [ "$probe_current_start" != "$target_start" ]; }; then
+        rollback_policy || rollback_rc=$?
+        printf '%s\n' 'TLP did not apply the requested battery charge policy; previous configuration restored.' >&2
+        [ "$rollback_rc" -eq 0 ] || printf '%s\n' 'Warning: re-applying the previous TLP policy also failed.' >&2
+        return 1
+    fi
+
+    [ -z "$backup_file" ] || rm -f -- "$backup_file"
+    backup_file=""
+    return 0
+}
+
+disable_policy() {
+    local fullcharge_output="" fullcharge_rc=0
+    local start_output="" start_rc=0
+
+    # Ownership removal is unconditional. If TLP disappeared, keeping a stale
+    # iNiR drop-in would be worse than reporting that hardware reset was skipped.
+    rm -f -- "$config_file" || return 1
+
+    if ! find_tlp_runtime; then
+        printf '%s\n' 'iNiR policy removed, but TLP is unavailable; hardware defaults could not be restored.' >&2
+        return 1
+    fi
+
+    fullcharge_output=$(run_tlp_fullcharge 2>&1) || fullcharge_rc=$?
+    if [ "$fullcharge_rc" -ne 0 ]; then
+        printf '%s\n' 'Warning: TLP could not restore vendor full-charge thresholds; continuing with remaining TLP configuration.' >&2
+        [ -z "$fullcharge_output" ] || printf '%s\n' "$fullcharge_output" >&2
+    fi
+
+    start_output=$(run_tlp_start 2>&1) || start_rc=$?
+    [ -z "$start_output" ] || printf '%s\n' "$start_output" >&2
+    if [ "$start_rc" -ne 0 ] || tlp_output_has_policy_error "$start_output"; then
+        printf '%s\n' 'iNiR policy removed, but re-applying the remaining TLP configuration failed.' >&2
+        return 1
+    fi
+
+    return 0
+}
+
+tlp_settings_schema_ready() {
+    command -v jq >/dev/null 2>&1 &&
+        [ -r "$tlp_settings_schema" ] &&
+        jq -e '.schema == 1 and ([.categories[].settings[].key] | length > 0)' "$tlp_settings_schema" >/dev/null 2>&1
+}
+
+tlp_settings_definition() {
+    local key=${1:-}
+
+    case "$key" in
+        ''|*[!A-Z0-9_]*) return 1 ;;
+    esac
+    jq -ce --arg key "$key" '[.categories[].settings[] | select(.key == $key)][0] // empty' "$tlp_settings_schema"
+}
+
+tlp_settings_version_minor() {
+    local version=${1:-}
+    local major rest minor
+
+    major=${version%%.*}
+    rest=${version#*.}
+    minor=${rest%%.*}
+    is_uint "$major" && is_uint "$minor" || return 1
+    [ "$major" -eq 1 ] || return 1
+    printf '%s' "$minor"
+}
+
+tlp_setting_available_for_version() {
+    local definition=$1 version=$2
+    local required version_minor required_minor
+
+    required=$(printf '%s' "$definition" | jq -r '.minVersion // empty')
+    [ -n "$required" ] || return 0
+    version_minor=$(tlp_settings_version_minor "$version") || return 1
+    required_minor=$(tlp_settings_version_minor "$required") || return 1
+    [ "$version_minor" -ge "$required_minor" ]
+}
+
+tlp_settings_value_is_safe() {
+    local value=${1:-}
+
+    [ "${#value}" -le 1024 ] || return 1
+    [ -n "$value" ] || return 0
+    printf '%s' "$value" | LC_ALL=C grep -Eq '^[A-Za-z0-9_+.,:/@*% -]*$'
+}
+
+# TLP's public settings documentation is authoritative where TLPUI's static
+# 1.10 schema is incomplete. Keep these exceptions deliberately small and
+# auditable rather than relaxing all schema validation.
+tlp_settings_extra_value_allowed() {
+    local key=$1 candidate=$2
+
+    case "$key" in
+        DISK_APM_LEVEL_ON_AC|DISK_APM_LEVEL_ON_BAT|\
+        DISK_SPINDOWN_TIMEOUT_ON_AC|DISK_SPINDOWN_TIMEOUT_ON_BAT|\
+        DISK_IOSCHED)
+            case "$candidate" in keep|_) return 0 ;; esac
+            ;;
+        CPU_SCALING_GOVERNOR_ON_AC|CPU_SCALING_GOVERNOR_ON_BAT|CPU_SCALING_GOVERNOR_ON_SAV)
+            [ "$candidate" = userspace ] && return 0
+            ;;
+    esac
+    return 1
+}
+
+tlp_platform_profile_choices() {
+    local raw candidate output=""
+
+    [ -r "$platform_profile_choices_file" ] || return 1
+    raw=$(tr '\t\r\n' '   ' < "$platform_profile_choices_file") || return 1
+    for candidate in $raw; do
+        # Kernel platform-profile ABI names are identifiers, not arbitrary
+        # config strings. Apply the same conservative alphabet as TLP values.
+        printf '%s' "$candidate" | LC_ALL=C grep -Eq '^[A-Za-z0-9_+.-]+$' || continue
+        value_in_list "$candidate" "$output" && continue
+        output="${output}${output:+ }${candidate}"
+    done
+    [ -n "$output" ] || return 1
+    printf '%s' "$output"
+}
+
+tlp_settings_runtime_values_json() {
+    local choices=""
+
+    choices=$(tlp_platform_profile_choices 2>/dev/null || true)
+    jq -n --arg choices "$choices" '
+        ($choices | split(" ") | map(select(length > 0))) as $values
+        | {
+            PLATFORM_PROFILE_ON_AC: $values,
+            PLATFORM_PROFILE_ON_BAT: $values,
+            PLATFORM_PROFILE_ON_SAV: $values
+        }
+    '
+}
+
+tlp_settings_validate_platform_profile() {
+    local key=$1 value=$2 version=$3 runtime_required=${4:-0}
+    local current_minor choices candidate match=0 count=0
+
+    [ -n "$value" ] || {
+        printf 'TLP setting %s requires at least one platform profile.\n' "$key" >&2
+        return 2
+    }
+    current_minor=$(tlp_settings_version_minor "$version") || {
+        printf 'Cannot determine TLP version for platform profile %s.\n' "$key" >&2
+        return 2
+    }
+
+    for candidate in $value; do
+        count=$((count + 1))
+    done
+    if [ "$current_minor" -lt 11 ] && [ "$count" -ne 1 ]; then
+        printf 'TLP %s requires exactly one value for %s.\n' "$version" "$key" >&2
+        return 2
+    fi
+
+    # Reading an existing iNiR drop-in must remain possible after a firmware or
+    # hardware capability change. Runtime matching is therefore mandatory only
+    # for a newly staged value, while stored values still undergo all safety and
+    # version/shape checks above.
+    [ "$runtime_required" -eq 1 ] || return 0
+
+    choices=$(tlp_platform_profile_choices 2>/dev/null || true)
+    [ -n "$choices" ] || {
+        printf 'Platform profile choices are unavailable for TLP setting %s. Check tlp-stat -p.\n' "$key" >&2
+        return 2
+    }
+
+    if [ "$current_minor" -lt 11 ]; then
+        value_in_list "$value" "$choices" || {
+            printf 'Platform profile %s is not available for TLP setting %s (available: %s).\n' "$value" "$key" "$choices" >&2
+            return 2
+        }
+        return 0
+    fi
+
+    # TLP 1.11 intentionally accepts ordered fallback lists. Some entries may
+    # target another laptop/firmware, so requiring every token to be locally
+    # available would break that feature. Require at least one local match to
+    # avoid accepting a list which TLP would silently no-op on this machine.
+    for candidate in $value; do
+        if value_in_list "$candidate" "$choices"; then
+            match=1
+            break
+        fi
+    done
+    [ "$match" -eq 1 ] || {
+        printf 'No platform profile in "%s" is available for %s (available: %s).\n' "$value" "$key" "$choices" >&2
+        return 2
+    }
+    return 0
+}
+
+tlp_settings_validate_value() {
+    local key=$1 value=$2 version=${3:-} runtime_required=${4:-0}
+    local definition type minimum maximum candidate
+    local multiple_from current_minor multiple_minor
+
+    tlp_settings_value_is_safe "$value" || {
+        printf 'Unsafe value for TLP setting %s.\n' "$key" >&2
+        return 2
+    }
+
+    definition=$(tlp_settings_definition "$key") || {
+        printf 'Unknown TLP setting: %s.\n' "$key" >&2
+        return 2
+    }
+    if [ -n "$version" ] && ! tlp_setting_available_for_version "$definition" "$version"; then
+        printf 'TLP setting %s requires a newer supported TLP version.\n' "$key" >&2
+        return 2
+    fi
+
+    case "$key" in
+        PLATFORM_PROFILE_ON_AC|PLATFORM_PROFILE_ON_BAT|PLATFORM_PROFILE_ON_SAV)
+            tlp_settings_validate_platform_profile "$key" "$value" "$version" "$runtime_required"
+            return $?
+            ;;
+    esac
+
+    type=$(printf '%s' "$definition" | jq -r '.type')
+    case "$type" in
+        number)
+            is_uint "$value" || {
+                printf 'TLP setting %s requires an unsigned integer.\n' "$key" >&2
+                return 2
+            }
+            minimum=$(printf '%s' "$definition" | jq -r '.min')
+            maximum=$(printf '%s' "$definition" | jq -r '.max')
+            [ "$value" -ge "$minimum" ] && [ "$value" -le "$maximum" ] || {
+                printf 'TLP setting %s must be between %s and %s.\n' "$key" "$minimum" "$maximum" >&2
+                return 2
+            }
+            ;;
+        select)
+            multiple_from=$(printf '%s' "$definition" | jq -r '.multipleFromVersion // empty')
+            current_minor=$(tlp_settings_version_minor "$version" 2>/dev/null || true)
+            multiple_minor=$(tlp_settings_version_minor "$multiple_from" 2>/dev/null || true)
+            if [ -n "$current_minor" ] && [ -n "$multiple_minor" ] && [ "$current_minor" -ge "$multiple_minor" ]; then
+                [ -n "$value" ] || {
+                    printf 'TLP setting %s requires at least one value.\n' "$key" >&2
+                    return 2
+                }
+                for candidate in $value; do
+                    if ! printf '%s' "$definition" | jq -e --arg value "$candidate" '.values | index($value) != null' >/dev/null \
+                        && ! tlp_settings_extra_value_allowed "$key" "$candidate"; then
+                        printf 'Unsupported list item %s for TLP setting %s.\n' "$candidate" "$key" >&2
+                        return 2
+                    fi
+                done
+            else
+                if ! printf '%s' "$definition" | jq -e --arg value "$value" '.values | index($value) != null' >/dev/null \
+                    && ! tlp_settings_extra_value_allowed "$key" "$value"; then
+                    printf 'Unsupported value for TLP setting %s.\n' "$key" >&2
+                    return 2
+                fi
+            fi
+            ;;
+        list)
+            for candidate in $value; do
+                if ! printf '%s' "$definition" | jq -e --arg value "$candidate" '.values | index($value) != null' >/dev/null \
+                    && ! tlp_settings_extra_value_allowed "$key" "$candidate"; then
+                    printf 'Unsupported list item %s for TLP setting %s.\n' "$candidate" "$key" >&2
+                    return 2
+                fi
+            done
+            ;;
+        text)
+            minimum=$(printf '%s' "$definition" | jq -r '.itemMin // empty')
+            maximum=$(printf '%s' "$definition" | jq -r '.itemMax // empty')
+            if printf '%s' "$definition" | jq -e 'has("itemValues")' >/dev/null; then
+                for candidate in $value; do
+                    if ! printf '%s' "$definition" | jq -e --arg value "$candidate" '.itemValues | index($value) != null' >/dev/null \
+                        && ! tlp_settings_extra_value_allowed "$key" "$candidate"; then
+                        printf 'Unsupported list item %s for TLP setting %s.\n' "$candidate" "$key" >&2
+                        return 2
+                    fi
+                done
+            elif [ -n "$minimum" ] && [ -n "$maximum" ] && [ "$maximum" -gt 0 ]; then
+                for candidate in $value; do
+                    if tlp_settings_extra_value_allowed "$key" "$candidate"; then
+                        continue
+                    fi
+                    is_uint "$candidate" &&
+                        [ "$candidate" -ge "$minimum" ] &&
+                        [ "$candidate" -le "$maximum" ] || {
+                        printf 'TLP setting %s requires values between %s and %s, or TLP keep (_).\n' "$key" "$minimum" "$maximum" >&2
+                        return 2
+                    }
+                done
+            fi
+            ;;
+        *)
+            printf 'Unsupported schema type for TLP setting %s.\n' "$key" >&2
+            return 2
+            ;;
+    esac
+    return 0
+}
+
+tlp_settings_managed_records() {
+    local version=${1:-}
+    local line key value
+
+    [ -f "$tlp_settings_config_file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            ''|'#'*) continue ;;
+        esac
+
+        key=${line%%=*}
+        value=${line#*=}
+        [ "$key" != "$line" ] || {
+            printf '%s\n' 'The iNiR TLP settings drop-in contains an invalid line.' >&2
+            return 1
+        }
+        case "$value" in
+            \"*\") value=${value#\"}; value=${value%\"} ;;
+            # Early iNiR builds used shell-style single quotes, which TLP's
+            # config reader ignores. Accept them only so the next Apply can
+            # migrate the owned drop-in to TLP's double-quoted syntax.
+            \'*\') value=${value#\'}; value=${value%\'} ;;
+            *)
+                printf 'The iNiR TLP setting %s is not safely quoted.\n' "$key" >&2
+                return 1
+                ;;
+        esac
+        tlp_settings_validate_value "$key" "$value" "$version" || return $?
+        printf '%s\t%s\n' "$key" "$value"
+    done < "$tlp_settings_config_file"
+}
+
+run_tlp_settings_probe() (
+    local key is_set value
+
+    set +e
+    set +u
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin
+    export PATH
+
+    # shellcheck disable=SC1090
+    . "$tlp_lib_dir/tlp-func-base" || exit 70
+
+    for key in $(jq -r '.categories[].settings[].key' "$tlp_settings_schema"); do
+        unset "$key"
+    done
+    unset TLP_ENABLE
+
+    _nodebug=1
+    _conf_tmp=""
+    probe_cleanup() {
+        [ -z "${_conf_tmp:-}" ] || rm -f -- "$_conf_tmp"
+    }
+    trap probe_cleanup EXIT
+    trap 'probe_cleanup; exit 1' HUP INT TERM
+
+    read_config 1 >/dev/null 2>&1
+    case "${TLP_ENABLE:-}" in
+        0|1) ;;
+        *) exit 73 ;;
+    esac
+
+    printf 'meta\tversion\t%s\n' "${TLPVER:-}"
+    printf 'meta\tenabled\t%s\n' "${TLP_ENABLE:-}"
+    for key in $(jq -r '.categories[].settings[].key' "$tlp_settings_schema"); do
+        eval "is_set=\${$key+x}"
+        [ "$is_set" = x ] || continue
+        eval "value=\${$key-}"
+        value=$(printf '%s' "$value" | tr '\t\r\n' '   ')
+        printf 'setting\t%s\t%s\n' "$key" "$value"
+    done
+)
+
+tlp_settings_records_json() {
+    jq -Rn '
+        reduce inputs as $line ({};
+            ($line | split("\t")) as $parts
+            | if ($parts | length) >= 2
+              then .[$parts[0]] = ($parts[1:] | join("\t"))
+              else .
+              end
+        )
+    '
+}
+
+emit_tlp_settings_empty_status() {
+    local status_available=${1:-0}
+    local status_supported=${2:-0}
+    local status_reason=${3:-tlp-unavailable}
+    local runtime_values_json
+
+    runtime_values_json=$(tlp_settings_runtime_values_json 2>/dev/null || printf '{}')
+    printf '{'
+    printf '"schema":1,'
+    printf '"available":%s,' "$(bool_json "$status_available")"
+    printf '"supported":%s,' "$(bool_json "$status_supported")"
+    printf '"configAvailable":false,'
+    printf '"enabled":false,'
+    printf '"tlpVersion":"",'
+    printf '"reason":%s,' "$(token_json "$status_reason")"
+    printf '"configFile":"%s",' "$tlp_settings_config_file"
+    printf '"effective":{},'
+    printf '"managed":{},'
+    printf '"runtimeValues":%s' "$runtime_values_json"
+    printf '}\n'
+}
+
+tlp_settings_status() {
+    local probe_output probe_rc=0 cli_version status_version status_enabled
+    local effective_records managed_records effective_json managed_json runtime_values_json
+
+    if ! command -v jq >/dev/null 2>&1 || [ ! -r "$tlp_settings_schema" ]; then
+        emit_tlp_settings_empty_status 0 0 schema-unavailable
+        return 0
+    fi
+    if ! tlp_settings_schema_ready; then
+        emit_tlp_settings_empty_status 0 0 schema-invalid
+        return 0
+    fi
+    if ! find_tlp_runtime; then
+        emit_tlp_settings_empty_status 0 0 tlp-unavailable
+        return 0
+    fi
+    if [ -z "$tlp_lib_dir" ]; then
+        emit_tlp_settings_empty_status 1 0 tlp-internals-unavailable
+        return 0
+    fi
+
+    probe_output=$(run_tlp_settings_probe 2>/dev/null) || probe_rc=$?
+    if [ "$probe_rc" -ne 0 ]; then
+        case "$probe_rc" in
+            70) emit_tlp_settings_empty_status 1 0 tlp-internals-unavailable ;;
+            73) emit_tlp_settings_empty_status 1 0 tlp-config-unavailable ;;
+            *) emit_tlp_settings_empty_status 1 0 probe-failed ;;
+        esac
+        return 0
+    fi
+
+    status_version=$(printf '%s\n' "$probe_output" | awk -F '\t' '$1 == "meta" && $2 == "version" { print $3; exit }')
+    status_enabled=$(printf '%s\n' "$probe_output" | awk -F '\t' '$1 == "meta" && $2 == "enabled" { print $3; exit }')
+    cli_version=$("$tlp_bin" --version 2>/dev/null | awk '/^TLP version / { print $3; exit }')
+    if [ -n "$cli_version" ] && [ "$cli_version" != "$status_version" ]; then
+        emit_tlp_settings_empty_status 1 0 tlp-runtime-mismatch
+        return 0
+    fi
+    if ! tlp_version_value_supported "$status_version"; then
+        emit_tlp_settings_empty_status 1 0 unsupported-tlp-version
+        return 0
+    fi
+
+    effective_records=$(printf '%s\n' "$probe_output" | awk -F '\t' '
+        $1 == "setting" {
+            printf "%s", $2
+            for (i = 3; i <= NF; i++) printf "%s%s", (i == 3 ? "\t" : FS), $i
+            printf "\n"
+        }
+    ')
+    if ! managed_records=$(tlp_settings_managed_records "$status_version"); then
+        emit_tlp_settings_empty_status 1 1 managed-config-invalid
+        return 0
+    fi
+
+    effective_json=$(printf '%s\n' "$effective_records" | sed '/^$/d' | tlp_settings_records_json)
+    managed_json=$(printf '%s\n' "$managed_records" | sed '/^$/d' | tlp_settings_records_json)
+    runtime_values_json=$(tlp_settings_runtime_values_json 2>/dev/null || printf '{}')
+
+    jq -n --arg version "$status_version" --arg reason "" --arg configFile "$tlp_settings_config_file" --argjson enabled "$([ "$status_enabled" = 1 ] && printf true || printf false)" --argjson effective "$effective_json" --argjson managed "$managed_json" --argjson runtimeValues "$runtime_values_json" '{
+            schema: 1,
+            available: true,
+            supported: true,
+            configAvailable: true,
+            enabled: $enabled,
+            tlpVersion: $version,
+            reason: $reason,
+            configFile: $configFile,
+            effective: $effective,
+            managed: $managed,
+            runtimeValues: $runtimeValues
+        }'
+}
+
+tlp_settings_update_record() {
+    local records=$1 mode=$2 key=$3 value=${4:-}
+    local next
+
+    next=$(mktemp "$records.next.XXXXXX") || return 1
+    awk -F '\t' -v key="$key" '$1 != key' "$records" > "$next" || {
+        rm -f -- "$next"
+        return 1
+    }
+    if [ "$mode" = set ]; then
+        printf '%s\t%s\n' "$key" "$value" >> "$next" || {
+            rm -f -- "$next"
+            return 1
+        }
+    fi
+    mv -f -- "$next" "$records"
+}
+
+tlp_settings_backup_owned_file() {
+    tlp_settings_had_config=0
+    tlp_settings_backup_file=""
+
+    if [ -f "$tlp_settings_config_file" ]; then
+        tlp_settings_backup_file=$(mktemp "$tlp_settings_config_file.prev.XXXXXX") || return 1
+        cp -p -- "$tlp_settings_config_file" "$tlp_settings_backup_file" || return 1
+        tlp_settings_had_config=1
+    fi
+}
+
+tlp_settings_write_records() {
+    local records=$1 key value tab
+
+    mkdir -p "$config_dir" || return 1
+    tlp_settings_backup_owned_file || return 1
+
+    if [ ! -s "$records" ]; then
+        rm -f -- "$tlp_settings_config_file"
+        return $?
+    fi
+
+    tlp_settings_tmp_file=$(mktemp "$tlp_settings_config_file.tmp.XXXXXX") || return 1
+    printf '%s\n' '# Managed by iNiR TLP Settings. Do not edit manually.' > "$tlp_settings_tmp_file" || return 1
+    tab=$(printf '\t')
+    sort "$records" | while IFS="$tab" read -r key value; do
+        [ -n "$key" ] || continue
+        printf '%s="%s"\n' "$key" "$value"
+    done >> "$tlp_settings_tmp_file" || return 1
+    chmod 0644 "$tlp_settings_tmp_file" || return 1
+    mv -f -- "$tlp_settings_tmp_file" "$tlp_settings_config_file" || return 1
+    tlp_settings_tmp_file=""
+}
+
+tlp_settings_restore_owned_file() {
+    if [ "$tlp_settings_had_config" -eq 1 ] &&
+        [ -n "$tlp_settings_backup_file" ] &&
+        [ -f "$tlp_settings_backup_file" ]; then
+        mv -f -- "$tlp_settings_backup_file" "$tlp_settings_config_file"
+        tlp_settings_backup_file=""
+    else
+        rm -f -- "$tlp_settings_config_file"
+    fi
+}
+
+tlp_settings_probe_enabled() {
+    awk -F '\t' '$1 == "meta" && $2 == "enabled" { print $3; exit }'
+}
+
+tlp_settings_probe_records() {
+    awk -F '\t' '
+        $1 == "setting" {
+            printf "%s", $2
+            for (i = 3; i <= NF; i++) printf "%s%s", (i == 3 ? "\t" : FS), $i
+            printf "\n"
+        }
+    '
+}
+
+tlp_settings_verify_records() {
+    local records=$1 probe_output effective_records managed_json effective_json
+
+    probe_output=$(run_tlp_settings_probe 2>/dev/null) || return 1
+    effective_records=$(printf '%s\n' "$probe_output" | tlp_settings_probe_records)
+    managed_json=$(sed '/^$/d' "$records" | tlp_settings_records_json) || return 1
+    effective_json=$(printf '%s\n' "$effective_records" | sed '/^$/d' | tlp_settings_records_json) || return 1
+
+    jq -ne --argjson managed "$managed_json" --argjson effective "$effective_json" '
+        $managed
+        | to_entries
+        | all(. as $entry | $effective[$entry.key] == $entry.value)
+    ' >/dev/null
+}
+
+tlp_settings_rollback() {
+    local previous_enabled=${1:-1}
+    local rollback_output="" rollback_rc=0
+
+    tlp_settings_restore_owned_file || rollback_rc=1
+    if [ "$previous_enabled" = 1 ]; then
+        rollback_output=$(run_tlp_start 2>&1) || rollback_rc=1
+        if [ "$rollback_rc" -eq 0 ] && tlp_output_has_policy_error "$rollback_output"; then
+            rollback_rc=1
+        fi
+    fi
+    return "$rollback_rc"
+}
+
+tlp_settings_apply() {
+    local records probe_output version previous_enabled next_enabled
+    local operation key value validation_rc apply_output="" apply_rc=0 rollback_rc=0
+    local settings_changed=0 charge_changed=0 charge_operation="" requested_stop=""
+    local target_start="" target_stop="" expected_plugin="" expected_battery=""
+    local fullcharge_output="" fullcharge_rc=0 restore_output=""
+
+    [ "$#" -gt 0 ] || {
+        printf '%s\n' 'No TLP setting operations were provided.' >&2
+        return 2
+    }
+    tlp_settings_schema_ready || {
+        printf '%s\n' 'The iNiR TLP settings schema is unavailable.' >&2
+        return 1
+    }
+    if ! find_tlp_runtime || [ -z "$tlp_lib_dir" ]; then
+        printf '%s\n' 'TLP or its internal runtime is not installed.' >&2
+        return 1
+    fi
+
+    version=$("$tlp_bin" --version 2>/dev/null | awk '/^TLP version / { print $3; exit }')
+    tlp_version_value_supported "$version" || {
+        printf 'Unsupported TLP version: %s.\n' "${version:-unknown}" >&2
+        return 1
+    }
+
+    records=$(mktemp) || return 1
+    if ! tlp_settings_managed_records "$version" > "$records"; then
+        rm -f -- "$records"
+        return 1
+    fi
+
+    while [ "$#" -gt 0 ]; do
+        operation=$1
+        shift
+        case "$operation" in
+            --charge-set)
+                [ "$#" -ge 1 ] || {
+                    rm -f -- "$records"
+                    usage
+                    return $?
+                }
+                [ -z "$charge_operation" ] || {
+                    printf '%s\n' 'Only one battery charge operation may be applied per transaction.' >&2
+                    rm -f -- "$records"
+                    return 2
+                }
+                requested_stop=$1
+                shift
+                is_uint "$requested_stop" &&
+                    [ "$requested_stop" -ge 1 ] &&
+                    [ "$requested_stop" -le 100 ] || {
+                    printf '%s\n' 'Invalid charge limit value.' >&2
+                    rm -f -- "$records"
+                    return 2
+                }
+                charge_operation=set
+                ;;
+            --charge-disable)
+                [ -z "$charge_operation" ] || {
+                    printf '%s\n' 'Only one battery charge operation may be applied per transaction.' >&2
+                    rm -f -- "$records"
+                    return 2
+                }
+                charge_operation=disable
+                ;;
+            --set)
+                [ "$#" -ge 2 ] || {
+                    rm -f -- "$records"
+                    usage
+                    return $?
+                }
+                key=$1
+                value=$2
+                shift 2
+                tlp_settings_validate_value "$key" "$value" "$version" 1 || {
+                    validation_rc=$?
+                    rm -f -- "$records"
+                    return "$validation_rc"
+                }
+                tlp_settings_update_record "$records" set "$key" "$value" || {
+                    rm -f -- "$records"
+                    return 1
+                }
+                settings_changed=1
+                ;;
+            --unset)
+                [ "$#" -ge 1 ] || {
+                    rm -f -- "$records"
+                    usage
+                    return $?
+                }
+                key=$1
+                shift
+                tlp_settings_definition "$key" >/dev/null || {
+                    printf 'Unknown TLP setting: %s.\n' "$key" >&2
+                    rm -f -- "$records"
+                    return 2
+                }
+                tlp_settings_update_record "$records" unset "$key" || {
+                    rm -f -- "$records"
+                    return 1
+                }
+                settings_changed=1
+                ;;
+            *)
+                printf 'Unknown TLP settings operation: %s.\n' "$operation" >&2
+                rm -f -- "$records"
+                return 2
+                ;;
+        esac
+    done
+
+    probe_output=$(run_tlp_settings_probe 2>/dev/null) || {
+        rm -f -- "$records"
+        printf '%s\n' 'The effective TLP configuration could not be read.' >&2
+        return 1
+    }
+    previous_enabled=$(printf '%s\n' "$probe_output" | tlp_settings_probe_enabled)
+
+    case "$charge_operation" in
+        set)
+            if ! load_probe || [ "$supported" -ne 1 ]; then
+                rm -f -- "$records"
+                printf 'TLP battery charge control is unavailable (%s).\n' "${reason:-probe-failed}" >&2
+                return 1
+            fi
+            target_stop=$(normalize_requested_stop "$requested_stop") || {
+                validation_rc=$?
+                rm -f -- "$records"
+                return "$validation_rc"
+            }
+            target_start=$(choose_start "$target_stop") || {
+                validation_rc=$?
+                rm -f -- "$records"
+                return "$validation_rc"
+            }
+            expected_plugin=$probe_plugin
+            expected_battery=$probe_config_battery
+            stage_policy "$target_start" "$target_stop" "$expected_battery" "$expected_plugin" || {
+                rm -f -- "$records"
+                printf '%s\n' 'Could not stage the iNiR battery charge policy.' >&2
+                return 1
+            }
+            charge_changed=1
+            ;;
+        disable)
+            if [ -f "$config_file" ]; then
+                stage_policy_removal || {
+                    rm -f -- "$records"
+                    printf '%s\n' 'Could not stage removal of the iNiR battery charge policy.' >&2
+                    return 1
+                }
+                charge_changed=1
+            fi
+            ;;
+    esac
+
+    if [ "$settings_changed" -eq 1 ]; then
+        tlp_settings_write_records "$records" || {
+            [ "$charge_changed" -eq 0 ] || restore_policy_file || true
+            rm -f -- "$records"
+            printf '%s\n' 'Could not write the iNiR TLP settings drop-in.' >&2
+            return 1
+        }
+    fi
+
+    # A charge-only disable which no longer owns a drop-in is already in the
+    # requested state and needs neither a TLP restart nor hardware mutation.
+    if [ "$settings_changed" -eq 0 ] && [ "$charge_changed" -eq 0 ]; then
+        rm -f -- "$records"
+        return 0
+    fi
+
+    probe_output=$(run_tlp_settings_probe 2>/dev/null) || apply_rc=1
+    if [ "$apply_rc" -eq 0 ]; then
+        next_enabled=$(printf '%s\n' "$probe_output" | tlp_settings_probe_enabled)
+        if [ "$charge_operation" = set ] && [ "$next_enabled" != 1 ]; then
+            printf '%s\n' 'Enabling battery charge care cannot be combined with disabling TLP.' >&2
+            apply_rc=1
+        fi
+    fi
+    if [ "$apply_rc" -eq 0 ] && [ "$charge_operation" = disable ] && [ "$charge_changed" -eq 1 ]; then
+        fullcharge_output=$(run_tlp_fullcharge 2>&1) || fullcharge_rc=$?
+        if [ "$fullcharge_rc" -ne 0 ]; then
+            printf '%s\n' 'Warning: TLP could not restore vendor full-charge thresholds; continuing with remaining TLP configuration.' >&2
+        fi
+        [ -z "$fullcharge_output" ] || printf '%s\n' "$fullcharge_output" >&2
+    fi
+    if [ "$apply_rc" -eq 0 ]; then
+        if [ "$next_enabled" = 1 ]; then
+            apply_output=$(run_tlp_start 2>&1) || apply_rc=$?
+            if [ "$apply_rc" -eq 0 ] && tlp_output_has_policy_error "$apply_output"; then
+                apply_rc=1
+            fi
+            if [ "$apply_rc" -ne 0 ]; then
+                [ -z "$apply_output" ] || printf '%s\n' "$apply_output" >&2
+            fi
+        fi
+    fi
+    if [ "$apply_rc" -eq 0 ] && [ "$settings_changed" -eq 1 ] &&
+        ! tlp_settings_verify_records "$records"; then
+        apply_rc=1
+    fi
+    if [ "$apply_rc" -eq 0 ] && [ "$charge_operation" = set ]; then
+        if ! load_probe ||
+            [ "$supported" -ne 1 ] ||
+            [ "$state_known" -ne 1 ] ||
+            [ "$probe_plugin" != "$expected_plugin" ] ||
+            [ "$probe_config_battery" != "$expected_battery" ] ||
+            [ "$probe_current_stop" != "$target_stop" ] ||
+            { [ -n "$target_start" ] && [ "$probe_current_start" != "$target_start" ]; }; then
+            apply_rc=1
+        fi
+    fi
+    if [ "$apply_rc" -eq 0 ] && [ "$charge_operation" = disable ] && [ -e "$config_file" ]; then
+        apply_rc=1
+    fi
+
+    rm -f -- "$records"
+    if [ "$apply_rc" -ne 0 ]; then
+        if [ "$settings_changed" -eq 1 ]; then
+            tlp_settings_restore_owned_file || rollback_rc=1
+        fi
+        if [ "$charge_changed" -eq 1 ]; then
+            restore_policy_file || rollback_rc=1
+            # If this transaction introduced a threshold where no iNiR charge
+            # file existed before, reset the hardware before re-applying the
+            # restored TLP configuration.
+            if [ "$had_config" -eq 0 ]; then
+                restore_output=$(run_tlp_fullcharge 2>&1) || rollback_rc=1
+                [ -z "$restore_output" ] || printf '%s\n' "$restore_output" >&2
+            fi
+        fi
+        if [ "$previous_enabled" = 1 ]; then
+            restore_output=$(run_tlp_start 2>&1) || rollback_rc=1
+            if [ "$rollback_rc" -eq 0 ] && tlp_output_has_policy_error "$restore_output"; then
+                rollback_rc=1
+            fi
+            if [ "$rollback_rc" -ne 0 ]; then
+                [ -z "$restore_output" ] || printf '%s\n' "$restore_output" >&2
+            fi
+        fi
+        printf '%s\n' 'TLP rejected the requested batch; previous configuration restored.' >&2
+        [ "$rollback_rc" -eq 0 ] || printf '%s\n' 'Warning: re-applying the previous TLP configuration also failed.' >&2
+        return 1
+    fi
+
+    [ "$settings_changed" -eq 0 ] || [ -z "$tlp_settings_backup_file" ] || rm -f -- "$tlp_settings_backup_file"
+    tlp_settings_backup_file=""
+    [ "$charge_changed" -eq 0 ] || [ -z "$backup_file" ] || rm -f -- "$backup_file"
+    backup_file=""
+    return 0
+}
+
+tlp_settings_reset() {
+    local probe_output enabled apply_output="" apply_rc=0
+
+    rm -f -- "$tlp_settings_config_file" || return 1
+    if ! find_tlp_runtime || [ -z "$tlp_lib_dir" ]; then
+        printf '%s\n' 'iNiR TLP settings removed, but TLP is unavailable.' >&2
+        return 1
+    fi
+    tlp_settings_schema_ready || {
+        printf '%s\n' 'iNiR TLP settings removed, but the settings schema is unavailable.' >&2
+        return 1
+    }
+
+    probe_output=$(run_tlp_settings_probe 2>/dev/null) || {
+        printf '%s\n' 'iNiR TLP settings removed, but the remaining TLP configuration is unreadable.' >&2
+        return 1
+    }
+    enabled=$(printf '%s\n' "$probe_output" | tlp_settings_probe_enabled)
+    if [ "$enabled" = 1 ]; then
+        apply_output=$(run_tlp_start 2>&1) || apply_rc=$?
+        [ -z "$apply_output" ] || printf '%s\n' "$apply_output" >&2
+        if [ "$apply_rc" -ne 0 ] || tlp_output_has_policy_error "$apply_output"; then
+            printf '%s\n' 'iNiR TLP settings removed, but re-applying the remaining TLP configuration failed.' >&2
+            return 1
+        fi
+    fi
+    return 0
+}
+
+acquire_tlp_settings_lock() {
+    command -v flock >/dev/null 2>&1 || {
+        printf '%s\n' 'flock is required to change iNiR TLP settings.' >&2
+        return 1
+    }
+    exec 9>"$tlp_settings_lock" || return 1
+    flock -w 10 9 || {
+        printf '%s\n' 'Another iNiR TLP settings operation is still running.' >&2
+        return 1
+    }
+}
+
+main() {
+    set -eu
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin
+    export PATH
+    umask 022
+    trap cleanup EXIT
+    trap 'cleanup; exit 1' HUP INT TERM
+
+    case "${1:-}" in
+        --status)
+            [ "$#" -eq 1 ] || { usage; return $?; }
+            status
+            ;;
+        --config-status)
+            [ "$#" -eq 1 ] || { usage; return $?; }
+            tlp_settings_status
+            ;;
+        --set)
+            [ "$#" -eq 2 ] || { usage; return $?; }
+            [ "$(id -u)" -eq 0 ] || {
+                printf '%s\n' 'Changing the battery charge policy requires root privileges.' >&2
+                return 1
+            }
+            acquire_tlp_settings_lock || return $?
+            if ! find_tlp_runtime || [ -z "$tlp_lib_dir" ]; then
+                printf '%s\n' 'TLP or its internal runtime is not installed.' >&2
+                return 1
+            fi
+            set_policy "$2"
+            ;;
+        --disable)
+            [ "$#" -eq 1 ] || { usage; return $?; }
+            [ "$(id -u)" -eq 0 ] || {
+                printf '%s\n' 'Changing the battery charge policy requires root privileges.' >&2
+                return 1
+            }
+            acquire_tlp_settings_lock || return $?
+            disable_policy
+            ;;
+        --config-apply)
+            [ "$#" -gt 1 ] || { usage; return $?; }
+            [ "$(id -u)" -eq 0 ] || {
+                printf '%s\n' 'Changing TLP settings requires root privileges.' >&2
+                return 1
+            }
+            acquire_tlp_settings_lock || return $?
+            shift
+            tlp_settings_apply "$@"
+            ;;
+        --config-reset)
+            [ "$#" -eq 1 ] || { usage; return $?; }
+            [ "$(id -u)" -eq 0 ] || {
+                printf '%s\n' 'Changing TLP settings requires root privileges.' >&2
+                return 1
+            }
+            acquire_tlp_settings_lock || return $?
+            tlp_settings_reset
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+# Keeping main behind the installed basename lets the regression tests source
+# the pure adapter functions without introducing a test-only privileged mode.
+if [ "${0##*/}" = inir-battery-charge-limit ]; then
+    main "$@"
+fi

--- a/assets/polkit/org.inir.battery-charge-limit.policy
+++ b/assets/polkit/org.inir.battery-charge-limit.policy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <action id="org.inir.battery-charge-limit">
+    <description>Change iNiR-managed TLP settings</description>
+    <message>Authentication is required to apply power-management settings.</message>
+    <defaults>
+      <allow_any>auth_admin_keep</allow_any>
+      <allow_inactive>auth_admin_keep</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/inir-battery-charge-limit</annotate>
+  </action>
+</policyconfig>

--- a/assets/tlp/tlp-settings-schema.json
+++ b/assets/tlp/tlp-settings-schema.json
@@ -1,0 +1,1736 @@
+{
+  "schema": 1,
+  "supportedVersions": [
+    "1.10",
+    "1.11"
+  ],
+  "sources": [
+    "https://github.com/linrunner/TLP/blob/1.10.2/tlp.conf",
+    "https://github.com/linrunner/TLP/blob/main/tlp.conf",
+    "https://github.com/d4nj1/TLPUI/blob/master/tlpui/configschema/1_10.yaml"
+  ],
+  "categories": [
+    {
+      "name": "General",
+      "description": "TLP service, profile switching and diagnostic behavior.",
+      "settings": [
+        {
+          "key": "TLP_ENABLE",
+          "group": "TLP_ENABLE",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Enable/disable TLP"
+        },
+        {
+          "key": "TLP_DISABLE_DEFAULTS",
+          "group": "TLP_DISABLE_DEFAULTS",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Set to 1 to deactivate all intrinsic defaults of TLP. This means that\nTLP only applies settings that have been explicitly activated i.e.\nparameters without a leading '#'.\nNotes:\n- Helpful if one wants to use only selected features of TLP\n- After activation, use tlp-stat -c to display your effective configuration"
+        },
+        {
+          "key": "TLP_WARN_LEVEL",
+          "group": "TLP_WARN_LEVEL",
+          "type": "select",
+          "values": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "description": "Control how warnings about invalid settings are issued:\n0=disabled,\n1=background tasks (boot, resume, change of power source) report to syslog,\n2=shell commands report to the terminal (stderr),\n3=combination of 1 and 2"
+        },
+        {
+          "key": "TLP_MSG_COLORS",
+          "group": "TLP_MSG_COLORS",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "description": "Colorize error, warning, notice and success messages.\nColors are specified with ANSI codes:\n1=bold black, 90=grey, 91=red, 92=green, 93=yellow, 94=blue, 95=magenta, 96=cyan, 97=white.\nOther colors are possible, refer to:\nhttps://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit\nColors must be specified in the order \"error, warning, notice, success\".\nBy default, errors are shown in red, warnings in yellow, notices in bold and success in green"
+        },
+        {
+          "key": "TLP_AUTO_SWITCH",
+          "group": "TLP_AUTO_SWITCH",
+          "type": "select",
+          "values": [
+            "0",
+            "1",
+            "2"
+          ],
+          "description": "Control automatic switching of the power profile when connecting or removing\nthe charger, when booting the system or when executing 'tlp start':\n0=disabled - never switch, use TLP_DEFAULT_MODE if configured\n1=auto - always switch, select performance on AC and\nbalanced on battery power.\n2=smart - do not switch if the following profiles were active previously:\npower-saver or balanced on AC resp.\npower-saver or performance on battery power.\nNote: the same applies if the charger was connected/removed during suspend"
+        },
+        {
+          "key": "TLP_PROFILE_AC",
+          "group": "TLP_PROFILE",
+          "type": "select",
+          "values": [
+            "AC",
+            "PRF",
+            "BAT",
+            "BAL",
+            "SAV"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "TLP_PROFILE_BAT",
+          "group": "TLP_PROFILE",
+          "type": "select",
+          "values": [
+            "AC",
+            "PRF",
+            "BAT",
+            "BAL",
+            "SAV"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "TLP_PROFILE_DEFAULT",
+          "group": "TLP_PROFILE",
+          "type": "select",
+          "values": [
+            "AC",
+            "PRF",
+            "BAT",
+            "BAL",
+            "SAV"
+          ],
+          "profile": "DEFAULT"
+        },
+        {
+          "key": "TLP_PS_IGNORE",
+          "group": "TLP_PS_IGNORE",
+          "type": "list",
+          "values": [
+            "AC",
+            "USB",
+            "BAT"
+          ],
+          "description": "Power supply classes to ignore when determining operation mode: AC, USB, BAT.\nSeparate multiple classes with spaces.\nNote: try on laptops where operation mode AC/BAT is incorrectly detected"
+        }
+      ],
+      "id": "general",
+      "icon": "tune",
+      "waffleIcon": "settings-cog-multiple",
+      "groups": [
+        {
+          "id": "TLP_ENABLE",
+          "title": "TLP ENABLE",
+          "description": "Turn TLP power management on or off."
+        },
+        {
+          "id": "TLP_DISABLE_DEFAULTS",
+          "title": "TLP DISABLE DEFAULTS",
+          "description": "Use only settings explicitly enabled below. Leave this off unless you want a fully manual TLP configuration."
+        },
+        {
+          "id": "TLP_WARN_LEVEL",
+          "title": "TLP WARN LEVEL",
+          "description": "Choose where TLP reports configuration warnings."
+        },
+        {
+          "id": "TLP_MSG_COLORS",
+          "title": "TLP MSG COLORS",
+          "description": "ANSI color codes for error, warning, notice, and success messages, in that order."
+        },
+        {
+          "id": "TLP_AUTO_SWITCH",
+          "title": "TLP AUTO SWITCH",
+          "description": "Select how TLP switches profiles when the power source changes."
+        },
+        {
+          "id": "TLP_PROFILE",
+          "title": "TLP PROFILE",
+          "description": "Map AC, battery, and fallback states to TLP profiles. AC/BAT remain available as legacy aliases."
+        },
+        {
+          "id": "TLP_PS_IGNORE",
+          "title": "TLP PS IGNORE",
+          "description": "Ignore selected power-supply classes when TLP detects AC or battery mode. Use only if detection is wrong."
+        }
+      ]
+    },
+    {
+      "name": "Audio",
+      "description": "Audio controller power saving on AC and battery.",
+      "settings": [
+        {
+          "key": "SOUND_POWER_SAVE_ON_AC",
+          "group": "SOUND_POWER_SAVE",
+          "type": "number",
+          "min": 0,
+          "max": 3600,
+          "step": 1,
+          "profile": "AC",
+          "unit": "s"
+        },
+        {
+          "key": "SOUND_POWER_SAVE_ON_BAT",
+          "group": "SOUND_POWER_SAVE",
+          "type": "number",
+          "min": 0,
+          "max": 3600,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "s"
+        },
+        {
+          "key": "SOUND_POWER_SAVE_CONTROLLER",
+          "group": "SOUND_POWER_SAVE_CONTROLLER",
+          "type": "select",
+          "values": [
+            "N",
+            "Y"
+          ],
+          "description": "Disable controller too (HDA only): Y/N.\nNote: effective only when SOUND_POWER_SAVE_ON_AC/BAT is activated"
+        }
+      ],
+      "id": "audio",
+      "icon": "volume_up",
+      "waffleIcon": "speaker",
+      "groups": [
+        {
+          "id": "SOUND_POWER_SAVE",
+          "title": "SOUND POWER SAVE",
+          "description": "Intel HDA/AC97 audio · Set the idle timeout before power saving; 0 disables it."
+        },
+        {
+          "id": "SOUND_POWER_SAVE_CONTROLLER",
+          "title": "SOUND POWER SAVE CONTROLLER",
+          "description": "HDA only · Power down the controller when audio power saving is active."
+        }
+      ]
+    },
+    {
+      "name": "Disks",
+      "description": "Disk idle, APM, I/O scheduler, SATA and AHCI runtime power.",
+      "settings": [
+        {
+          "key": "DISK_IDLE_SECS_ON_AC",
+          "group": "DISK_IDLE_SECS",
+          "type": "number",
+          "min": 0,
+          "max": 1000,
+          "step": 1,
+          "profile": "AC",
+          "unit": "s"
+        },
+        {
+          "key": "DISK_IDLE_SECS_ON_BAT",
+          "group": "DISK_IDLE_SECS",
+          "type": "number",
+          "min": 0,
+          "max": 1000,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "s"
+        },
+        {
+          "key": "MAX_LOST_WORK_SECS_ON_AC",
+          "group": "MAX_LOST_WORK_SECS",
+          "type": "number",
+          "min": 0,
+          "max": 10000,
+          "step": 1,
+          "profile": "AC",
+          "unit": "s"
+        },
+        {
+          "key": "MAX_LOST_WORK_SECS_ON_BAT",
+          "group": "MAX_LOST_WORK_SECS",
+          "type": "number",
+          "min": 0,
+          "max": 10000,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "s"
+        },
+        {
+          "key": "DISK_DEVICES",
+          "group": "DISK_DEVICES",
+          "type": "text",
+          "placeholder": "Space-separated device identifiers",
+          "description": "Define disk devices on which the following DISK/AHCI_RUNTIME parameters act.\nSeparate multiple devices with spaces.\nDevices can be specified by disk ID also (lookup with: tlp diskid)"
+        },
+        {
+          "key": "DISK_APM_LEVEL_ON_AC",
+          "group": "DISK_APM_LEVEL",
+          "type": "text",
+          "itemMin": 1,
+          "itemMax": 255,
+          "placeholder": "Space-separated values matching DISK_DEVICES",
+          "profile": "AC"
+        },
+        {
+          "key": "DISK_APM_LEVEL_ON_BAT",
+          "group": "DISK_APM_LEVEL",
+          "type": "text",
+          "itemMin": 1,
+          "itemMax": 255,
+          "placeholder": "Space-separated values matching DISK_DEVICES",
+          "profile": "BAT"
+        },
+        {
+          "key": "DISK_APM_CLASS_DENYLIST",
+          "group": "DISK_APM_CLASS_DENYLIST",
+          "type": "list",
+          "values": [
+            "sata",
+            "ata",
+            "usb",
+            "ieee1394"
+          ],
+          "description": "Exclude disk classes from advanced power management (APM):\n- sata, ata, usb, ieee1394.\nSeparate multiple classes with spaces.\nCAUTION: USB and IEEE1394 disks may fail to mount or data may get corrupted with APM enabled.\nBe careful and make sure you have backups of all affected media before removing 'usb' or 'ieee1394' from the denylist(!)"
+        },
+        {
+          "key": "DISK_SPINDOWN_TIMEOUT_ON_AC",
+          "group": "DISK_SPINDOWN_TIMEOUT",
+          "type": "text",
+          "itemMin": 0,
+          "itemMax": 251,
+          "placeholder": "Space-separated values matching DISK_DEVICES",
+          "profile": "AC"
+        },
+        {
+          "key": "DISK_SPINDOWN_TIMEOUT_ON_BAT",
+          "group": "DISK_SPINDOWN_TIMEOUT",
+          "type": "text",
+          "itemMin": 0,
+          "itemMax": 251,
+          "placeholder": "Space-separated values matching DISK_DEVICES",
+          "profile": "BAT"
+        },
+        {
+          "key": "DISK_IOSCHED",
+          "group": "DISK_IOSCHED",
+          "type": "text",
+          "itemValues": [
+            "mq-deadline",
+            "none",
+            "kyber",
+            "bfq",
+            "deadline",
+            "cfq",
+            "noop"
+          ],
+          "placeholder": "Space-separated values matching DISK_DEVICES",
+          "description": "Select io scheduler for the disk devices: noop/deadline/cfq (Default: cfq)\nSeparate values for multiple devices with spaces"
+        },
+        {
+          "key": "SATA_LINKPWR_ON_AC",
+          "group": "SATA_LINKPWR",
+          "type": "list",
+          "values": [
+            "min_power",
+            "med_power_with_dipm",
+            "medium_power",
+            "max_performance"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "SATA_LINKPWR_ON_BAT",
+          "group": "SATA_LINKPWR",
+          "type": "list",
+          "values": [
+            "min_power",
+            "med_power_with_dipm",
+            "medium_power",
+            "max_performance"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "SATA_LINKPWR_DENYLIST",
+          "group": "SATA_LINKPWR_DENYLIST",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "description": "Exclude SATA links from AHCI link power management (ALPM).\nSATA links are specified by their host. Refer to the output of\ntlp-stat -d to determine the host; the format is \"hostX\".\nSeparate multiple hosts with spaces"
+        },
+        {
+          "key": "AHCI_RUNTIME_PM_ON_AC",
+          "group": "AHCI_RUNTIME_PM",
+          "type": "select",
+          "values": [
+            "on",
+            "auto"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "AHCI_RUNTIME_PM_ON_BAT",
+          "group": "AHCI_RUNTIME_PM",
+          "type": "select",
+          "values": [
+            "on",
+            "auto"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "AHCI_RUNTIME_PM_TIMEOUT",
+          "group": "AHCI_RUNTIME_PM_TIMEOUT",
+          "type": "number",
+          "min": 0,
+          "max": 10000,
+          "step": 1,
+          "description": "Seconds of inactivity before disk is suspended",
+          "unit": "s"
+        },
+        {
+          "key": "BAY_POWEROFF_ON_AC",
+          "group": "BAY_POWEROFF",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "BAY_POWEROFF_ON_BAT",
+          "group": "BAY_POWEROFF",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "BAY_DEVICE",
+          "group": "BAY_DEVICE",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "description": "Optical drive device to power off (default sr0)"
+        }
+      ],
+      "id": "disks",
+      "icon": "hard_drive",
+      "waffleIcon": "desktop",
+      "groups": [
+        {
+          "id": "DISK_IDLE_SECS",
+          "title": "DISK IDLE SECS",
+          "description": "Delay before syncing an idle disk; 0 disables laptop mode."
+        },
+        {
+          "id": "MAX_LOST_WORK_SECS",
+          "title": "MAX LOST WORK SECS",
+          "description": "Maximum age of dirty pages before they are written to disk."
+        },
+        {
+          "id": "DISK_DEVICES",
+          "title": "DISK DEVICES",
+          "description": "Target disks for disk and AHCI settings. Separate device names or tlp diskid IDs with spaces."
+        },
+        {
+          "id": "DISK_APM_LEVEL",
+          "title": "DISK APM LEVEL",
+          "description": "Hard-disk APM level per device. Lower values save more power; 255 disables APM. Levels 1–127 may spin disks down."
+        },
+        {
+          "id": "DISK_APM_CLASS_DENYLIST",
+          "title": "DISK APM CLASS DENYLIST",
+          "description": "Disk classes excluded from APM. Keep USB and IEEE 1394 excluded unless you understand the data-loss risk."
+        },
+        {
+          "id": "DISK_SPINDOWN_TIMEOUT",
+          "title": "DISK SPINDOWN TIMEOUT",
+          "description": "Hard-disk spin-down timeout in hdparm units; 0 disables spin-down."
+        },
+        {
+          "id": "DISK_IOSCHED",
+          "title": "DISK IOSCHED",
+          "description": "I/O scheduler per target disk. Separate multiple values with spaces."
+        },
+        {
+          "id": "SATA_LINKPWR",
+          "title": "SATA LINKPWR",
+          "description": "SATA/AHCI link power policy. Aggressive modes save more power but may reduce compatibility."
+        },
+        {
+          "id": "SATA_LINKPWR_DENYLIST",
+          "title": "SATA LINKPWR DENYLIST",
+          "description": "SATA hosts excluded from link power management. Find host names with tlp-stat -d."
+        },
+        {
+          "id": "AHCI_RUNTIME_PM",
+          "title": "AHCI RUNTIME PM",
+          "description": "Runtime power management for NVMe, SATA, ATA, USB disks, and SATA ports."
+        },
+        {
+          "id": "AHCI_RUNTIME_PM_TIMEOUT",
+          "title": "AHCI RUNTIME PM TIMEOUT",
+          "description": "Idle time before managed disks enter runtime suspend."
+        },
+        {
+          "id": "BAY_POWEROFF",
+          "title": "BAY POWEROFF",
+          "description": "Power off supported optical drives in UltraBay/MediaBay. Hard disks are never powered off."
+        },
+        {
+          "id": "BAY_DEVICE",
+          "title": "BAY DEVICE",
+          "description": "Optical-drive device to power off, usually sr0."
+        }
+      ]
+    },
+    {
+      "name": "Graphics",
+      "description": "Intel and AMD graphics power and frequency policy.",
+      "settings": [
+        {
+          "key": "INTEL_GPU_POWER_PROFILE_ON_AC",
+          "group": "INTEL_GPU_POWER_PROFILE",
+          "type": "select",
+          "values": [
+            "base",
+            "power_saving"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "INTEL_GPU_POWER_PROFILE_ON_BAT",
+          "group": "INTEL_GPU_POWER_PROFILE",
+          "type": "select",
+          "values": [
+            "base",
+            "power_saving"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "INTEL_GPU_POWER_PROFILE_ON_SAV",
+          "group": "INTEL_GPU_POWER_PROFILE",
+          "type": "select",
+          "values": [
+            "base",
+            "power_saving"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "INTEL_GPU_MIN_FREQ_ON_AC",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "AC",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_MIN_FREQ_ON_BAT",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_MIN_FREQ_ON_SAV",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "SAV",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_MAX_FREQ_ON_AC",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "AC",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_MAX_FREQ_ON_BAT",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_MAX_FREQ_ON_SAV",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "SAV",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_BOOST_FREQ_ON_AC",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "AC",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_BOOST_FREQ_ON_BAT",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "MHz"
+        },
+        {
+          "key": "INTEL_GPU_BOOST_FREQ_ON_SAV",
+          "group": "INTEL_GPU_FREQ",
+          "type": "number",
+          "min": 0,
+          "max": 5000,
+          "step": 1,
+          "profile": "SAV",
+          "unit": "MHz"
+        },
+        {
+          "key": "RADEON_DPM_PERF_LEVEL_ON_AC",
+          "group": "RADEON_DPM_PERF_LEVEL",
+          "type": "select",
+          "values": [
+            "auto",
+            "low",
+            "high"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "RADEON_DPM_PERF_LEVEL_ON_BAT",
+          "group": "RADEON_DPM_PERF_LEVEL",
+          "type": "select",
+          "values": [
+            "auto",
+            "low",
+            "high"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "RADEON_DPM_PERF_LEVEL_ON_SAV",
+          "group": "RADEON_DPM_PERF_LEVEL",
+          "type": "select",
+          "values": [
+            "auto",
+            "low",
+            "high"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "AMDGPU_ABM_LEVEL_ON_AC",
+          "group": "AMDGPU_ABM_LEVEL",
+          "type": "number",
+          "min": 0,
+          "max": 4,
+          "step": 1,
+          "profile": "AC"
+        },
+        {
+          "key": "AMDGPU_ABM_LEVEL_ON_BAT",
+          "group": "AMDGPU_ABM_LEVEL",
+          "type": "number",
+          "min": 0,
+          "max": 4,
+          "step": 1,
+          "profile": "BAT"
+        },
+        {
+          "key": "AMDGPU_ABM_LEVEL_ON_SAV",
+          "group": "AMDGPU_ABM_LEVEL",
+          "type": "number",
+          "min": 0,
+          "max": 4,
+          "step": 1,
+          "profile": "SAV"
+        }
+      ],
+      "id": "graphics",
+      "icon": "monitor",
+      "waffleIcon": "desktop",
+      "groups": [
+        {
+          "id": "INTEL_GPU_POWER_PROFILE",
+          "title": "INTEL GPU POWER PROFILE",
+          "description": "Intel Xe only · Select the xe-driver power profile."
+        },
+        {
+          "id": "INTEL_GPU_FREQ",
+          "title": "INTEL GPU FREQ",
+          "description": "Intel only · Set supported GPU min, max, and boost frequencies. Check tlp-stat -g."
+        },
+        {
+          "id": "RADEON_DPM_PERF_LEVEL",
+          "title": "RADEON DPM PERF LEVEL",
+          "description": "AMD only · Select the DPM level for amdgpu/radeon; Automatic is recommended."
+        },
+        {
+          "id": "AMDGPU_ABM_LEVEL",
+          "title": "AMDGPU ABM LEVEL",
+          "description": "AMD Vega+ only · Set panel ABM strength. Higher levels save more power but may affect color."
+        }
+      ]
+    },
+    {
+      "name": "Network",
+      "description": "Wi-Fi power saving and Wake-on-LAN.",
+      "settings": [
+        {
+          "key": "WIFI_PWR_ON_AC",
+          "group": "WIFI_PWR",
+          "type": "select",
+          "values": [
+            "off",
+            "on"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "WIFI_PWR_ON_BAT",
+          "group": "WIFI_PWR",
+          "type": "select",
+          "values": [
+            "off",
+            "on"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "WOL_DISABLE",
+          "group": "WOL_DISABLE",
+          "type": "select",
+          "values": [
+            "N",
+            "Y"
+          ],
+          "description": "Disable wake on LAN"
+        }
+      ],
+      "id": "network",
+      "icon": "wifi",
+      "waffleIcon": "wifi-3",
+      "groups": [
+        {
+          "id": "WIFI_PWR",
+          "title": "WIFI PWR",
+          "description": "Wi-Fi power-saving policy for AC and battery profiles."
+        },
+        {
+          "id": "WOL_DISABLE",
+          "title": "WOL DISABLE",
+          "description": "Disable Wake-on-LAN to reduce idle network power."
+        }
+      ]
+    },
+    {
+      "name": "PCIe",
+      "description": "PCIe ASPM and runtime power management.",
+      "settings": [
+        {
+          "key": "PCIE_ASPM_ON_AC",
+          "group": "PCIE_ASPM",
+          "type": "select",
+          "values": [
+            "default",
+            "performance",
+            "powersave",
+            "powersupersave"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "PCIE_ASPM_ON_BAT",
+          "group": "PCIE_ASPM",
+          "type": "select",
+          "values": [
+            "default",
+            "performance",
+            "powersave",
+            "powersupersave"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "PCIE_ASPM_ON_SAV",
+          "group": "PCIE_ASPM",
+          "type": "select",
+          "values": [
+            "default",
+            "performance",
+            "powersave",
+            "powersupersave"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "RUNTIME_PM_ON_AC",
+          "group": "RUNTIME_PM",
+          "type": "select",
+          "values": [
+            "on",
+            "auto"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "RUNTIME_PM_ON_BAT",
+          "group": "RUNTIME_PM",
+          "type": "select",
+          "values": [
+            "on",
+            "auto"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "RUNTIME_PM_DENYLIST",
+          "group": "RUNTIME_PM_DENYLIST",
+          "type": "text",
+          "placeholder": "Space-separated device identifiers",
+          "description": "Exclude listed PCIe device adresses from Runtime PM.\nNote: this preserves the kernel driver default, to force a certain state\n- use RUNTIME_PM_ENABLE/DISABLE instead.\nSeparate multiple addresses with spaces.\nUse lspci to get the addresses (1st column)"
+        },
+        {
+          "key": "RUNTIME_PM_DRIVER_DENYLIST",
+          "group": "RUNTIME_PM_DRIVER_DENYLIST",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "description": "Exclude PCIe devices assigned to the listed drivers from Runtime PM.\nNote: this preserves the kernel driver default, to force a certain state\n- use RUNTIME_PM_ENABLE/DISABLE instead.\nSeparate multiple drivers with spaces.\nLeave empty to disable completely"
+        },
+        {
+          "key": "RUNTIME_PM_ENABLE",
+          "group": "RUNTIME_PM_DEVICE",
+          "type": "text",
+          "placeholder": "TLP configuration value"
+        },
+        {
+          "key": "RUNTIME_PM_DISABLE",
+          "group": "RUNTIME_PM_DEVICE",
+          "type": "text",
+          "placeholder": "TLP configuration value"
+        }
+      ],
+      "id": "pcie",
+      "icon": "device_hub",
+      "waffleIcon": "device-eq",
+      "groups": [
+        {
+          "id": "PCIE_ASPM",
+          "title": "PCIE ASPM",
+          "description": "PCIe link power policy. System default is the safest choice."
+        },
+        {
+          "id": "RUNTIME_PM",
+          "title": "RUNTIME PM",
+          "description": "Runtime power management for PCIe devices."
+        },
+        {
+          "id": "RUNTIME_PM_DENYLIST",
+          "title": "RUNTIME PM DENYLIST",
+          "description": "PCIe addresses excluded from Runtime PM. Find addresses with lspci."
+        },
+        {
+          "id": "RUNTIME_PM_DRIVER_DENYLIST",
+          "title": "RUNTIME PM DRIVER DENYLIST",
+          "description": "Exclude all PCIe devices using listed drivers. Separate driver names with spaces."
+        },
+        {
+          "id": "RUNTIME_PM_DEVICE",
+          "title": "RUNTIME PM DEVICE",
+          "description": "Force Runtime PM on or off for listed PCIe addresses. These rules take priority."
+        }
+      ]
+    },
+    {
+      "name": "Processor",
+      "description": "Intel and AMD CPU drivers, governors, boost, and platform profiles.",
+      "settings": [
+        {
+          "key": "CPU_DRIVER_OPMODE_ON_AC",
+          "group": "CPU_DRIVER_OPMODE",
+          "type": "select",
+          "values": [
+            "active",
+            "passive",
+            "guided"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_DRIVER_OPMODE_ON_BAT",
+          "group": "CPU_DRIVER_OPMODE",
+          "type": "select",
+          "values": [
+            "active",
+            "passive",
+            "guided"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_DRIVER_OPMODE_ON_SAV",
+          "group": "CPU_DRIVER_OPMODE",
+          "type": "select",
+          "values": [
+            "active",
+            "passive",
+            "guided"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "CPU_SCALING_GOVERNOR_ON_AC",
+          "group": "CPU_SCALING_GOVERNOR",
+          "type": "select",
+          "values": [
+            "ondemand",
+            "powersave",
+            "performance",
+            "conservative",
+            "schedutil"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_SCALING_GOVERNOR_ON_BAT",
+          "group": "CPU_SCALING_GOVERNOR",
+          "type": "select",
+          "values": [
+            "ondemand",
+            "powersave",
+            "performance",
+            "conservative",
+            "schedutil"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_SCALING_GOVERNOR_ON_SAV",
+          "group": "CPU_SCALING_GOVERNOR",
+          "type": "select",
+          "values": [
+            "ondemand",
+            "powersave",
+            "performance",
+            "conservative",
+            "schedutil"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "CPU_SCALING_MIN_FREQ_ON_AC",
+          "group": "CPU_SCALING_FREQ",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_SCALING_MAX_FREQ_ON_AC",
+          "group": "CPU_SCALING_FREQ",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_SCALING_MIN_FREQ_ON_BAT",
+          "group": "CPU_SCALING_FREQ",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_SCALING_MAX_FREQ_ON_BAT",
+          "group": "CPU_SCALING_FREQ",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_SCALING_MIN_FREQ_ON_SAV",
+          "group": "CPU_SCALING_FREQ",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "profile": "SAV"
+        },
+        {
+          "key": "CPU_SCALING_MAX_FREQ_ON_SAV",
+          "group": "CPU_SCALING_FREQ",
+          "type": "text",
+          "placeholder": "TLP configuration value",
+          "profile": "SAV"
+        },
+        {
+          "key": "CPU_ENERGY_PERF_POLICY_ON_AC",
+          "group": "CPU_ENERGY_PERF_POLICY",
+          "type": "select",
+          "values": [
+            "default",
+            "performance",
+            "balance_performance",
+            "balance_power",
+            "power"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_ENERGY_PERF_POLICY_ON_BAT",
+          "group": "CPU_ENERGY_PERF_POLICY",
+          "type": "select",
+          "values": [
+            "default",
+            "performance",
+            "balance_performance",
+            "balance_power",
+            "power"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_ENERGY_PERF_POLICY_ON_SAV",
+          "group": "CPU_ENERGY_PERF_POLICY",
+          "type": "select",
+          "values": [
+            "default",
+            "performance",
+            "balance_performance",
+            "balance_power",
+            "power"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "CPU_MIN_PERF_ON_AC",
+          "group": "CPU_PERF",
+          "type": "number",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "profile": "AC",
+          "unit": "%"
+        },
+        {
+          "key": "CPU_MAX_PERF_ON_AC",
+          "group": "CPU_PERF",
+          "type": "number",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "profile": "AC",
+          "unit": "%"
+        },
+        {
+          "key": "CPU_MIN_PERF_ON_BAT",
+          "group": "CPU_PERF",
+          "type": "number",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "%"
+        },
+        {
+          "key": "CPU_MAX_PERF_ON_BAT",
+          "group": "CPU_PERF",
+          "type": "number",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "profile": "BAT",
+          "unit": "%"
+        },
+        {
+          "key": "CPU_MIN_PERF_ON_SAV",
+          "group": "CPU_PERF",
+          "type": "number",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "profile": "SAV",
+          "unit": "%"
+        },
+        {
+          "key": "CPU_MAX_PERF_ON_SAV",
+          "group": "CPU_PERF",
+          "type": "number",
+          "min": 0,
+          "max": 100,
+          "step": 1,
+          "profile": "SAV",
+          "unit": "%"
+        },
+        {
+          "key": "CPU_BOOST_ON_AC",
+          "group": "CPU_BOOST",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_BOOST_ON_BAT",
+          "group": "CPU_BOOST",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_BOOST_ON_SAV",
+          "group": "CPU_BOOST",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "CPU_HWP_DYN_BOOST_ON_AC",
+          "group": "CPU_HWP_DYN_BOOST",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "CPU_HWP_DYN_BOOST_ON_BAT",
+          "group": "CPU_HWP_DYN_BOOST",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "BAT"
+        },
+        {
+          "key": "CPU_HWP_DYN_BOOST_ON_SAV",
+          "group": "CPU_HWP_DYN_BOOST",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "profile": "SAV"
+        },
+        {
+          "key": "NMI_WATCHDOG",
+          "group": "NMI_WATCHDOG",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Kernel NMI Watchdog\noff: saves power, on: for kernel debugging only"
+        },
+        {
+          "key": "PLATFORM_PROFILE_ON_AC",
+          "group": "PLATFORM_PROFILE",
+          "type": "select",
+          "values": [
+            "performance",
+            "balanced",
+            "low-power"
+          ],
+          "multipleFromVersion": "1.11",
+          "profile": "AC"
+        },
+        {
+          "key": "PLATFORM_PROFILE_ON_BAT",
+          "group": "PLATFORM_PROFILE",
+          "type": "select",
+          "values": [
+            "performance",
+            "balanced",
+            "low-power"
+          ],
+          "multipleFromVersion": "1.11",
+          "profile": "BAT"
+        },
+        {
+          "key": "PLATFORM_PROFILE_ON_SAV",
+          "group": "PLATFORM_PROFILE",
+          "type": "select",
+          "values": [
+            "performance",
+            "balanced",
+            "low-power"
+          ],
+          "multipleFromVersion": "1.11",
+          "profile": "SAV"
+        },
+        {
+          "key": "MEM_SLEEP_ON_AC",
+          "group": "MEM_SLEEP",
+          "type": "select",
+          "values": [
+            "s2idle",
+            "deep"
+          ],
+          "profile": "AC"
+        },
+        {
+          "key": "MEM_SLEEP_ON_BAT",
+          "group": "MEM_SLEEP",
+          "type": "select",
+          "values": [
+            "s2idle",
+            "deep"
+          ],
+          "profile": "BAT"
+        }
+      ],
+      "id": "processor",
+      "icon": "memory",
+      "waffleIcon": "settings-cog-multiple",
+      "groups": [
+        {
+          "id": "CPU_DRIVER_OPMODE",
+          "title": "CPU DRIVER OPMODE",
+          "description": "Intel/AMD · intel_pstate supports Active or Passive; amd-pstate may also support Guided."
+        },
+        {
+          "id": "CPU_SCALING_GOVERNOR",
+          "title": "CPU SCALING GOVERNOR",
+          "description": "Intel/AMD · Available governors depend on the active CPU driver. Check tlp-stat -p before changing defaults."
+        },
+        {
+          "id": "CPU_SCALING_FREQ",
+          "title": "CPU SCALING FREQ",
+          "description": "Intel/AMD · Set frequency limits supported by the active driver. With intel_pstate, prefer performance percentages."
+        },
+        {
+          "id": "CPU_ENERGY_PERF_POLICY",
+          "title": "CPU ENERGY PERF POLICY",
+          "description": "Intel only · Select the HWP/EPP or EPB energy policy. Check tlp-stat -p for support."
+        },
+        {
+          "id": "CPU_PERF",
+          "title": "CPU PERF",
+          "description": "Intel only · Limit CPU performance as a percentage. Requires intel_pstate or intel_cpufreq."
+        },
+        {
+          "id": "CPU_BOOST",
+          "title": "CPU BOOST",
+          "description": "Intel/AMD · Allow or block turbo boost. Enabled permits boost; it does not force it."
+        },
+        {
+          "id": "CPU_HWP_DYN_BOOST",
+          "title": "CPU HWP DYN BOOST",
+          "description": "Intel only · Dynamic HWP boost requires intel_pstate Active mode and a supported CPU."
+        },
+        {
+          "id": "NMI_WATCHDOG",
+          "title": "NMI WATCHDOG",
+          "description": "Disable to save a small amount of power; enable only for kernel debugging."
+        },
+        {
+          "id": "PLATFORM_PROFILE",
+          "title": "PLATFORM PROFILE",
+          "description": "Hardware-dependent · Balance performance, thermals, and fan behavior. Check tlp-stat -p."
+        },
+        {
+          "id": "MEM_SLEEP",
+          "title": "MEM SLEEP",
+          "description": "Suspend mode: s2idle wakes faster; deep usually saves more power. Keep the system default if unsure."
+        }
+      ]
+    },
+    {
+      "name": "Radio",
+      "description": "Bluetooth, Wi-Fi, WWAN and NFC state by power profile.",
+      "settings": [
+        {
+          "key": "DEVICES_TO_DISABLE_ON_STARTUP",
+          "group": "DEVICES_TO_DISABLE_ON_STARTUP",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "description": "Radio devices to disable on startup: bluetooth wifi wwan"
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_STARTUP",
+          "group": "DEVICES_TO_ENABLE_ON_STARTUP",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "description": "Radio devices to enable on startup: bluetooth wifi wwan"
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_AC",
+          "group": "DEVICES_TO_ENABLE_ON_AC",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "description": "Radio devices to enable on AC: bluetooth, wifi, wwan",
+          "profile": "AC"
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_BAT",
+          "group": "DEVICES_TO_DISABLE_ON_BAT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "description": "Radio devices to disable on battery: bluetooth, wifi, wwan",
+          "profile": "BAT"
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE",
+          "group": "DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "description": "Radio devices to disable on battery when not in use (not connected):\nbluetooth, wifi, wwan",
+          "profile": "BAT"
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_AC",
+          "group": "PROFILE_RADIO",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "minVersion": "1.11",
+          "profile": "AC"
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_AC_NOT_IN_USE",
+          "group": "PROFILE_RADIO",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "minVersion": "1.11",
+          "profile": "AC"
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_BAT",
+          "group": "PROFILE_RADIO",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "minVersion": "1.11",
+          "profile": "BAT"
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_SAV",
+          "group": "PROFILE_RADIO",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "minVersion": "1.11",
+          "profile": "SAV"
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_SAV",
+          "group": "PROFILE_RADIO",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "minVersion": "1.11",
+          "profile": "SAV"
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_SAV_NOT_IN_USE",
+          "group": "PROFILE_RADIO",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "nfc",
+            "wifi",
+            "wwan"
+          ],
+          "minVersion": "1.11",
+          "profile": "SAV"
+        }
+      ],
+      "id": "radio",
+      "icon": "cell_tower",
+      "waffleIcon": "wifi-3",
+      "groups": [
+        {
+          "id": "DEVICES_TO_DISABLE_ON_STARTUP",
+          "title": "DEVICES TO DISABLE ON STARTUP",
+          "description": "Select radios TLP disables at startup."
+        },
+        {
+          "id": "DEVICES_TO_ENABLE_ON_STARTUP",
+          "title": "DEVICES TO ENABLE ON STARTUP",
+          "description": "Select radios TLP enables at startup."
+        },
+        {
+          "id": "DEVICES_TO_ENABLE_ON_AC",
+          "title": "DEVICES TO ENABLE ON AC",
+          "description": "Select radios TLP enables while connected to AC."
+        },
+        {
+          "id": "DEVICES_TO_DISABLE_ON_BAT",
+          "title": "DEVICES TO DISABLE ON BAT",
+          "description": "Select radios TLP disables on battery power."
+        },
+        {
+          "id": "DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE",
+          "title": "DEVICES TO DISABLE ON BAT NOT IN USE",
+          "description": "Disable selected radios on battery when they are not connected."
+        },
+        {
+          "id": "PROFILE_RADIO",
+          "title": "PROFILE RADIO",
+          "description": "TLP 1.11+ · Radio rules for Performance, Balanced, and Power saver profiles."
+        }
+      ]
+    },
+    {
+      "name": "Radio Wizard",
+      "description": "Radio switching on network, dock and undock events.",
+      "settings": [
+        {
+          "key": "DEVICES_TO_DISABLE_ON_LAN_CONNECT",
+          "group": "DEVICES_TO_DISABLE_ON_CONNECT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_WIFI_CONNECT",
+          "group": "DEVICES_TO_DISABLE_ON_CONNECT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_WWAN_CONNECT",
+          "group": "DEVICES_TO_DISABLE_ON_CONNECT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_LAN_DISCONNECT",
+          "group": "DEVICES_TO_ENABLE_ON_DISCONNECT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_WIFI_DISCONNECT",
+          "group": "DEVICES_TO_ENABLE_ON_DISCONNECT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_WWAN_DISCONNECT",
+          "group": "DEVICES_TO_ENABLE_ON_DISCONNECT",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_DOCK",
+          "group": "DEVICES_ON_DOCK",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_DOCK",
+          "group": "DEVICES_ON_DOCK",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_ENABLE_ON_UNDOCK",
+          "group": "DEVICES_ON_UNDOCK",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        },
+        {
+          "key": "DEVICES_TO_DISABLE_ON_UNDOCK",
+          "group": "DEVICES_ON_UNDOCK",
+          "type": "list",
+          "values": [
+            "bluetooth",
+            "wifi",
+            "wwan"
+          ]
+        }
+      ],
+      "id": "radio-device-wizard",
+      "icon": "settings_input_antenna",
+      "waffleIcon": "settings",
+      "groups": [
+        {
+          "id": "DEVICES_TO_DISABLE_ON_CONNECT",
+          "title": "DEVICES TO DISABLE ON CONNECT",
+          "description": "Disable selected radios when LAN, Wi-Fi, or WWAN connects."
+        },
+        {
+          "id": "DEVICES_TO_ENABLE_ON_DISCONNECT",
+          "title": "DEVICES TO ENABLE ON DISCONNECT",
+          "description": "Enable selected radios when LAN, Wi-Fi, or WWAN disconnects."
+        },
+        {
+          "id": "DEVICES_ON_DOCK",
+          "title": "DEVICES ON DOCK",
+          "description": "Choose radio changes applied when the laptop docks."
+        },
+        {
+          "id": "DEVICES_ON_UNDOCK",
+          "title": "DEVICES ON UNDOCK",
+          "description": "Choose radio changes applied when the laptop undocks."
+        }
+      ]
+    },
+    {
+      "name": "USB",
+      "description": "USB autosuspend and device inclusion/exclusion rules.",
+      "settings": [
+        {
+          "key": "USB_AUTOSUSPEND",
+          "group": "USB_AUTOSUSPEND",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "USB autosuspend feature"
+        },
+        {
+          "key": "USB_DENYLIST",
+          "group": "USB_DENYLIST",
+          "type": "text",
+          "placeholder": "Space-separated device identifiers",
+          "description": "Exclude listed devices from USB autosuspend (separate with spaces).\nUse lsusb to get the ids.\nNote: input devices (usbhid) and libsane-supported scanners are excluded automatically"
+        },
+        {
+          "key": "USB_EXCLUDE_AUDIO",
+          "group": "USB_EXCLUDE_AUDIO",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Exclude audio devices from USB autosuspend:\n- 0=do not exclude, 1=exclude"
+        },
+        {
+          "key": "USB_EXCLUDE_BTUSB",
+          "group": "USB_EXCLUDE_BTUSB",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Exclude bluetooth devices from USB autosuspend:\n- 0=do not exclude, 1=exclude"
+        },
+        {
+          "key": "USB_EXCLUDE_PHONE",
+          "group": "USB_EXCLUDE_PHONE",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Exclude phone devices from USB autosuspend:\n- 0=do not exclude, 1=exclude (enable charging)"
+        },
+        {
+          "key": "USB_EXCLUDE_PRINTER",
+          "group": "USB_EXCLUDE_PRINTER",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Exclude printers from USB autosuspend:\n- 0=do not exclude, 1=exclude"
+        },
+        {
+          "key": "USB_EXCLUDE_WWAN",
+          "group": "USB_EXCLUDE_WWAN",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Exclude WWAN devices from USB autosuspend:\n- 0=do not exclude, 1=exclude"
+        },
+        {
+          "key": "USB_ALLOWLIST",
+          "group": "USB_ALLOWLIST",
+          "type": "text",
+          "placeholder": "Space-separated device identifiers",
+          "description": "Allow USB autosuspend for listed devices even if already denylisted or\nexcluded above (separate with spaces). Use lsusb to get the ids"
+        }
+      ],
+      "id": "usb",
+      "icon": "usb",
+      "waffleIcon": "device-eq",
+      "groups": [
+        {
+          "id": "USB_AUTOSUSPEND",
+          "title": "USB AUTOSUSPEND",
+          "description": "Suspend idle USB devices to reduce power use."
+        },
+        {
+          "id": "USB_DENYLIST",
+          "title": "USB DENYLIST",
+          "description": "USB IDs excluded from autosuspend. Find IDs with lsusb and separate them with spaces."
+        },
+        {
+          "id": "USB_EXCLUDE_AUDIO",
+          "title": "USB EXCLUDE AUDIO",
+          "description": "Keep USB audio devices awake."
+        },
+        {
+          "id": "USB_EXCLUDE_BTUSB",
+          "title": "USB EXCLUDE BTUSB",
+          "description": "Keep USB Bluetooth adapters awake."
+        },
+        {
+          "id": "USB_EXCLUDE_PHONE",
+          "title": "USB EXCLUDE PHONE",
+          "description": "Keep connected phones awake so they can continue charging."
+        },
+        {
+          "id": "USB_EXCLUDE_PRINTER",
+          "title": "USB EXCLUDE PRINTER",
+          "description": "Keep USB printers awake."
+        },
+        {
+          "id": "USB_EXCLUDE_WWAN",
+          "title": "USB EXCLUDE WWAN",
+          "description": "Keep USB WWAN adapters awake."
+        },
+        {
+          "id": "USB_ALLOWLIST",
+          "title": "USB ALLOWLIST",
+          "description": "USB IDs allowed to autosuspend even when another rule excludes them."
+        }
+      ]
+    },
+    {
+      "name": "Battery Care",
+      "description": "Charge thresholds and restoration behavior.",
+      "settings": [
+        {
+          "key": "RESTORE_THRESHOLDS_ON_BAT",
+          "group": "RESTORE_THRESHOLDS_ON_BAT",
+          "type": "select",
+          "values": [
+            "0",
+            "1"
+          ],
+          "description": "Restore charge thresholds when AC is unplugged",
+          "profile": "BAT"
+        }
+      ],
+      "id": "battery-care",
+      "icon": "battery_saver",
+      "waffleIcon": "battery-saver",
+      "groups": [
+        {
+          "id": "RESTORE_THRESHOLDS_ON_BAT",
+          "title": "RESTORE THRESHOLDS ON BAT",
+          "description": "Reapply configured charge thresholds after unplugging AC."
+        }
+      ]
+    }
+  ],
+  "descriptionAttribution": {
+    "source": "TLPUI configdescriptions.po",
+    "copyright": "Copyright (c) 2026 Daniel Christophis; descriptions adapted from TLP by Thomas Koch",
+    "license": "GPL-2.0-or-later"
+  }
+}

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -156,6 +156,19 @@ Input simulation, hardware control, and idle management.
 
 ---
 
+## Power Management
+
+TLP-backed battery care, power profiles, and device power policy.
+
+| Package | Purpose |
+|---------|---------|
+| `tlp` | Core TLP power-management service and configuration |
+| `tlp-pd` | Power Profiles D-Bus compatibility backed by TLP |
+| `tlp-rdw` | TLP Radio Device Wizard for network-triggered radio switching |
+| `ethtool` | Ethernet Wake-on-LAN control used by TLP's `WOL_DISABLE` setting |
+
+---
+
 ## Fonts & Theming (`inir-fonts`)
 
 Fonts, theming, and utilities.
@@ -185,7 +198,7 @@ Fonts, theming, and utilities.
 | `ttf-readex-pro` | Readex Pro font | No (has fallback) |
 | `ttf-rubik-vf` | Rubik variable font | No (has fallback) |
 | `otf-space-grotesk` | Space Grotesk font | No (has fallback) |
-| `ttf-twemoji` | Twitter emoji | No (has fallback) |
+| `ttf-twemoji` | Twitter emoji font | No (has fallback) |
 | `adw-gtk-theme-git` | Adwaita GTK theme | Yes |
 | `capitaine-cursors` | Capitaine cursor theme | Yes |
 | `xwayland-satellite` | Xwayland helper for legacy apps | Yes |

--- a/modules/settings/BatteryChargeLimitSettings.qml
+++ b/modules/settings/BatteryChargeLimitSettings.qml
@@ -1,0 +1,118 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+ColumnLayout {
+    id: root
+
+    property bool showStatus: true
+    property bool staged: false
+
+    readonly property bool requestedEnabled: root.staged
+        ? TlpSettingsService.chargeEnabled()
+        : (Config.options?.battery?.chargeLimit?.enable ?? false)
+    readonly property int requestedThreshold: root.staged
+        ? TlpSettingsService.chargeThreshold()
+        : Battery.effectiveChargeLimitThreshold
+
+    Layout.fillWidth: true
+    spacing: SettingsMaterialPreset.groupSpacing
+
+    ConfigRow {
+        enabled: Battery.chargeLimitSupported
+            || Battery.chargeLimitManaged
+            || root.requestedEnabled
+        uniform: false
+        Layout.fillWidth: false
+
+        SettingsSwitch {
+            buttonIcon: "battery_saver"
+            text: Translation.tr("Charge limit")
+            checked: root.requestedEnabled
+            autoToggle: false
+            onToggledByUser: checked => {
+                if (root.staged)
+                    TlpSettingsService.stageChargeEnabled(checked, root.requestedThreshold)
+                else
+                    Config.setNestedValue("battery.chargeLimit.enable", checked)
+            }
+
+            StyledToolTip {
+                text: !Battery.chargeLimitAvailable
+                    ? Translation.tr("TLP is not available")
+                    : Battery.chargeLimitStatusReason === "unsupported-tlp-version"
+                        ? Translation.tr("This TLP version is not supported yet")
+                    : Battery.chargeLimitStatusReason === "tlp-disabled"
+                        ? Translation.tr("TLP is disabled in its configuration")
+                    : Battery.chargeLimitStatusReason === "tlp-config-unavailable"
+                        ? Translation.tr("TLP configuration could not be read")
+                    : !Battery.chargeLimitSupported
+                        ? Translation.tr("Not supported on this device")
+                    : Battery.chargeLimitDiscrete
+                        ? Translation.tr("Choose a charge limit supported by this device (requires polkit)")
+                    : Battery.chargeLimitAdjustable
+                        ? Translation.tr("Stop charging at a specific percentage to extend battery lifespan (requires polkit)")
+                        : Translation.tr("Use your device's built-in battery conservation mode (requires polkit)")
+            }
+        }
+
+        ConfigSpinBox {
+            property bool _ready: false
+            visible: Battery.chargeLimitContinuous
+            enabled: root.requestedEnabled && Battery.chargeLimitContinuous
+            icon: "speed"
+            text: Translation.tr("at")
+            value: root.requestedThreshold
+            from: Battery.chargeLimitMinimum
+            to: Battery.chargeLimitMaximum
+            stepSize: Battery.chargeLimitStepSize
+            Component.onCompleted: _ready = true
+            onValueChanged: {
+                if (!_ready || value === root.requestedThreshold)
+                    return
+                if (root.staged)
+                    TlpSettingsService.stageChargeThreshold(value)
+                else
+                    Config.setNestedValue("battery.chargeLimit.threshold", value)
+            }
+
+            StyledToolTip {
+                text: Translation.tr("Maximum charge percentage")
+            }
+        }
+
+        ConfigSelectionArray {
+            visible: Battery.chargeLimitDiscrete
+            enabled: root.requestedEnabled && Battery.chargeLimitDiscrete
+            currentValue: root.requestedThreshold
+            options: Battery.chargeLimitAllowedValues.map(value => ({
+                displayName: String(value) + "%",
+                value: value
+            }))
+            onSelected: newValue => {
+                if (root.staged)
+                    TlpSettingsService.stageChargeThreshold(Number(newValue))
+                else
+                    Config.setNestedValue("battery.chargeLimit.threshold", newValue)
+            }
+        }
+    }
+
+    StyledText {
+        visible: root.showStatus && Battery.chargeLimitSupported
+        Layout.leftMargin: SettingsMaterialPreset.groupPadding
+        text: !Battery.chargeLimitStateKnown
+            ? Translation.tr("Charge limit state unavailable")
+            : Battery.chargeLimitActive
+                ? (Battery.chargeLimitAdjustable && Battery.currentChargeLimit > 0 && Battery.currentChargeLimit < 100
+                    ? Translation.tr("Current limit: %1%").arg(Battery.currentChargeLimit)
+                    : Translation.tr("Battery conservation mode active"))
+                : Translation.tr("No charge limit active")
+        font.pixelSize: Appearance.font.pixelSize.smaller
+        color: Appearance.colors.colSubtext
+    }
+}

--- a/modules/settings/GeneralConfig.qml
+++ b/modules/settings/GeneralConfig.qml
@@ -159,59 +159,6 @@ ContentPage {
                     }
                 }
             }
-
-            SettingsDivider {}
-
-            ConfigRow {
-                enabled: Battery.chargeLimitSupported
-                uniform: false
-                Layout.fillWidth: false
-                SettingsSwitch {
-                    buttonIcon: "battery_saver"
-                    text: Translation.tr("Charge limit")
-                    checked: Config.options?.battery?.chargeLimit?.enable ?? false
-                    autoToggle: false
-                    onToggledByUser: checked => Config.setNestedValue("battery.chargeLimit.enable", checked)
-                    StyledToolTip {
-                        text: !Battery.chargeLimitSupported
-                            ? Translation.tr("Not supported on this device")
-                            : Battery.chargeLimitAdjustable
-                                ? Translation.tr("Stop charging at a specific percentage to extend battery lifespan (requires polkit)")
-                                : Translation.tr("Use your device's built-in battery conservation mode (requires polkit)")
-                    }
-                }
-                ConfigSpinBox {
-                    property bool _ready: false
-                    visible: Battery.chargeLimitAdjustable
-                    enabled: (Config.options?.battery?.chargeLimit?.enable ?? false) && Battery.chargeLimitAdjustable
-                    icon: "speed"
-                    text: Translation.tr("at")
-                    value: Config.options?.battery?.chargeLimit?.threshold ?? 80
-                    from: 20
-                    to: 100
-                    stepSize: 5
-                    Component.onCompleted: _ready = true
-                    onValueChanged: {
-                        if (_ready && value !== (Config.options?.battery?.chargeLimit?.threshold ?? 80))
-                            Config.setNestedValue("battery.chargeLimit.threshold", value);
-                    }
-                    StyledToolTip {
-                        text: Translation.tr("Maximum charge percentage")
-                    }
-                }
-            }
-
-            StyledText {
-                visible: Battery.chargeLimitSupported
-                Layout.leftMargin: 16
-                text: Battery.chargeLimitActive
-                    ? (Battery.currentChargeLimit > 0 && Battery.currentChargeLimit < 100
-                        ? Translation.tr("Current limit: %1%").arg(Battery.currentChargeLimit)
-                        : Translation.tr("Battery conservation mode active"))
-                    : Translation.tr("No charge limit active")
-                font.pixelSize: Appearance.font.pixelSize.smaller
-                color: Appearance.colors.colSubtext
-            }
         }
     }
     

--- a/modules/settings/SettingsOverlay.qml
+++ b/modules/settings/SettingsOverlay.qml
@@ -36,6 +36,8 @@ Scope {
             _closeAnimRunning = false
             closeAnimTimer.stop()
         } else {
+            if (TlpSettingsService.hasPendingChanges)
+                TlpSettingsService.applyOnLeave()
             _closeAnimRunning = true
             closeAnimTimer.restart()
         }
@@ -1863,6 +1865,11 @@ Scope {
     }
 
     onOverlayCurrentPageChanged: {
+        if (root._navigationInitialized
+                && root._prevPage === 27
+                && root.overlayCurrentPage !== 27
+                && TlpSettingsService.hasPendingChanges)
+            TlpSettingsService.applyOnLeave()
         root._slideDir = root.overlayCurrentPage > root._prevPage ? 1 : -1
         root._prevPage = root.overlayCurrentPage
         root._persistOverlayPage()

--- a/modules/settings/SettingsOverlay.qml
+++ b/modules/settings/SettingsOverlay.qml
@@ -36,8 +36,6 @@ Scope {
             _closeAnimRunning = false
             closeAnimTimer.stop()
         } else {
-            if (TlpSettingsService.hasPendingChanges)
-                TlpSettingsService.applyOnLeave()
             _closeAnimRunning = true
             closeAnimTimer.restart()
         }
@@ -1865,11 +1863,6 @@ Scope {
     }
 
     onOverlayCurrentPageChanged: {
-        if (root._navigationInitialized
-                && root._prevPage === 27
-                && root.overlayCurrentPage !== 27
-                && TlpSettingsService.hasPendingChanges)
-            TlpSettingsService.applyOnLeave()
         root._slideDir = root.overlayCurrentPage > root._prevPage ? 1 : -1
         root._prevPage = root.overlayCurrentPage
         root._persistOverlayPage()

--- a/modules/settings/SettingsPageRegistry.qml
+++ b/modules/settings/SettingsPageRegistry.qml
@@ -231,6 +231,14 @@ Singleton {
             desc: Translation.tr("Move and resize persistent shell surfaces"),
             essential: true,
             component: "modules/settings/ShellLayoutConfig.qml"
+        },
+        {
+            key: "tlp",
+            name: Translation.tr("Battery"),
+            icon: "battery_saver",
+            desc: Translation.tr("Charge care and TLP power management"),
+            essential: true,
+            component: "modules/settings/TlpConfig.qml"
         }
     ]
 
@@ -240,7 +248,7 @@ Singleton {
         { label: Translation.tr("Essentials"), pages: [0] },
         { label: Translation.tr("Appearance"), pages: [4, 25, 3, 14, 21] },
         { label: Translation.tr("Shell"), pages: [2, 26, 5, 22, 23, 16, 10, 11, 18, 19, 20] },
-        { label: Translation.tr("System"), pages: [1, 24, 7, 6, 12, 15, 8, 17] },
+        { label: Translation.tr("System"), pages: [1, 27, 24, 7, 6, 12, 15, 8, 17] },
         { label: Translation.tr("Reference"), pages: [9, 13] }
     ]
 
@@ -287,6 +295,20 @@ Singleton {
     }
 
     readonly property var staticSearchIndex: [
+        {
+            pageIndex: 27, pageName: root.pages[27].name,
+            section: Translation.tr("Power management"),
+            label: Translation.tr("Battery and TLP settings"),
+            description: Translation.tr("Power profiles, processor, disks, PCIe, USB, radios and battery care"),
+            keywords: ["tlp", "power", "battery", "cpu", "processor", "disk", "pcie", "usb", "radio", "energy", "profile", "charge"]
+        },
+        {
+            pageIndex: 27, pageName: root.pages[27].name,
+            section: Translation.tr("Battery Care"),
+            label: Translation.tr("Charge limit"),
+            description: Translation.tr("Hardware-aware TLP battery charge thresholds"),
+            keywords: ["tlp", "battery", "charge", "limit", "threshold", "thinkpad", "conservation"]
+        },
         {
             pageIndex: 26, pageName: root.pages[26].name,
             section: Translation.tr("Live shell layout"),

--- a/modules/settings/TlpConfig.qml
+++ b/modules/settings/TlpConfig.qml
@@ -1,0 +1,359 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+ContentPage {
+    id: root
+
+    settingsPageIndex: 27
+    settingsPageName: Translation.tr("Battery")
+
+    property int selectedCategoryIndex: 0
+    property string filterText: ""
+    property bool _categoryReady: false
+    property int _previousCategoryIndex: 0
+
+    readonly property string profileGuidanceSource: "When overriding this group, set every shown profile together to avoid values spilling between TLP profiles."
+    readonly property var selectedCategory: {
+        const categories = TlpSettingsService._array(TlpSettingsService.navigationCategories)
+        if (categories.length === 0)
+            return null
+        return categories[Math.max(0, Math.min(root.selectedCategoryIndex, categories.length - 1))]
+    }
+    readonly property var visibleGroups: TlpSettingsService.groupsForCategory(
+        root.selectedCategory, root.filterText)
+    readonly property bool profileGuidanceVisible: root.visibleGroups.some(group =>
+        String(group?.description ?? "").includes(root.profileGuidanceSource))
+    readonly property bool batteryCareSelected: String(root.selectedCategory?.id ?? "") === "battery-care"
+
+    function conciseGroupDescription(group): string {
+        const description = String(group?.description ?? "")
+        if (description === root.profileGuidanceSource)
+            return ""
+        const suffix = " " + root.profileGuidanceSource
+        return description.endsWith(suffix)
+            ? description.slice(0, description.length - suffix.length)
+            : description
+    }
+
+    function statusDescription(): string {
+        if (!TlpSettingsService.schemaLoaded)
+            return Translation.tr("The bundled TLP settings schema could not be loaded")
+        if (!TlpSettingsService.available)
+            return Translation.tr("TLP is not installed")
+        if (!TlpSettingsService.supported)
+            return TlpSettingsService.statusReason === "unsupported-tlp-version"
+                ? Translation.tr("This TLP version is not supported yet")
+                : Translation.tr("The installed TLP runtime is unavailable")
+        if (!TlpSettingsService.configAvailable)
+            return TlpSettingsService.statusReason === "managed-config-invalid"
+                ? Translation.tr("The iNiR TLP override file is invalid; reset overrides to recover")
+                : Translation.tr("TLP configuration could not be read")
+        return TlpSettingsService.enabled
+            ? Translation.tr("TLP %1 is active · %2 iNiR overrides").arg(
+                TlpSettingsService.tlpVersion).arg(TlpSettingsService.managedCount)
+            : Translation.tr("TLP %1 is disabled by configuration").arg(TlpSettingsService.tlpVersion)
+    }
+
+    function selectCategory(index: int): void {
+        if (index === root.selectedCategoryIndex || TlpSettingsService.busy)
+            return
+        root.selectedCategoryIndex = index
+    }
+
+    onSelectedCategoryIndexChanged: {
+        if (root._categoryReady
+                && root._previousCategoryIndex !== root.selectedCategoryIndex
+                && TlpSettingsService.hasPendingChanges)
+            TlpSettingsService.applyOnLeave()
+        root._previousCategoryIndex = root.selectedCategoryIndex
+        root.filterText = ""
+    }
+
+    Component.onCompleted: {
+        root._previousCategoryIndex = root.selectedCategoryIndex
+        root._categoryReady = true
+    }
+
+    SettingsCardSection {
+        expanded: true
+        collapsible: false
+        icon: "battery_saver"
+        title: Translation.tr("Battery and TLP power management")
+
+        SettingsGroup {
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: SettingsMaterialPreset.groupPadding
+
+                MaterialSymbol {
+                    text: TlpSettingsService.configAvailable
+                        ? (TlpSettingsService.enabled ? "check_circle" : "pause_circle")
+                        : "warning"
+                    iconSize: Appearance.font.pixelSize.huge
+                    color: TlpSettingsService.configAvailable
+                        ? Appearance.colors.colPrimary
+                        : Appearance.colors.colError
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: SettingsMaterialPreset.groupSpacing
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: root.statusDescription()
+                        wrapMode: Text.WordWrap
+                    }
+
+                    StyledText {
+                        visible: TlpSettingsService.configAvailable
+                            || TlpSettingsService.managedConfigPresent
+                        Layout.fillWidth: true
+                        text: Translation.tr("Managed settings: %1").arg(TlpSettingsService.configFile)
+                        color: Appearance.colors.colSubtext
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        font.family: Appearance.font.family.monospace
+                        elide: Text.ElideMiddle
+                    }
+                }
+
+                DialogButton {
+                    buttonText: Translation.tr("Refresh status")
+                    enabled: !TlpSettingsService.busy
+                    onClicked: {
+                        TlpSettingsService.refresh()
+                        TlpService.refresh()
+                    }
+                }
+            }
+
+            StyledText {
+                visible: TlpSettingsService.lastError.length > 0
+                Layout.fillWidth: true
+                text: TlpSettingsService.lastError
+                color: Appearance.colors.colError
+                wrapMode: Text.WordWrap
+                font.pixelSize: Appearance.font.pixelSize.smaller
+            }
+
+            SettingsDivider {}
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: SettingsMaterialPreset.groupSpacing
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: SettingsMaterialPreset.groupSpacing
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: TlpSettingsService.hasPendingChanges
+                            ? Translation.tr("%1 staged change(s)").arg(TlpSettingsService.pendingCount)
+                            : Translation.tr("Values shown below come from TLP's effective configuration")
+                        color: TlpSettingsService.hasPendingChanges
+                            ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
+                        font.weight: TlpSettingsService.hasPendingChanges ? Font.Medium : Font.Normal
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: Translation.tr("Apply validates every change and authenticates only once. No shell reload is required.")
+                        color: Appearance.colors.colSubtext
+                        wrapMode: Text.WordWrap
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                    }
+                }
+
+                DialogButton {
+                    buttonText: Translation.tr("Discard")
+                    enabled: TlpSettingsService.hasPendingChanges && !TlpSettingsService.busy
+                    onClicked: TlpSettingsService.discard()
+                }
+
+                DialogButton {
+                    buttonText: TlpSettingsService.busy
+                        ? Translation.tr("Applying…")
+                        : Translation.tr("Apply")
+                    enabled: TlpSettingsService.hasPendingChanges
+                        && TlpSettingsService.supported
+                        && TlpSettingsService.configAvailable
+                        && !TlpSettingsService.busy
+                    colBackground: Appearance.colors.colPrimary
+                    colBackgroundHover: Appearance.colors.colPrimaryHover
+                    colRipple: Appearance.colors.colPrimaryActive
+                    colText: Appearance.colors.colOnPrimary
+                    onClicked: TlpSettingsService.apply()
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: SettingsMaterialPreset.groupSpacing
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: TlpSettingsService.statusReason === "managed-config-invalid"
+                        ? Translation.tr("Reset deletes the invalid iNiR-owned TLP override file so TLP can fall back to its remaining configuration.")
+                        : Translation.tr("Reset removes only the general iNiR TLP override file; battery charge care stays separate.")
+                    color: Appearance.colors.colSubtext
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    wrapMode: Text.WordWrap
+                }
+
+                DialogButton {
+                    buttonText: Translation.tr("Reset overrides")
+                    enabled: TlpSettingsService.canResetOverrides
+                    onClicked: TlpSettingsService.reset()
+                }
+            }
+        }
+    }
+
+    SettingsCardSection {
+        expanded: true
+        collapsible: false
+        icon: "category"
+        title: Translation.tr("Configuration categories")
+
+        SettingsGroup {
+            GridLayout {
+                Layout.fillWidth: true
+                columns: root.width >= 760 ? 4 : (root.width >= 540 ? 3 : 2)
+                columnSpacing: SettingsMaterialPreset.groupSpacing
+                rowSpacing: SettingsMaterialPreset.groupSpacing
+
+                Repeater {
+                    model: TlpSettingsService.navigationCategories
+
+                    delegate: SelectionGroupButton {
+                        required property var modelData
+                        required property int index
+                        Layout.fillWidth: true
+                        Layout.minimumWidth: 0
+                        Layout.preferredWidth: 1
+                        leftmost: true
+                        rightmost: true
+                        buttonIcon: String(modelData?.icon ?? "tune")
+                        buttonText: Translation.tr(TlpSettingsService.categoryLabel(modelData))
+                        toggled: root.selectedCategoryIndex === index
+                        enabled: !TlpSettingsService.busy
+                        onClicked: root.selectCategory(index)
+                    }
+                }
+            }
+
+            SettingsDivider {}
+
+            MaterialTextField {
+                Layout.fillWidth: true
+                placeholderText: Translation.tr("Filter by name, parameter, or description")
+                text: root.filterText
+                onTextEdited: root.filterText = text
+            }
+
+            StyledText {
+                visible: root.selectedCategory !== null
+                Layout.fillWidth: true
+                text: root.selectedCategory
+                    ? Translation.tr(String(root.selectedCategory.description ?? "")) : ""
+                color: Appearance.colors.colSubtext
+                wrapMode: Text.WordWrap
+                font.pixelSize: Appearance.font.pixelSize.smaller
+            }
+
+            StyledText {
+                visible: root.profileGuidanceVisible
+                Layout.fillWidth: true
+                text: Translation.tr("Profiled settings should be overridden together so values do not carry over between TLP profiles.")
+                color: Appearance.colors.colSubtext
+                wrapMode: Text.WordWrap
+                font.pixelSize: Appearance.font.pixelSize.smaller
+            }
+        }
+    }
+
+    SettingsCardSection {
+        visible: root.batteryCareSelected
+        expanded: true
+        collapsible: false
+        icon: "battery_saver"
+        title: Translation.tr("Hardware-aware charge care")
+
+        SettingsGroup {
+            StyledText {
+                Layout.fillWidth: true
+                text: Translation.tr("TLP detects supported charge limits. Apply saves them with the other Battery changes.")
+                color: Appearance.colors.colSubtext
+                wrapMode: Text.WordWrap
+                font.pixelSize: Appearance.font.pixelSize.smaller
+            }
+
+            BatteryChargeLimitSettings {
+                staged: true
+            }
+        }
+    }
+
+    Repeater {
+        model: root.visibleGroups
+
+        delegate: SettingsCardSection {
+            id: groupCard
+            required property var modelData
+            expanded: true
+            collapsible: true
+            icon: String(root.selectedCategory?.icon ?? "tune")
+            title: Translation.tr(String(modelData?.title ?? ""))
+
+            SettingsGroup {
+                StyledText {
+                    visible: root.conciseGroupDescription(groupCard.modelData).length > 0
+                    Layout.fillWidth: true
+                    text: Translation.tr(root.conciseGroupDescription(groupCard.modelData))
+                    color: Appearance.colors.colSubtext
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: Appearance.font.pixelSize.smallest
+                }
+
+                SettingsDivider {
+                    visible: root.conciseGroupDescription(groupCard.modelData).length > 0
+                }
+
+                Repeater {
+                    model: TlpSettingsService._array(groupCard.modelData?.settings)
+
+                    delegate: TlpSettingRow {
+                        required property var modelData
+                        definition: modelData
+                        groupDescription: root.conciseGroupDescription(groupCard.modelData)
+                        compactProfileRows: TlpSettingsService.groupUsesCompactProfileRows(groupCard.modelData)
+                        singleSettingGroup: TlpSettingsService._array(groupCard.modelData?.settings).length === 1
+                    }
+                }
+            }
+        }
+    }
+
+    SettingsCardSection {
+        visible: root.selectedCategory !== null && root.visibleGroups.length === 0
+        expanded: true
+        collapsible: false
+        icon: "search_off"
+        title: Translation.tr("No matching settings")
+
+        SettingsGroup {
+            StyledText {
+                Layout.fillWidth: true
+                text: Translation.tr("Try another search term or clear the category filter.")
+                color: Appearance.colors.colSubtext
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+    }
+}

--- a/modules/settings/TlpConfig.qml
+++ b/modules/settings/TlpConfig.qml
@@ -14,8 +14,6 @@ ContentPage {
 
     property int selectedCategoryIndex: 0
     property string filterText: ""
-    property bool _categoryReady: false
-    property int _previousCategoryIndex: 0
 
     readonly property string profileGuidanceSource: "When overriding this group, set every shown profile together to avoid values spilling between TLP profiles."
     readonly property var selectedCategory: {
@@ -65,19 +63,7 @@ ContentPage {
         root.selectedCategoryIndex = index
     }
 
-    onSelectedCategoryIndexChanged: {
-        if (root._categoryReady
-                && root._previousCategoryIndex !== root.selectedCategoryIndex
-                && TlpSettingsService.hasPendingChanges)
-            TlpSettingsService.applyOnLeave()
-        root._previousCategoryIndex = root.selectedCategoryIndex
-        root.filterText = ""
-    }
-
-    Component.onCompleted: {
-        root._previousCategoryIndex = root.selectedCategoryIndex
-        root._categoryReady = true
-    }
+    onSelectedCategoryIndexChanged: root.filterText = ""
 
     SettingsCardSection {
         expanded: true

--- a/modules/settings/TlpSettingRow.qml
+++ b/modules/settings/TlpSettingRow.qml
@@ -1,0 +1,377 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+ColumnLayout {
+    id: root
+
+    required property var definition
+    property string groupDescription: ""
+    property bool compactProfileRows: false
+    property bool singleSettingGroup: false
+
+    readonly property string settingKey: String(root.definition?.key ?? "")
+    readonly property string settingType: String(root.definition?.type ?? "text")
+    readonly property string profile: String(root.definition?.profile ?? "")
+    readonly property bool isProfileMapping: root.settingKey.startsWith("TLP_PROFILE_")
+    readonly property bool compactProfileRow: root.isProfileMapping
+        || (root.compactProfileRows && root.profile.length > 0)
+    readonly property string label: TlpSettingsService.settingLabel(root.definition)
+    readonly property string displayLabel: root.compactProfileRow
+        ? Translation.tr(TlpSettingsService.profileLabel(root.profile))
+        : root.singleSettingGroup
+            ? Translation.tr("Use custom value")
+            : Translation.tr(root.label)
+    readonly property bool managed: TlpSettingsService.isManaged(root.settingKey)
+    readonly property bool pending: Object.prototype.hasOwnProperty.call(
+        TlpSettingsService.pendingValues, root.settingKey)
+    readonly property string currentValue: TlpSettingsService.value(root.settingKey)
+    readonly property string inheritedValue: TlpSettingsService.effectiveValue(root.settingKey)
+    readonly property bool editable: TlpSettingsService.supported
+        && TlpSettingsService.configAvailable
+        && !TlpSettingsService.busy
+    readonly property bool hasVisibleValue: root.managed || root.currentValue.length > 0
+    readonly property string notice: root.managed || root.pending
+        ? TlpSettingsService.settingNotice(root.definition) : ""
+    readonly property var selectedTokens: root.currentValue.trim()
+        ? root.currentValue.trim().split(/\s+/)
+        : []
+    readonly property var optionValues: TlpSettingsService.optionValues(root.definition)
+    readonly property var optionLabels: root.optionValues.map(value =>
+        Translation.tr(TlpSettingsService.displayValue(root.definition, value)))
+    readonly property real editorHeight: 38 * Appearance.fontSizeScale
+    readonly property real editorWidth: root.settingType === "list" ? 310 : 240
+
+    Layout.fillWidth: true
+    spacing: 0
+
+    function defaultValue(): string {
+        if (root.currentValue.length > 0)
+            return root.currentValue
+        if (root.inheritedValue.length > 0)
+            return root.inheritedValue
+        const example = TlpSettingsService.exampleValue(root.definition)
+        if (example.length > 0)
+            return example
+        if (root.settingType === "number")
+            return String(root.definition?.min ?? 0)
+        return root.optionValues.length > 0 ? String(root.optionValues[0]) : ""
+    }
+
+    function setValue(value): void {
+        TlpSettingsService.stageSet(root.settingKey, String(value ?? ""))
+    }
+
+    function toggleToken(token: string): void {
+        const next = root.selectedTokens.slice()
+        const index = next.indexOf(token)
+        if (index >= 0)
+            next.splice(index, 1)
+        else
+            next.push(token)
+        root.setValue(next.join(" "))
+    }
+
+    function profileIcon(): string {
+        switch (root.profile) {
+        case "AC": return "bolt"
+        case "BAT": return "battery_5_bar"
+        case "SAV": return "energy_savings_leaf"
+        case "DEFAULT": return "home"
+        default: return ""
+        }
+    }
+
+    function stateText(): string {
+        if (root.pending)
+            return root.managed
+                ? Translation.tr("Staged for Apply")
+                : Translation.tr("Will inherit after Apply")
+        if (root.managed)
+            return Translation.tr("Overridden by iNiR")
+        if (root.inheritedValue.length > 0)
+            return Translation.tr("Inherited: %1").arg(root.inheritedValue)
+        return Translation.tr("TLP default")
+    }
+
+    function wrapToolTip(text: string): string {
+        const words = text.trim().split(/\s+/)
+        const lines = []
+        let line = ""
+        for (const word of words) {
+            const candidate = line.length > 0 ? line + " " + word : word
+            if (candidate.length > 64 && line.length > 0) {
+                lines.push(line)
+                line = word
+            } else {
+                line = candidate
+            }
+        }
+        if (line.length > 0)
+            lines.push(line)
+        return lines.join("\n")
+    }
+
+    function toggleToolTip(): string {
+        const action = root.managed
+            ? Translation.tr("Disable this override to inherit TLP's value after Apply.")
+            : Translation.tr("Enable an iNiR override for this setting.")
+        const parameter = Translation.tr("Parameter: %1").arg(root.settingKey)
+        const state = Translation.tr("State: %1").arg(root.stateText())
+        const note = root.wrapToolTip(Translation.tr(root.groupDescription))
+        const warning = root.wrapToolTip(Translation.tr(root.notice))
+        let result = action + "\n" + parameter + "\n" + state
+        if (note.length > 0)
+            result += "\n" + note
+        if (warning.length > 0)
+            result += "\n" + warning
+        return result
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.leftMargin: SettingsMaterialPreset.groupSpacing
+        Layout.rightMargin: SettingsMaterialPreset.groupSpacing
+        Layout.topMargin: SettingsMaterialPreset.groupSpacing
+        Layout.bottomMargin: root.notice.length > 0 ? 0 : SettingsMaterialPreset.groupSpacing
+        spacing: SettingsMaterialPreset.groupPadding
+
+        StyledSwitch {
+            Layout.alignment: Qt.AlignVCenter
+            hoverEnabled: true
+            checked: root.managed
+            enabled: root.editable
+            onClicked: {
+                if (checked)
+                    root.setValue(root.defaultValue())
+                else
+                    TlpSettingsService.stageUnset(root.settingKey)
+            }
+
+            StyledToolTip {
+                text: root.toggleToolTip()
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.minimumWidth: 150
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 0
+
+            StyledText {
+                Layout.fillWidth: true
+                text: root.displayLabel
+                color: root.pending
+                    ? Appearance.colors.colPrimary : Appearance.colors.colOnLayer0
+                font.weight: Font.Medium
+                elide: Text.ElideRight
+            }
+        }
+
+        Rectangle {
+            id: profileBadge
+            visible: root.profile.length > 0 && !root.isProfileMapping && !root.compactProfileRows
+            Layout.alignment: Qt.AlignVCenter
+            implicitWidth: profileRow.implicitWidth + SettingsMaterialPreset.groupPadding
+            implicitHeight: Math.round(24 * Appearance.fontSizeScale)
+            radius: Appearance.rounding.full
+            color: Appearance.colors.colSecondaryContainer
+
+            RowLayout {
+                id: profileRow
+                anchors.centerIn: parent
+                spacing: SettingsMaterialPreset.groupSpacing
+
+                MaterialSymbol {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: root.profileIcon()
+                    iconSize: Appearance.font.pixelSize.small
+                    color: Appearance.colors.colOnSecondaryContainer
+                }
+
+                StyledText {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: Translation.tr(TlpSettingsService.profileLabel(root.profile))
+                    color: Appearance.colors.colOnSecondaryContainer
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                }
+            }
+        }
+
+        Loader {
+            id: editorLoader
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredWidth: root.editorWidth
+            Layout.maximumWidth: root.editorWidth
+            opacity: root.managed ? 1 : 0.72
+            enabled: root.editable
+            active: true
+            sourceComponent: !root.hasVisibleValue
+                ? unsetEditor
+                : root.settingType === "number"
+                    ? numberEditor
+                    : root.settingType === "select"
+                        ? selectEditor
+                        : root.settingType === "list"
+                            ? listEditor
+                            : textEditor
+        }
+    }
+
+    StyledText {
+        visible: root.notice.length > 0
+        Layout.fillWidth: true
+        Layout.leftMargin: SettingsMaterialPreset.groupSpacing
+        Layout.rightMargin: SettingsMaterialPreset.groupSpacing
+        Layout.bottomMargin: SettingsMaterialPreset.groupSpacing
+        text: Translation.tr(root.notice)
+        color: Appearance.colors.colError
+        font.pixelSize: Appearance.font.pixelSize.smaller
+        wrapMode: Text.WordWrap
+    }
+
+    Component {
+        id: unsetEditor
+
+        Rectangle {
+            width: root.editorWidth
+            implicitHeight: root.editorHeight
+            radius: Appearance.rounding.small
+            color: Appearance.colors.colLayer2
+
+            StyledText {
+                anchors.fill: parent
+                anchors.leftMargin: SettingsMaterialPreset.groupPadding
+                anchors.rightMargin: SettingsMaterialPreset.groupPadding
+                text: Translation.tr("TLP default")
+                color: Appearance.colors.colSubtext
+                font.pixelSize: Appearance.font.pixelSize.small
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+            }
+        }
+    }
+
+    Component {
+        id: numberEditor
+
+        RowLayout {
+            spacing: SettingsMaterialPreset.groupSpacing
+
+            StyledSpinBox {
+                Layout.fillWidth: true
+                baseHeight: root.editorHeight
+                from: Number(root.definition?.min ?? 0)
+                to: Number(root.definition?.max ?? 100)
+                stepSize: Number(root.definition?.step ?? 1)
+                value: {
+                    const parsed = Number.parseInt(root.currentValue, 10)
+                    return Number.isFinite(parsed) ? parsed : from
+                }
+                enabled: root.editable
+                onValueModified: root.setValue(String(value))
+            }
+
+            StyledText {
+                visible: String(root.definition?.unit ?? "").length > 0
+                text: String(root.definition?.unit ?? "")
+                color: Appearance.colors.colSubtext
+                font.pixelSize: Appearance.font.pixelSize.smaller
+            }
+        }
+    }
+
+    Component {
+        id: selectEditor
+
+        StyledComboBox {
+            width: root.editorWidth
+            baseHeight: root.editorHeight
+            model: root.optionLabels
+            currentIndex: root.optionValues.indexOf(root.currentValue)
+            enabled: root.editable
+            onActivated: index => {
+                if (index >= 0 && index < root.optionValues.length)
+                    root.setValue(String(root.optionValues[index]))
+            }
+        }
+    }
+
+    Component {
+        id: listEditor
+
+        Item {
+            width: root.editorWidth
+            implicitHeight: Math.max(root.editorHeight, optionFlow.implicitHeight)
+
+            Flow {
+                id: optionFlow
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                }
+                spacing: SettingsMaterialPreset.groupSpacing
+
+                Repeater {
+                    model: root.optionValues
+
+                    delegate: FilterChip {
+                        required property var modelData
+                        text: Translation.tr(TlpSettingsService.displayValue(root.definition, modelData))
+                        monospace: false
+                        selected: root.selectedTokens.indexOf(String(modelData)) >= 0
+                        enabled: root.editable
+                        onClicked: root.toggleToken(String(modelData))
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: textEditor
+
+        ToolbarTextField {
+            width: root.editorWidth
+            implicitHeight: root.editorHeight
+            text: root.currentValue
+            placeholderText: {
+                if (root.managed && root.currentValue.length === 0)
+                    return Translation.tr("Explicit empty value")
+                const example = TlpSettingsService.exampleValue(root.definition)
+                if (root.currentValue.trim().length === 0 && example.length > 0)
+                    return Translation.tr("Example: %1").arg(example)
+                return Translation.tr(String(root.definition?.placeholder
+                    ?? "TLP configuration value"))
+            }
+            enabled: root.editable
+            font.family: Appearance.font.family.monospace
+            onTextEdited: root.setValue(text.trim())
+        }
+    }
+
+    SettingsDivider {}
+
+    Connections {
+        target: TlpSettingsService
+
+        function reloadEditor(): void {
+            editorLoader.active = false
+            Qt.callLater(() => editorLoader.active = true)
+        }
+
+        function onManagedValuesChanged(): void { reloadEditor() }
+        function onEffectiveValuesChanged(): void { reloadEditor() }
+        function onPendingValuesChanged(): void {
+            if (!TlpSettingsService.hasPendingChanges)
+                reloadEditor()
+        }
+    }
+}

--- a/modules/settings/qmldir
+++ b/modules/settings/qmldir
@@ -3,6 +3,8 @@ singleton SettingsPageRegistry 1.0 SettingsPageRegistry.qml
 QuickWallpaperItem 1.0 QuickWallpaperItem.qml
 ThemePresetCard 1.0 ThemePresetCard.qml
 ColorPickerRow 1.0 ColorPickerRow.qml
+BatteryChargeLimitSettings 1.0 BatteryChargeLimitSettings.qml
+TlpSettingRow 1.0 TlpSettingRow.qml
 WaffleConfig 1.0 WaffleConfig.qml
 AutostartConfig 1.0 AutostartConfig.qml
 WorkspaceStripConfig 1.0 WorkspaceStripConfig.qml

--- a/modules/waffle/settings/WBatteryChargeLimitRows.qml
+++ b/modules/waffle/settings/WBatteryChargeLimitRows.qml
@@ -1,0 +1,96 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+
+ColumnLayout {
+    id: root
+
+    property bool staged: false
+
+    readonly property bool requestedEnabled: root.staged
+        ? TlpSettingsService.chargeEnabled()
+        : (Config.options?.battery?.chargeLimit?.enable ?? false)
+    readonly property int requestedThreshold: root.staged
+        ? TlpSettingsService.chargeThreshold()
+        : Battery.effectiveChargeLimitThreshold
+
+    Layout.fillWidth: true
+    spacing: 0
+
+    WSettingsSwitch {
+        property bool _ready: false
+        label: Translation.tr("Charge limit")
+        icon: "battery-saver"
+        description: !Battery.chargeLimitAvailable
+            ? Translation.tr("TLP is not available")
+            : Battery.chargeLimitStatusReason === "unsupported-tlp-version"
+                ? Translation.tr("This TLP version is not supported yet")
+            : Battery.chargeLimitStatusReason === "tlp-disabled"
+                ? Translation.tr("TLP is disabled in its configuration")
+            : Battery.chargeLimitStatusReason === "tlp-config-unavailable"
+                ? Translation.tr("TLP configuration could not be read")
+            : !Battery.chargeLimitSupported
+                ? Translation.tr("Not supported on this device")
+            : Battery.chargeLimitDiscrete
+                ? Translation.tr("Choose a charge limit supported by this device")
+            : Battery.chargeLimitAdjustable
+                ? Translation.tr("Limit maximum charge to preserve battery health")
+                : Translation.tr("Use your device's built-in battery conservation mode (requires polkit)")
+        enabled: Battery.chargeLimitSupported
+            || Battery.chargeLimitManaged
+            || root.requestedEnabled
+        checked: root.requestedEnabled
+        Component.onCompleted: _ready = true
+        onCheckedChanged: {
+            if (!_ready || checked === root.requestedEnabled)
+                return
+            if (root.staged)
+                TlpSettingsService.stageChargeEnabled(checked, root.requestedThreshold)
+            else
+                Config.setNestedValue("battery.chargeLimit.enable", checked)
+        }
+    }
+
+    WSettingsSpinBox {
+        property bool _ready: false
+        visible: Battery.chargeLimitContinuous
+        enabled: root.requestedEnabled
+        label: Translation.tr("Charge limit threshold")
+        icon: "battery-saver"
+        suffix: "%"
+        from: Battery.chargeLimitMinimum
+        to: Battery.chargeLimitMaximum
+        stepSize: Battery.chargeLimitStepSize
+        value: root.requestedThreshold
+        Component.onCompleted: _ready = true
+        onValueChanged: {
+            if (!_ready || value === root.requestedThreshold)
+                return
+            if (root.staged)
+                TlpSettingsService.stageChargeThreshold(value)
+            else
+                Config.setNestedValue("battery.chargeLimit.threshold", value)
+        }
+    }
+
+    WSettingsDropdown {
+        visible: Battery.chargeLimitDiscrete
+        enabled: root.requestedEnabled
+        label: Translation.tr("Charge limit threshold")
+        icon: "battery-saver"
+        currentValue: root.requestedThreshold
+        options: Battery.chargeLimitAllowedValues.map(value => ({
+            value: value,
+            displayName: String(value) + "%"
+        }))
+        onSelected: newValue => {
+            if (root.staged)
+                TlpSettingsService.stageChargeThreshold(Number(newValue))
+            else
+                Config.setNestedValue("battery.chargeLimit.threshold", newValue)
+        }
+    }
+}

--- a/modules/waffle/settings/WSettingsContent.qml
+++ b/modules/waffle/settings/WSettingsContent.qml
@@ -30,6 +30,8 @@ Item {
     
     // Complete search index with all individual options + targetLabel for spotlight
     property var searchIndex: [
+        { pageIndex: 18, pageName: "Battery", section: "Power management", label: "Battery and TLP settings", targetLabel: "Configuration categories", keywords: ["tlp", "power", "battery", "cpu", "processor", "disk", "pcie", "usb", "radio", "energy", "profile"] },
+        { pageIndex: 18, pageName: "Battery", section: "Battery Care", label: "Charge limit", targetLabel: "Hardware-aware charge care", keywords: ["tlp", "battery", "charge", "limit", "threshold", "thinkpad", "conservation"] },
         { pageIndex: 17, pageName: "Shell Layout", section: "Live shell layout", label: "Edit live", targetLabel: "Edit live", keywords: ["layout", "move", "position", "taskbar", "output", "edit", "live"] },
         { pageIndex: 17, pageName: "Shell Layout", section: "Taskbar placement", label: "Current position", targetLabel: "Current position", keywords: ["layout", "taskbar", "top", "bottom", "position", "reset"] },
         // === Quick (0) ===
@@ -749,9 +751,11 @@ Item {
                                 // Page icon
                                 FluentIcon {
                                     icon: {
-                                        var icons = ["home", "settings", "desktop", "image", "color", 
-                                                    "apps", "settings-cog-multiple", "desktop", "info"];
-                                        return icons[resultDelegate.modelData.pageIndex] || "settings";
+                                        const pageIndex = resultDelegate.modelData.pageIndex
+                                        const page = pageIndex >= 0 && pageIndex < root.pages.length
+                                            ? root.pages[pageIndex]
+                                            : null
+                                        return page?.icon || "settings"
                                     }
                                     implicitSize: 16
                                     color: resultDelegate.ListView.isCurrentItem 

--- a/modules/waffle/settings/WTlpSettingRow.qml
+++ b/modules/waffle/settings/WTlpSettingRow.qml
@@ -1,0 +1,263 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.waffle.looks
+import qs.modules.waffle.settings
+
+ColumnLayout {
+    id: root
+
+    required property var definition
+    property bool compactProfileRows: false
+    property bool singleSettingGroup: false
+
+    readonly property string settingKey: String(root.definition?.key ?? "")
+    readonly property string settingType: String(root.definition?.type ?? "text")
+    readonly property string profile: String(root.definition?.profile ?? "")
+    readonly property bool isProfileMapping: root.settingKey.startsWith("TLP_PROFILE_")
+    readonly property bool compactProfileRow: root.isProfileMapping
+        || (root.compactProfileRows && root.profile.length > 0)
+    readonly property bool managed: TlpSettingsService.isManaged(root.settingKey)
+    readonly property bool pending: Object.prototype.hasOwnProperty.call(
+        TlpSettingsService.pendingValues, root.settingKey)
+    readonly property string currentValue: TlpSettingsService.value(root.settingKey)
+    readonly property string inheritedValue: TlpSettingsService.effectiveValue(root.settingKey)
+    readonly property bool editable: TlpSettingsService.supported
+        && TlpSettingsService.configAvailable
+        && !TlpSettingsService.busy
+    readonly property bool hasVisibleValue: root.managed || root.currentValue.length > 0
+    readonly property string notice: root.managed || root.pending
+        ? TlpSettingsService.settingNotice(root.definition) : ""
+    readonly property var selectedTokens: root.currentValue.trim()
+        ? root.currentValue.trim().split(/\s+/)
+        : []
+    readonly property var optionValues: TlpSettingsService.optionValues(root.definition)
+    readonly property string displayLabel: {
+        const base = Translation.tr(TlpSettingsService.settingLabel(root.definition))
+        const profileName = TlpSettingsService.profileLabel(root.profile)
+        if (root.compactProfileRow)
+            return Translation.tr(profileName)
+        if (root.singleSettingGroup)
+            return Translation.tr("Use custom value")
+        return profileName.length > 0 ? base + " · " + Translation.tr(profileName) : base
+    }
+
+    Layout.fillWidth: true
+    spacing: 0
+
+    function defaultValue(): string {
+        if (root.currentValue.length > 0)
+            return root.currentValue
+        if (root.inheritedValue.length > 0)
+            return root.inheritedValue
+        const example = TlpSettingsService.exampleValue(root.definition)
+        if (example.length > 0)
+            return example
+        if (root.settingType === "number")
+            return String(root.definition?.min ?? 0)
+        return root.optionValues.length > 0 ? String(root.optionValues[0]) : ""
+    }
+
+    function setValue(value): void {
+        TlpSettingsService.stageSet(root.settingKey, String(value ?? ""))
+    }
+
+    function toggleToken(token: string): void {
+        const next = root.selectedTokens.slice()
+        const index = next.indexOf(token)
+        if (index >= 0)
+            next.splice(index, 1)
+        else
+            next.push(token)
+        root.setValue(next.join(" "))
+    }
+
+    function rowIcon(): string {
+        switch (root.profile) {
+        case "AC": return "power"
+        case "BAT": return "battery-saver"
+        case "SAV": return "battery-saver"
+        default: return root.managed ? "settings-cog-multiple" : "settings"
+        }
+    }
+
+    WSettingsSwitch {
+        id: overrideSwitch
+        property bool _ready: false
+        label: root.displayLabel
+        icon: root.rowIcon()
+        description: ""
+        checked: root.managed
+        enabled: root.editable
+        Component.onCompleted: _ready = true
+        onCheckedChanged: {
+            if (!_ready || checked === root.managed)
+                return
+            if (checked)
+                root.setValue(root.defaultValue())
+            else
+                TlpSettingsService.stageUnset(root.settingKey)
+        }
+    }
+
+    Loader {
+        id: editorLoader
+        Layout.fillWidth: true
+        Layout.leftMargin: Looks.dp(28)
+        opacity: root.managed ? 1 : 0.72
+        enabled: root.editable
+        active: true
+        sourceComponent: !root.hasVisibleValue
+            ? unsetEditor
+            : root.settingType === "number"
+                ? numberEditor
+                : root.settingType === "select"
+                    ? selectEditor
+                    : root.settingType === "list"
+                        ? listEditor
+                        : textEditor
+    }
+
+    WText {
+        visible: root.notice.length > 0
+        Layout.fillWidth: true
+        Layout.leftMargin: Looks.dp(28)
+        Layout.rightMargin: Looks.dp(10)
+        Layout.bottomMargin: Looks.dp(6)
+        text: Translation.tr(root.notice)
+        color: Looks.colors.danger
+        font.pixelSize: Looks.font.pixelSize.small
+        wrapMode: Text.WordWrap
+    }
+
+    Component {
+        id: unsetEditor
+
+        WSettingsTextField {
+            label: Translation.tr("Value")
+            placeholderText: Translation.tr("TLP default")
+            text: ""
+            enabled: false
+        }
+    }
+
+    Component {
+        id: numberEditor
+
+        WSettingsSpinBox {
+            property bool _ready: false
+            label: Translation.tr("Value")
+            description: Translation.tr("Allowed: %1–%2").arg(
+                root.definition?.min ?? 0).arg(root.definition?.max ?? 100)
+            suffix: String(root.definition?.unit ?? "")
+            from: Number(root.definition?.min ?? 0)
+            to: Number(root.definition?.max ?? 100)
+            stepSize: Number(root.definition?.step ?? 1)
+            value: {
+                const parsed = Number.parseInt(root.currentValue, 10)
+                return Number.isFinite(parsed) ? parsed : from
+            }
+            enabled: root.editable
+            Component.onCompleted: _ready = true
+            onValueChanged: {
+                if (_ready && String(value) !== root.currentValue)
+                    root.setValue(String(value))
+            }
+        }
+    }
+
+    Component {
+        id: selectEditor
+
+        WSettingsDropdown {
+            label: Translation.tr("Value")
+            currentValue: root.currentValue
+            options: root.optionValues.map(value => ({
+                value: String(value),
+                displayName: Translation.tr(TlpSettingsService.displayValue(root.definition, value))
+            }))
+            enabled: root.editable
+            onSelected: newValue => root.setValue(String(newValue))
+        }
+    }
+
+    Component {
+        id: textEditor
+
+        WSettingsTextField {
+            label: Translation.tr("Value")
+            placeholderText: {
+                if (root.managed && root.currentValue.length === 0)
+                    return Translation.tr("Explicit empty value")
+                const example = TlpSettingsService.exampleValue(root.definition)
+                if (root.currentValue.trim().length === 0 && example.length > 0)
+                    return Translation.tr("Example: %1").arg(example)
+                return Translation.tr(String(root.definition?.placeholder
+                    ?? "TLP configuration value"))
+            }
+            text: root.currentValue
+            enabled: root.editable
+            onTextEdited: newText => root.setValue(newText.trim())
+        }
+    }
+
+    Component {
+        id: listEditor
+
+        Item {
+            implicitHeight: tokenFlow.implicitHeight + Looks.dp(16)
+
+            Flow {
+                id: tokenFlow
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                }
+                spacing: Looks.dp(6)
+
+                Repeater {
+                    model: root.optionValues
+
+                    delegate: WButton {
+                        required property var modelData
+                        text: Translation.tr(TlpSettingsService.displayValue(root.definition, modelData))
+                        checked: root.selectedTokens.indexOf(String(modelData)) >= 0
+                        enabled: root.editable
+                        font.pixelSize: Looks.font.pixelSize.small
+                        horizontalPadding: Looks.dp(10)
+                        verticalPadding: Looks.dp(5)
+                        onClicked: root.toggleToken(String(modelData))
+                    }
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: TlpSettingsService
+
+        function syncOverride(): void {
+            overrideSwitch.checked = root.managed
+        }
+
+        function reloadEditor(): void {
+            editorLoader.active = false
+            Qt.callLater(() => editorLoader.active = true)
+        }
+
+        function onManagedValuesChanged(): void {
+            Qt.callLater(syncOverride)
+            reloadEditor()
+        }
+        function onEffectiveValuesChanged(): void { reloadEditor() }
+        function onPendingValuesChanged(): void {
+            Qt.callLater(syncOverride)
+            if (!TlpSettingsService.hasPendingChanges)
+                reloadEditor()
+        }
+    }
+}

--- a/modules/waffle/settings/pages/WGeneralPage.qml
+++ b/modules/waffle/settings/pages/WGeneralPage.qml
@@ -79,40 +79,6 @@ WSettingsPage {
             checked: Config.options?.battery?.notifyFull ?? true
             onCheckedChanged: Config.setNestedValue("battery.notifyFull", checked)
         }
-
-        WSettingsSwitch {
-            property bool _ready: false
-            label: Translation.tr("Charge limit")
-            icon: "battery-saver"
-            description: !Battery.chargeLimitSupported
-                ? Translation.tr("Not supported on this device")
-                : Battery.chargeLimitAdjustable
-                    ? Translation.tr("Limit maximum charge to preserve battery health")
-                    : Translation.tr("Use your device's built-in battery conservation mode (requires polkit)")
-            enabled: Battery.chargeLimitSupported
-            checked: Config.options?.battery?.chargeLimit?.enable ?? false
-            Component.onCompleted: _ready = true
-            onCheckedChanged: {
-                if (_ready && checked !== (Config.options?.battery?.chargeLimit?.enable ?? false))
-                    Config.setNestedValue("battery.chargeLimit.enable", checked)
-            }
-        }
-
-        WSettingsSpinBox {
-            property bool _ready: false
-            visible: Battery.chargeLimitAdjustable
-            enabled: Config.options?.battery?.chargeLimit?.enable ?? false
-            label: Translation.tr("Charge limit threshold")
-            icon: "battery-saver"
-            suffix: "%"
-            from: 20; to: 100; stepSize: 5
-            value: Config.options?.battery?.chargeLimit?.threshold ?? 80
-            Component.onCompleted: _ready = true
-            onValueChanged: {
-                if (_ready && value !== (Config.options?.battery?.chargeLimit?.threshold ?? 80))
-                    Config.setNestedValue("battery.chargeLimit.threshold", value)
-            }
-        }
     }
     
     WSettingsCard {

--- a/modules/waffle/settings/pages/WTlpPage.qml
+++ b/modules/waffle/settings/pages/WTlpPage.qml
@@ -17,8 +17,6 @@ WSettingsPage {
 
     property int selectedCategoryIndex: 0
     property string filterText: ""
-    property bool _categoryReady: false
-    property int _previousCategoryIndex: 0
 
     readonly property string profileGuidanceSource: "When overriding this group, set every shown profile together to avoid values spilling between TLP profiles."
     readonly property var selectedCategory: {
@@ -68,19 +66,7 @@ WSettingsPage {
         root.selectedCategoryIndex = index
     }
 
-    onSelectedCategoryIndexChanged: {
-        if (root._categoryReady
-                && root._previousCategoryIndex !== root.selectedCategoryIndex
-                && TlpSettingsService.hasPendingChanges)
-            TlpSettingsService.applyOnLeave()
-        root._previousCategoryIndex = root.selectedCategoryIndex
-        root.filterText = ""
-    }
-
-    Component.onCompleted: {
-        root._previousCategoryIndex = root.selectedCategoryIndex
-        root._categoryReady = true
-    }
+    onSelectedCategoryIndexChanged: root.filterText = ""
 
     WSettingsInfoBar {
         severity: TlpSettingsService.configAvailable

--- a/modules/waffle/settings/pages/WTlpPage.qml
+++ b/modules/waffle/settings/pages/WTlpPage.qml
@@ -1,0 +1,253 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.waffle.looks
+import qs.modules.waffle.settings
+
+WSettingsPage {
+    id: root
+
+    settingsPageIndex: 18
+    pageTitle: Translation.tr("Battery")
+    pageIcon: "battery-saver"
+    pageDescription: Translation.tr("Charge care, power profiles, processor, devices, and the effective TLP configuration")
+
+    property int selectedCategoryIndex: 0
+    property string filterText: ""
+    property bool _categoryReady: false
+    property int _previousCategoryIndex: 0
+
+    readonly property string profileGuidanceSource: "When overriding this group, set every shown profile together to avoid values spilling between TLP profiles."
+    readonly property var selectedCategory: {
+        const categories = TlpSettingsService._array(TlpSettingsService.navigationCategories)
+        if (categories.length === 0)
+            return null
+        return categories[Math.max(0, Math.min(root.selectedCategoryIndex, categories.length - 1))]
+    }
+    readonly property var visibleGroups: TlpSettingsService.groupsForCategory(
+        root.selectedCategory, root.filterText)
+    readonly property bool profileGuidanceVisible: root.visibleGroups.some(group =>
+        String(group?.description ?? "").includes(root.profileGuidanceSource))
+    readonly property bool batteryCareSelected: String(root.selectedCategory?.id ?? "") === "battery-care"
+
+    function conciseGroupDescription(group): string {
+        const description = String(group?.description ?? "")
+        if (description === root.profileGuidanceSource)
+            return ""
+        const suffix = " " + root.profileGuidanceSource
+        return description.endsWith(suffix)
+            ? description.slice(0, description.length - suffix.length)
+            : description
+    }
+
+    function statusMessage(): string {
+        if (!TlpSettingsService.schemaLoaded)
+            return Translation.tr("The bundled TLP settings schema could not be loaded")
+        if (!TlpSettingsService.available)
+            return Translation.tr("TLP is not installed")
+        if (!TlpSettingsService.supported)
+            return TlpSettingsService.statusReason === "unsupported-tlp-version"
+                ? Translation.tr("This TLP version is not supported yet")
+                : Translation.tr("The installed TLP runtime is unavailable")
+        if (!TlpSettingsService.configAvailable)
+            return TlpSettingsService.statusReason === "managed-config-invalid"
+                ? Translation.tr("The iNiR TLP override file is invalid; reset overrides to recover")
+                : Translation.tr("TLP configuration could not be read")
+        return TlpSettingsService.enabled
+            ? Translation.tr("TLP %1 is active · %2 iNiR overrides").arg(
+                TlpSettingsService.tlpVersion).arg(TlpSettingsService.managedCount)
+            : Translation.tr("TLP %1 is disabled by configuration").arg(TlpSettingsService.tlpVersion)
+    }
+
+    function selectCategory(index: int): void {
+        if (index === root.selectedCategoryIndex || TlpSettingsService.busy)
+            return
+        root.selectedCategoryIndex = index
+    }
+
+    onSelectedCategoryIndexChanged: {
+        if (root._categoryReady
+                && root._previousCategoryIndex !== root.selectedCategoryIndex
+                && TlpSettingsService.hasPendingChanges)
+            TlpSettingsService.applyOnLeave()
+        root._previousCategoryIndex = root.selectedCategoryIndex
+        root.filterText = ""
+    }
+
+    Component.onCompleted: {
+        root._previousCategoryIndex = root.selectedCategoryIndex
+        root._categoryReady = true
+    }
+
+    WSettingsInfoBar {
+        severity: TlpSettingsService.configAvailable
+            ? (TlpSettingsService.enabled
+                ? WSettingsInfoBar.Severity.Success
+                : WSettingsInfoBar.Severity.Warning)
+            : WSettingsInfoBar.Severity.Error
+        message: root.statusMessage()
+    }
+
+    WSettingsInfoBar {
+        severity: WSettingsInfoBar.Severity.Error
+        message: TlpSettingsService.lastError
+    }
+
+    WSettingsCard {
+        title: Translation.tr("Apply changes")
+        icon: "battery-saver"
+        description: TlpSettingsService.hasPendingChanges
+            ? Translation.tr("%1 staged change(s) · one Polkit authentication").arg(TlpSettingsService.pendingCount)
+            : Translation.tr("Editors show TLP's current effective values; no shell reload is required")
+
+        WSettingsButton {
+            label: Translation.tr("Apply all staged changes")
+            description: Translation.tr("Validate, write both iNiR drop-ins, run TLP once, and verify")
+            buttonText: TlpSettingsService.busy ? Translation.tr("Applying…") : Translation.tr("Apply")
+            accent: true
+            enabled: TlpSettingsService.hasPendingChanges
+                && TlpSettingsService.supported
+                && TlpSettingsService.configAvailable
+                && !TlpSettingsService.busy
+            onButtonClicked: TlpSettingsService.apply()
+        }
+
+        WSettingsButton {
+            label: Translation.tr("Discard staged changes")
+            description: Translation.tr("Return every editor to the last effective configuration")
+            buttonText: Translation.tr("Discard")
+            enabled: TlpSettingsService.hasPendingChanges && !TlpSettingsService.busy
+            onButtonClicked: TlpSettingsService.discard()
+        }
+
+        WSettingsButton {
+            label: Translation.tr("Refresh effective configuration")
+            description: Translation.tr("Read TLP settings and battery care state again")
+            buttonText: Translation.tr("Refresh")
+            enabled: !TlpSettingsService.busy
+            onButtonClicked: {
+                TlpSettingsService.refresh()
+                TlpService.refresh()
+            }
+        }
+
+        WSettingsButton {
+            label: Translation.tr("Reset general iNiR overrides")
+            description: TlpSettingsService.statusReason === "managed-config-invalid"
+                ? Translation.tr("Delete the invalid iNiR-owned override file and keep battery charge care")
+                : Translation.tr("Keep battery charge care and all non-iNiR TLP files")
+            buttonText: Translation.tr("Reset")
+            enabled: TlpSettingsService.canResetOverrides
+            onButtonClicked: TlpSettingsService.reset()
+        }
+    }
+
+    WSettingsCard {
+        title: Translation.tr("Configuration categories")
+        icon: "settings-cog-multiple"
+        description: root.selectedCategory
+            ? Translation.tr(String(root.selectedCategory.description ?? "")) : ""
+
+        GridLayout {
+            Layout.fillWidth: true
+            columns: root.width >= Looks.dp(760) ? 3 : 2
+            columnSpacing: Looks.dp(6)
+            rowSpacing: Looks.dp(4)
+
+            Repeater {
+                model: TlpSettingsService.navigationCategories
+
+                delegate: WSettingsNavItem {
+                    required property var modelData
+                    required property int index
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                    Layout.preferredWidth: 1
+                    expanded: true
+                    selected: root.selectedCategoryIndex === index
+                    navIcon: String(modelData?.waffleIcon ?? "settings")
+                    text: Translation.tr(TlpSettingsService.categoryLabel(modelData))
+                    enabled: !TlpSettingsService.busy
+                    onClicked: root.selectCategory(index)
+                }
+            }
+        }
+
+        WSettingsTextField {
+            label: Translation.tr("Filter this category")
+            placeholderText: Translation.tr("Name, parameter, or description")
+            text: root.filterText
+            onTextEdited: newText => root.filterText = newText
+        }
+
+        WText {
+            visible: root.profileGuidanceVisible
+            Layout.fillWidth: true
+            Layout.leftMargin: Looks.dp(10)
+            Layout.rightMargin: Looks.dp(10)
+            text: Translation.tr("Profiled settings should be overridden together so values do not carry over between TLP profiles.")
+            color: Looks.colors.subfg
+            font.pixelSize: Looks.font.pixelSize.small
+            wrapMode: Text.WordWrap
+            lineHeight: 1.2
+        }
+    }
+
+    WSettingsCard {
+        visible: root.batteryCareSelected
+        title: Translation.tr("Hardware-aware charge care")
+        icon: "battery-saver"
+        description: Translation.tr("TLP detects supported limits and applies them with the rest of this page")
+
+        WBatteryChargeLimitRows {
+            staged: true
+        }
+    }
+
+    Repeater {
+        model: root.visibleGroups
+
+        delegate: WSettingsCard {
+            id: groupCard
+            required property var modelData
+            title: Translation.tr(String(modelData?.title ?? ""))
+            icon: String(root.selectedCategory?.waffleIcon ?? "settings")
+            collapsible: true
+            expanded: true
+
+            WText {
+                visible: root.conciseGroupDescription(groupCard.modelData).length > 0
+                Layout.fillWidth: true
+                Layout.leftMargin: Looks.dp(10)
+                Layout.rightMargin: Looks.dp(10)
+                Layout.topMargin: Looks.dp(4)
+                Layout.bottomMargin: Looks.dp(8)
+                text: Translation.tr(root.conciseGroupDescription(groupCard.modelData))
+                color: Looks.colors.subfg
+                font.pixelSize: Looks.font.pixelSize.small
+                wrapMode: Text.WordWrap
+                lineHeight: 1.25
+            }
+
+            Repeater {
+                model: TlpSettingsService._array(groupCard.modelData?.settings)
+
+                delegate: WTlpSettingRow {
+                    required property var modelData
+                    definition: modelData
+                    compactProfileRows: TlpSettingsService.groupUsesCompactProfileRows(groupCard.modelData)
+                    singleSettingGroup: TlpSettingsService._array(groupCard.modelData?.settings).length === 1
+                }
+            }
+        }
+    }
+
+    WSettingsInfoBar {
+        message: root.selectedCategory !== null && root.visibleGroups.length === 0
+            ? Translation.tr("No matching settings. Try another search term or clear the filter.")
+            : ""
+    }
+}

--- a/modules/waffle/settings/pages/qmldir
+++ b/modules/waffle/settings/pages/qmldir
@@ -9,3 +9,4 @@ WInterfacePage 1.0 WInterfacePage.qml
 WModulesPage 1.0 WModulesPage.qml
 WWaffleStylePage 1.0 WWaffleStylePage.qml
 WAboutPage 1.0 WAboutPage.qml
+WTlpPage 1.0 WTlpPage.qml

--- a/modules/waffle/settings/qmldir
+++ b/modules/waffle/settings/qmldir
@@ -17,3 +17,5 @@ WSettingsInfoBar 1.0 WSettingsInfoBar.qml
 WSettingsChoiceGroup 1.0 WSettingsChoiceGroup.qml
 WSettingsFontSelector 1.0 WSettingsFontSelector.qml
 WMascotPoseGallery 1.0 WMascotPoseGallery.qml
+WBatteryChargeLimitRows 1.0 WBatteryChargeLimitRows.qml
+WTlpSettingRow 1.0 WTlpSettingRow.qml

--- a/scripts/test-battery-charge-limit-helper.sh
+++ b/scripts/test-battery-charge-limit-helper.sh
@@ -945,9 +945,7 @@ test_tlp_settings_ui_uses_schema_groups_and_batched_apply() {
     runtime_service="$repo_root/services/TlpRuntimeCapabilities.qml"
     services_qmldir="$repo_root/services/qmldir"
     classic_page="$repo_root/modules/settings/TlpConfig.qml"
-    classic_row="$repo_root/modules/settings/TlpSettingRow.qml"
     waffle_page="$repo_root/modules/waffle/settings/pages/WTlpPage.qml"
-    waffle_row="$repo_root/modules/waffle/settings/WTlpSettingRow.qml"
     schema="$repo_root/assets/tlp/tlp-settings-schema.json"
 
     jq -e '
@@ -956,134 +954,35 @@ test_tlp_settings_ui_uses_schema_groups_and_batched_apply() {
         ([.categories[].groups[]] | length) == 62 and
         ([.categories[].groups[] |
             select(.description == "" or (.description | contains("\n")) or (.description | length) > 120)] | length) == 0 and
-        ([.categories[].groups[] |
-            select(.id == "CPU_DRIVER_OPMODE" and (.description | startswith("Intel/AMD")))] | length) == 1 and
         .descriptionAttribution.license == "GPL-2.0-or-later"
-    ' "$schema" >/dev/null || fail 'the UI schema must expose concise, hardware-aware setting groups'
-    assert_eq 'pragma ComponentBehavior: Bound' "$(sed -n '1p' "$settings_service")" \
-        'the settings service must follow the new-QML pragma convention'
-    assert_eq 'pragma ComponentBehavior: Bound' "$(sed -n '1p' "$runtime_service")" \
-        'the runtime capability service must follow the new-QML pragma convention'
+    ' "$schema" >/dev/null || fail 'the UI schema must expose concise setting groups'
+
     assert_contains 'singleton TlpRuntimeCapabilities 1.0 TlpRuntimeCapabilities.qml' "$services_qmldir" \
-        'the runtime capability service must be registered in services/qmldir'
-    assert_contains 'property var categories: []' "$settings_service" \
-        'schema categories must remain a JavaScript array'
-    assert_contains 'property var runtimeValues: ({})' "$settings_service" \
-        'runtime platform-profile choices must be carried separately from the static schema'
-    assert_contains 'const capabilityValues = TlpRuntimeCapabilities.values' "$settings_service" \
-        'editors must prefer local kernel capability choices when they are available'
-    assert_contains 'root._array(root.runtimeValues[key])' "$settings_service" \
-        'editors must retain helper-reported platform-profile choices'
-    assert_contains 'TlpRuntimeCapabilities.isRdwSetting(key)' "$settings_service" \
-        'radio-event settings must be gated by the RDW runtime backend'
+        'runtime capability service must be registered'
     assert_contains '/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors' "$runtime_service" \
-        'CPU governor choices must come from the active kernel cpufreq interface'
+        'CPU governor choices must come from the kernel'
     assert_contains '/sys/power/mem_sleep' "$runtime_service" \
-        'suspend choices must come from the active kernel suspend interface'
-    assert_contains 'onTriggered: root.refresh()' "$runtime_service" \
-        'runtime capabilities must be refreshed while the settings process stays alive'
-    assert_contains 'DISK_IOSCHED: "keep"' "$settings_service" \
-        'the I/O scheduler example must demonstrate TLP\047s no-op default'
-    assert_contains 'key.startsWith("CPU_SCALING_GOVERNOR_")' "$settings_service" \
-        'the UI must retain TLP\047s documented userspace governor fallback when sysfs is unavailable'
-    assert_contains '"battery-care", "general", "processor", "graphics", "disks"' "$settings_service" \
-        'Battery care and common power domains must lead the adapted category layout'
-    assert_not_contains 'Array.isArray(category?.settings)' "$settings_service" \
-        'nested QML sequence wrappers must not hide category settings'
+        'suspend choices must come from the kernel'
     assert_contains 'function groupsForCategory(category, filterText): var {' "$settings_service" \
-        'the settings service must expose TLPUI-style groups'
+        'settings service must expose grouped schema data'
     assert_contains 'command.push("--charge-set"' "$settings_service" \
         'charge care must join the same privileged batch'
     assert_eq 1 "$(grep -Fc 'const command = ["/usr/bin/pkexec", root.helperPath, "--config-apply"]' "$settings_service")" \
-        'the settings service must build exactly one privileged Apply command' || return 1
+        'settings service must build one privileged Apply command' || return 1
+    assert_not_contains 'applyOnLeave' "$settings_service" \
+        'settings service must require explicit Apply'
     assert_contains 'settingsPageName: Translation.tr("Battery")' "$classic_page" \
-        'the classic page must be named Battery'
-    assert_not_contains 'leftAlignedContent:' "$classic_page" \
-        'the TLP page must not require TLP-only changes in the shared category button'
-    assert_not_contains 'TlpSettingsService.categorySettingCount(modelData)' "$classic_page" \
-        'classic category labels must not append setting counts'
-    assert_contains 'id: profileBadge' "$classic_row" \
-        'the profile badge must be a peer of the editor for vertical alignment'
-    assert_contains 'readonly property real editorHeight: 38 * Appearance.fontSizeScale' "$classic_row" \
-        'classic TLP editors must share one compact height that follows UI scaling'
-    assert_contains 'readonly property real editorWidth: root.settingType === "list" ? 310 : 240' "$classic_row" \
-        'list editors must reserve enough width for balanced option wrapping'
-    assert_contains 'implicitHeight: Math.max(root.editorHeight, optionFlow.implicitHeight)' "$classic_row" \
-        'multi-line option flows must remain vertically centered in their row'
-    assert_contains 'ToolbarTextField {' "$classic_row" \
-        'free-form values must reuse the compact upstream text field'
-    assert_not_contains 'MaterialTextField {' "$classic_row" \
-        'free-form values must not compress the floating-label Material field'
-    assert_contains 'groupDescription: root.conciseGroupDescription(groupCard.modelData)' "$classic_page" \
-        'each classic override tooltip must receive only the concise group guidance'
-    assert_contains 'hoverEnabled: true' "$classic_row" \
-        'TLP override switches must own their tooltip hover behavior locally'
-    assert_contains 'text: root.toggleToolTip()' "$classic_row" \
-        'each override toggle must expose ownership and setting guidance on hover'
-    assert_contains 'function wrapToolTip(text: string): string {' "$classic_row" \
-        'setting guidance tooltips must wrap before crossing the settings window'
-    assert_contains 'Translation.tr("Parameter: %1")' "$classic_row" \
-        'raw TLP keys must stay available in the classic tooltip instead of the main row'
-    assert_contains 'Translation.tr("State: %1")' "$classic_row" \
-        'detailed ownership state must stay available in the classic tooltip'
-    assert_not_contains 'root.settingKey + "  ·  " + root.stateText()' "$classic_row" \
-        'classic rows must not repeat the raw key and state under every toggle'
-    assert_not_contains '+ "  ·  " + root.stateText()' "$classic_row" \
-        'classic compact profile rows must not append redundant state text'
-    assert_contains 'root.profile.length > 0 && !root.isProfileMapping' "$classic_row" \
-        'classic profile mappings must merge rather than duplicate their profile badge'
-    assert_contains 'font.pixelSize: Appearance.font.pixelSize.smallest' "$classic_page" \
-        'visible group guidance must remain visually secondary'
-    assert_contains 'profileGuidanceVisible' "$classic_page" \
-        'classic settings must centralize repeated profile guidance at category level'
-    assert_contains 'title: Translation.tr(String(modelData?.title ?? ""))' "$classic_page" \
-        'schema-driven classic group titles must pass through the translation boundary'
-    assert_contains 'text: Translation.tr(root.conciseGroupDescription(groupCard.modelData))' "$classic_page" \
-        'schema-driven classic group descriptions must pass through the translation boundary'
+        'classic Battery page must remain registered'
     assert_contains 'pageTitle: Translation.tr("Battery")' "$waffle_page" \
-        'the Waffle page must be named Battery'
-    assert_contains 'description: ""' "$waffle_row" \
-        'Waffle rows must not render raw-key or state subtitles'
-    assert_not_contains '+ "  ·  " + root.stateText()' "$waffle_row" \
-        'Waffle compact profile rows must not append redundant state text'
-    assert_contains 'profileGuidanceVisible' "$waffle_page" \
-        'Waffle settings must centralize repeated profile guidance at category level'
-    assert_contains 'title: Translation.tr(String(modelData?.title ?? ""))' "$waffle_page" \
-        'schema-driven Waffle group titles must pass through the translation boundary'
-    assert_contains 'text: Translation.tr(root.conciseGroupDescription(groupCard.modelData))' "$waffle_page" \
-        'schema-driven Waffle group descriptions must pass through the translation boundary'
-    assert_not_contains 'TlpSettingsService.categorySettingCount(modelData)' "$waffle_page" \
-        'Waffle category labels must not append setting counts'
+        'Waffle Battery page must remain registered'
     assert_contains 'model: root.visibleGroups' "$classic_page" \
-        'the classic page must render configuration groups'
+        'classic page must render schema groups'
     assert_contains 'model: root.visibleGroups' "$waffle_page" \
-        'the Waffle page must render configuration groups'
-}
-
-test_tlp_settings_auto_apply_hooks_cover_navigation_and_close() {
-    settings_service="$repo_root/services/TlpSettingsService.qml"
-    classic_window="$repo_root/settings.qml"
-    waffle_window="$repo_root/waffleSettings.qml"
-    overlay="$repo_root/modules/settings/SettingsOverlay.qml"
-    classic_page="$repo_root/modules/settings/TlpConfig.qml"
-    waffle_page="$repo_root/modules/waffle/settings/pages/WTlpPage.qml"
-
-    assert_contains 'function applyOnLeave(): bool {' "$settings_service" \
-        'the service must distinguish automatic Apply from manual retry behavior'
-    assert_contains 'root._previousPage === 27' "$classic_window" \
-        'classic page navigation must apply staged Battery changes'
-    assert_contains 'root._previousPage === 18' "$waffle_window" \
-        'Waffle page navigation must apply staged Battery changes'
-    assert_contains 'root._prevPage === 27' "$overlay" \
-        'overlay page navigation must apply staged Battery changes'
-    assert_contains 'onClosing: close =>' "$classic_window" \
-        'classic window close must wait for the privileged transaction'
-    assert_contains 'onClosing: close =>' "$waffle_window" \
-        'Waffle window close must wait for the privileged transaction'
-    assert_contains 'onSelectedCategoryIndexChanged:' "$classic_page" \
-        'classic category changes must auto-apply staged edits'
-    assert_contains 'onSelectedCategoryIndexChanged:' "$waffle_page" \
-        'Waffle category changes must auto-apply staged edits'
+        'Waffle page must render schema groups'
+    assert_contains 'onClicked: TlpSettingsService.apply()' "$classic_page" \
+        'classic page must expose explicit Apply'
+    assert_contains 'onButtonClicked: TlpSettingsService.apply()' "$waffle_page" \
+        'Waffle page must expose explicit Apply'
 }
 
 test_quickshell_lifecycle_contract_is_status_driven() {
@@ -1199,9 +1098,7 @@ test_post_resume_hardware_drift_is_repaired_transactionally() {
     set_policy 80 >/dev/null 2>&1 || fail 'initial battery policy should apply'
     cp "$config_file" "$case_dir/pre-drift-policy"
 
-    # Model firmware which returned to full-charge after resume. The next
-    # Quickshell status read exposes the mismatch; TlpService then requests the
-    # same policy through the transactional helper.
+    # Simulate firmware restoring full-charge thresholds after resume.
     printf '99\n' > "$state_start"
     printf '100\n' > "$state_stop"
     drift_output=$(status)
@@ -1296,7 +1193,7 @@ run_test() {
     fi
 }
 
-printf '1..38\n'
+printf '1..37\n'
 run_test 'status uses TLP plugin metadata' test_status_uses_tlp_plugin_metadata
 run_test 'generic plugin fails closed' test_generic_plugin_fails_closed
 run_test 'unsupported TLP version fails closed' test_unsupported_tlp_version_fails_closed
@@ -1328,7 +1225,6 @@ run_test 'TLP settings batch charge disable and overrides' test_tlp_settings_bat
 run_test 'TLP settings batch disable keeps fullcharge best-effort' test_tlp_settings_batch_disable_keeps_fullcharge_best_effort
 run_test 'TLP settings batch rolls back both drop-ins' test_tlp_settings_batch_rolls_back_both_dropins
 run_test 'TLP settings UI exposes grouped batched controls' test_tlp_settings_ui_uses_schema_groups_and_batched_apply
-run_test 'TLP settings auto-apply covers navigation and close' test_tlp_settings_auto_apply_hooks_cover_navigation_and_close
 run_test 'Quickshell lifecycle contract is status-driven' test_quickshell_lifecycle_contract_is_status_driven
 run_test 'startup timer and display polling are read-only' test_startup_timer_and_display_polling_are_read_only
 run_test 'TLP resume preserves persistent iNiR policies' test_tlp_resume_preserves_persistent_inir_policies

--- a/scripts/test-battery-charge-limit-helper.sh
+++ b/scripts/test-battery-charge-limit-helper.sh
@@ -1,0 +1,1337 @@
+#!/bin/sh
+
+set -u
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+helper="$repo_root/assets/helpers/inir-battery-charge-limit"
+installed_helper=${INIR_TLP_HELPER:-/usr/libexec/inir-battery-charge-limit}
+live_tmp=""
+
+live_fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    return 1
+}
+
+live_usage() {
+    printf '%s\n' 'Live lifecycle checks (run as the desktop user):'
+    printf '%s\n' '  test-battery-charge-limit-helper.sh --live-restart'
+    printf '%s\n' '  test-battery-charge-limit-helper.sh --live-display'
+    printf '%s\n' '  test-battery-charge-limit-helper.sh --live-suspend'
+    printf '%s\n' ''
+    printf '%s\n' '--live-display waits while you turn the display off and wake it.'
+    printf '%s\n' '--live-suspend requires typing SUSPEND before invoking systemctl suspend.'
+}
+
+live_file_fingerprint() {
+    local path=$1 checksum metadata
+
+    if [ ! -e "$path" ]; then
+        printf 'missing\n'
+        return 0
+    fi
+    [ -f "$path" ] || {
+        printf 'not-a-regular-file\n'
+        return 0
+    }
+    checksum=$(sha256sum "$path" 2>/dev/null | awk '{ print $1 }') || return 1
+    metadata=$(stat -Lc '%d:%i:%s:%Y:%Z:%a:%U:%G' "$path" 2>/dev/null) || return 1
+    printf '%s %s\n' "$checksum" "$metadata"
+}
+
+live_capture() {
+    local destination=$1
+
+    mkdir -p "$destination" || return 1
+    "$installed_helper" --status > "$destination/charge.json" || return 1
+    "$installed_helper" --config-status > "$destination/settings.json" || return 1
+    jq -e '.schema == 1' "$destination/charge.json" >/dev/null || return 1
+    jq -e '.schema == 1' "$destination/settings.json" >/dev/null || return 1
+    live_file_fingerprint /etc/tlp.d/99-inir-battery-charge-limit.conf \
+        > "$destination/battery-dropin.fingerprint" || return 1
+    live_file_fingerprint /etc/tlp.d/99-inir-tlp-settings.conf \
+        > "$destination/settings-dropin.fingerprint" || return 1
+    systemctl is-active tlp.service > "$destination/tlp-service" 2>/dev/null || true
+}
+
+live_wait_for_status() {
+    local attempts=0
+
+    while [ "$attempts" -lt 40 ]; do
+        if "$installed_helper" --status > "$live_tmp/wait-charge.json" 2>/dev/null \
+            && "$installed_helper" --config-status > "$live_tmp/wait-settings.json" 2>/dev/null \
+            && jq -e '.schema == 1' "$live_tmp/wait-charge.json" >/dev/null \
+            && jq -e '.schema == 1' "$live_tmp/wait-settings.json" >/dev/null \
+            && jq -e '
+                if .managed == true and .supported == true and .stateKnown == true
+                then (.currentLimit == .managedLimit and
+                    (.managedStart == null or .currentStart == .managedStart))
+                else true
+                end
+            ' "$live_tmp/wait-charge.json" >/dev/null; then
+                return 0
+        fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    return 1
+}
+
+live_compare() {
+    local before=$1 after=$2 before_service after_service
+    local before_charge after_charge before_settings after_settings
+
+    cmp -s "$before/battery-dropin.fingerprint" "$after/battery-dropin.fingerprint" || {
+        live_fail 'battery-care drop-in was rewritten or replaced during the lifecycle event'
+        return 1
+    }
+    cmp -s "$before/settings-dropin.fingerprint" "$after/settings-dropin.fingerprint" || {
+        live_fail 'general TLP settings drop-in was rewritten or replaced during the lifecycle event'
+        return 1
+    }
+
+    before_charge=$(jq -Sc '{managed, managedBattery, managedStart, managedLimit}' "$before/charge.json") || return 1
+    after_charge=$(jq -Sc '{managed, managedBattery, managedStart, managedLimit}' "$after/charge.json") || return 1
+    [ "$before_charge" = "$after_charge" ] || {
+        live_fail 'iNiR battery-care ownership changed during the lifecycle event'
+        return 1
+    }
+
+    before_settings=$(jq -Sc '.managed' "$before/settings.json") || return 1
+    after_settings=$(jq -Sc '.managed' "$after/settings.json") || return 1
+    [ "$before_settings" = "$after_settings" ] || {
+        live_fail 'iNiR general TLP overrides changed during the lifecycle event'
+        return 1
+    }
+
+    if jq -e '.managed == true and .supported == true and .stateKnown == true' "$after/charge.json" >/dev/null; then
+        jq -e '
+            .currentLimit == .managedLimit and
+            (.managedStart == null or .currentStart == .managedStart)
+        ' "$after/charge.json" >/dev/null || {
+            live_fail 'managed battery thresholds did not recover after the lifecycle event'
+            return 1
+        }
+    fi
+
+    before_service=$(cat "$before/tlp-service")
+    after_service=$(cat "$after/tlp-service")
+    if [ "$before_service" = active ] && [ "$after_service" != active ]; then
+        live_fail 'tlp.service was active before the event but is not active afterwards'
+        return 1
+    fi
+
+    printf '%s\n' 'ok - TLP ownership, drop-ins and effective charge limit remained consistent'
+    printf 'charge:  %s\n' "$after_charge"
+    printf 'settings: %s\n' "$after_settings"
+    printf 'service:  %s\n' "${after_service:-unknown}"
+}
+
+run_live_lifecycle() {
+    local event=$1 launcher reply
+
+    [ "$(id -u)" -ne 0 ] || live_fail 'run live lifecycle checks as the desktop user, not root' || return 1
+    [ -x "$installed_helper" ] || live_fail "installed helper is missing: $installed_helper" || return 1
+    command -v jq >/dev/null 2>&1 || live_fail 'jq is required' || return 1
+    command -v sha256sum >/dev/null 2>&1 || live_fail 'sha256sum is required' || return 1
+
+    live_tmp=$(mktemp -d) || return 1
+    trap '[ -z "${live_tmp:-}" ] || rm -rf -- "$live_tmp"' EXIT
+    trap '[ -z "${live_tmp:-}" ] || rm -rf -- "$live_tmp"; exit 1' HUP INT TERM
+
+    live_capture "$live_tmp/before" || live_fail 'could not capture the pre-event TLP state' || return 1
+    jq -e '
+        if .managed == true and .supported == true and .stateKnown == true
+        then (.currentLimit == .managedLimit and
+            (.managedStart == null or .currentStart == .managedStart))
+        else true
+        end
+    ' "$live_tmp/before/charge.json" >/dev/null || {
+        live_fail 'the battery policy is already out of sync; wait for iNiR reconciliation before testing a lifecycle event'
+        return 1
+    }
+
+    case "$event" in
+        restart)
+            if command -v inir >/dev/null 2>&1; then
+                launcher=$(command -v inir)
+            else
+                launcher="$repo_root/scripts/inir"
+            fi
+            [ -x "$launcher" ] || live_fail 'could not resolve the iNiR launcher' || return 1
+            printf '%s\n' 'Restarting Quickshell through iNiR...'
+            "$launcher" restart || live_fail 'iNiR restart failed' || return 1
+            sleep 5
+            ;;
+        display)
+            printf '%s\n' 'Turn the display off, wait a few seconds, then wake it again.' > /dev/tty
+            printf '%s' 'Type DONE after the display is awake: ' > /dev/tty
+            IFS= read -r reply < /dev/tty || return 1
+            [ "$reply" = DONE ] || live_fail 'display lifecycle check cancelled' || return 1
+            sleep 2
+            ;;
+        suspend)
+            printf '%s\n' 'This will suspend the machine. Save open work first.' > /dev/tty
+            printf '%s' 'Type SUSPEND to continue: ' > /dev/tty
+            IFS= read -r reply < /dev/tty || return 1
+            [ "$reply" = SUSPEND ] || live_fail 'suspend lifecycle check cancelled' || return 1
+            systemctl suspend || live_fail 'system suspend failed' || return 1
+            sleep 5
+            ;;
+        *) live_usage; return 2 ;;
+    esac
+
+    live_wait_for_status || live_fail 'TLP status did not become readable after the event' || return 1
+    live_capture "$live_tmp/after" || live_fail 'could not capture the post-event TLP state' || return 1
+    live_compare "$live_tmp/before" "$live_tmp/after"
+}
+
+case "${1:-}" in
+    --live-restart) run_live_lifecycle restart; exit $? ;;
+    --live-display) run_live_lifecycle display; exit $? ;;
+    --live-suspend) run_live_lifecycle suspend; exit $? ;;
+    --live-help) live_usage; exit 0 ;;
+esac
+
+# The helper deliberately exposes no privileged test mode. Source its functions
+# under this different basename and replace only the hardware/TLP boundaries.
+# shellcheck disable=SC1090
+. "$helper"
+
+suite_tmp=$(mktemp -d)
+trap 'rm -rf -- "$suite_tmp"' EXIT
+trap 'rm -rf -- "$suite_tmp"; exit 1' HUP INT TERM
+
+tests_run=0
+
+fail() {
+    printf 'not ok - %s\n' "$1" >&2
+    return 1
+}
+
+assert_eq() {
+    local expected=$1 actual=$2 message=$3
+    [ "$expected" = "$actual" ] || fail "$message (expected '$expected', got '$actual')"
+}
+
+assert_contains() {
+    local needle=$1 file=$2 message=$3
+    grep -Fq -- "$needle" "$file" || fail "$message"
+}
+
+assert_not_contains() {
+    local needle=$1 file=$2 message=$3
+    if grep -Fq -- "$needle" "$file"; then
+        fail "$message"
+    fi
+}
+
+reset_case() {
+    case_dir=$(mktemp -d "$suite_tmp/case.XXXXXX")
+    config_dir="$case_dir/etc/tlp.d"
+    config_file="$config_dir/99-inir-battery-charge-limit.conf"
+    tlp_settings_config_file="$config_dir/99-inir-tlp-settings.conf"
+    tlp_settings_schema="$repo_root/assets/tlp/tlp-settings-schema.json"
+    tlp_settings_lock="$case_dir/inir-tlp-settings.lock"
+    platform_profile_choices_file="$case_dir/platform_profile_choices"
+    mkdir -p "$config_dir"
+    printf '%s\n' 'performance balanced low-power balanced-performance quiet cool' > "$platform_profile_choices_file"
+
+    test_version=1.10.2
+    export test_version
+    test_enabled=1
+    test_plugin=dell
+    test_method=natacpi
+    test_variant=1
+    test_battery=BAT1
+    test_config_battery=BAT1
+    test_start_values=""
+    test_stop_values=""
+    test_behavior=success
+    test_fullcharge_rc=0
+    test_runtime_available=1
+    test_probe_rc=0
+    test_config_probe_rc=0
+
+    state_start="$case_dir/current-start"
+    state_stop="$case_dir/current-stop"
+    calls_file="$case_dir/start-calls"
+    resume_calls_file="$case_dir/resume-calls"
+    printf '95\n' > "$state_start"
+    printf '100\n' > "$state_stop"
+    printf '0\n' > "$calls_file"
+    printf '0\n' > "$resume_calls_file"
+
+    tlp_bin="$case_dir/tlp"
+    printf '%s\n' '#!/bin/sh' "printf 'TLP version %s\\n' \"\$test_version\"" > "$tlp_bin"
+    chmod 0755 "$tlp_bin"
+
+    tmp_file=""
+    backup_file=""
+    had_config=0
+    tlp_settings_tmp_file=""
+    tlp_settings_backup_file=""
+    tlp_settings_had_config=0
+}
+
+find_tlp_runtime() {
+    if [ "$test_runtime_available" -ne 1 ]; then
+        tlp_bin=""
+        tlp_lib_dir=""
+        return 1
+    fi
+    tlp_bin="$case_dir/tlp"
+    tlp_lib_dir=/test/tlp-runtime
+    return 0
+}
+
+run_probe() {
+    [ "$test_probe_rc" -eq 0 ] || return "$test_probe_rc"
+    printf 'version=%s\n' "$test_version"
+    printf 'enabled=%s\n' "$test_enabled"
+    [ "$test_enabled" -eq 1 ] || return 0
+    printf 'plugin=%s\n' "$test_plugin"
+    printf 'method=%s\n' "$test_method"
+    printf 'variant=%s\n' "$test_variant"
+    if [ "$test_method" != none ]; then
+        printf 'battery=%s\n' "$test_battery"
+        printf 'config_battery=%s\n' "$test_config_battery"
+        printf 'current_start=%s\n' "$(cat "$state_start")"
+        printf 'current_stop=%s\n' "$(cat "$state_stop")"
+        printf 'start_values=%s\n' "$test_start_values"
+        printf 'stop_values=%s\n' "$test_stop_values"
+    fi
+}
+
+run_tlp_settings_probe() {
+    local line key value effective_enabled
+
+    [ "$test_config_probe_rc" -eq 0 ] || return "$test_config_probe_rc"
+    effective_enabled=$test_enabled
+    if [ -f "$tlp_settings_config_file" ]; then
+        value=$(sed -n 's/^TLP_ENABLE="\([01]\)"$/\1/p' "$tlp_settings_config_file" | tail -n 1)
+        [ -z "$value" ] || effective_enabled=$value
+    fi
+    printf 'meta\tversion\t%s\n' "$test_version"
+    printf 'meta\tenabled\t%s\n' "$effective_enabled"
+    printf 'setting\tTLP_ENABLE\t%s\n' "$effective_enabled"
+    printf 'setting\tCPU_BOOST_ON_BAT\t0\n'
+    printf 'setting\tSOUND_POWER_SAVE_ON_BAT\t1\n'
+
+    [ -f "$tlp_settings_config_file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            ''|'#'*) continue ;;
+        esac
+        key=${line%%=*}
+        value=${line#*=}
+        case "$value" in
+            \"*\") value=${value#\"}; value=${value%\"} ;;
+            *) continue ;;
+        esac
+        printf 'setting\t%s\t%s\n' "$key" "$value"
+    done < "$tlp_settings_config_file"
+}
+
+apply_staged_state() {
+    local value
+
+    value=$(sed -n 's/^START_CHARGE_THRESH_BAT[01]=//p' "$config_file" | tail -n 1)
+    [ -z "$value" ] || printf '%s\n' "$value" > "$state_start"
+    value=$(sed -n 's/^STOP_CHARGE_THRESH_BAT[01]=//p' "$config_file" | tail -n 1)
+    [ -z "$value" ] || printf '%s\n' "$value" > "$state_stop"
+}
+
+run_tlp_start() {
+    local calls
+    calls=$(( $(cat "$calls_file") + 1 ))
+    printf '%s\n' "$calls" > "$calls_file"
+
+    case "$test_behavior" in
+        silent-error-once)
+            if [ "$calls" -eq 1 ]; then
+                printf '%s\n' 'Error in configuration at START_CHARGE_THRESH_BAT1="0": Battery skipped.'
+                printf '%s\n' 'TLP started'
+                return 0
+            fi
+            ;;
+        mismatch-once)
+            if [ "$calls" -eq 1 ]; then
+                apply_staged_state
+                printf '%s\n' "$(( $(cat "$state_stop") + 1 ))" > "$state_stop"
+                printf '%s\n' 'TLP started'
+                return 0
+            fi
+            ;;
+        fail-once)
+            if [ "$calls" -eq 1 ]; then
+                printf '%s\n' 'TLP failed'
+                return 1
+            fi
+            ;;
+    esac
+
+    [ ! -f "$config_file" ] || apply_staged_state
+    printf '%s\n' 'TLP started'
+    return 0
+}
+
+run_tlp_fullcharge() {
+    [ "$test_fullcharge_rc" -eq 0 ] || return "$test_fullcharge_rc"
+    printf '95\n' > "$state_start"
+    printf '100\n' > "$state_stop"
+    printf '%s\n' 'Full charge thresholds restored'
+}
+
+simulate_tlp_resume() {
+    local calls
+
+    calls=$(( $(cat "$resume_calls_file") + 1 ))
+    printf '%s\n' "$calls" > "$resume_calls_file"
+
+    # TLP owns suspend/resume. Its system-sleep hook re-reads the persistent
+    # configuration and applies the relevant profile. Hardware which needs
+    # threshold restoration sees the same iNiR-owned drop-in at resume time.
+    [ ! -f "$config_file" ] || apply_staged_state
+}
+
+test_status_uses_tlp_plugin_metadata() {
+    reset_case
+    printf '%s\n' 'STOP_CHARGE_THRESH_BAT1=80' > "$config_file"
+    printf '50\n' > "$state_start"
+    printf '80\n' > "$state_stop"
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .schema == 1 and
+        .available == true and
+        .supported == true and
+        .plugin == "dell" and
+        .configBattery == "BAT1" and
+        .limitKind == "continuous" and
+        .minimumLimit == 55 and
+        .maximumLimit == 100 and
+        .currentStart == 50 and
+        .currentLimit == 80 and
+        .managed == true
+    ' >/dev/null || fail 'Dell status JSON does not match TLP metadata'
+}
+
+test_generic_plugin_fails_closed() {
+    reset_case
+    test_plugin=generic
+    test_method=none
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .available == true and
+        .supported == false and
+        .reason == "charge-control-unsupported"
+    ' >/dev/null || fail 'generic plugin must not advertise charge control'
+}
+
+test_unsupported_tlp_version_fails_closed() {
+    reset_case
+    test_version=2.0.0
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .available == true and
+        .supported == false and
+        .reason == "unsupported-tlp-version"
+    ' >/dev/null || fail 'unknown TLP versions must fail closed'
+}
+
+test_disabled_tlp_fails_closed() {
+    reset_case
+    test_enabled=0
+    printf '%s\n' 'STOP_CHARGE_THRESH_BAT1=80' > "$config_file"
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .available == true and
+        .supported == false and
+        .managed == true and
+        .reason == "tlp-disabled"
+    ' >/dev/null || fail 'a disabled TLP must fail closed without hiding iNiR ownership'
+}
+
+test_unreadable_tlp_config_fails_closed() {
+    reset_case
+    test_probe_rc=73
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .available == true and
+        .supported == false and
+        .reason == "tlp-config-unavailable"
+    ' >/dev/null || fail 'an unreadable TLP config must not fall through to defaults'
+}
+
+test_runtime_unavailable_is_reported_without_failure() {
+    reset_case
+    test_runtime_available=0
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .available == false and
+        .supported == false and
+        .stateKnown == false and
+        .reason == "tlp-unavailable"
+    ' >/dev/null || fail 'missing TLP must be a valid, non-mutating status result'
+}
+
+test_missing_battery_preserves_managed_ownership() {
+    reset_case
+    printf '%s\n' 'STOP_CHARGE_THRESH_BAT1=80' > "$config_file"
+    test_probe_rc=72
+
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .available == true and
+        .supported == false and
+        .managed == true and
+        .reason == "battery-unavailable"
+    ' >/dev/null || fail 'a removed battery must not hide iNiR drop-in ownership'
+}
+
+test_plugin_capability_classes() {
+    reset_case
+    test_plugin=asus
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .limitKind == "continuous" and .minimumLimit == 1 and .maximumLimit == 100
+    ' >/dev/null || fail 'ASUS must expose its 1..100 stop range'
+
+    reset_case
+    test_plugin=msi
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .limitKind == "continuous" and .minimumLimit == 10 and .maximumLimit == 100
+    ' >/dev/null || fail 'MSI must expose its 10..100 stop range'
+
+    reset_case
+    test_plugin=lenovo
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .limitKind == "mode" and .adjustable == false and
+        .allowedLimits == [0, 1] and .fixedLimit == 1
+    ' >/dev/null || fail 'Lenovo must expose conservation mode, not percentages'
+
+    reset_case
+    test_plugin=sony
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .limitKind == "discrete" and .adjustable == true and
+        .allowedLimits == [50, 80, 100]
+    ' >/dev/null || fail 'Sony must expose its discrete thresholds'
+
+    reset_case
+    test_plugin=cros-ec
+    test_variant=1
+    output=$(status)
+    printf '%s\n' "$output" | jq -e '
+        .limitKind == "continuous" and .minimumLimit == 1 and .maximumLimit == 100
+    ' >/dev/null || fail 'cros-ec v2 must expose stop-only continuous control'
+}
+
+test_dell_derives_valid_start_and_bat1_key() {
+    reset_case
+
+    set_policy 80 >/dev/null 2>&1 || fail 'Dell policy should apply'
+    assert_contains 'START_CHARGE_THRESH_BAT1=50' "$config_file" 'Dell must use its minimum valid start threshold'
+    assert_contains 'STOP_CHARGE_THRESH_BAT1=80' "$config_file" 'Dell must target the TLP-selected BAT1 key'
+    assert_not_contains 'RESTORE_THRESHOLDS_ON_BAT' "$config_file" 'iNiR must not override the user restore setting'
+    assert_eq 644 "$(stat -c '%a' "$config_file")" 'managed policy mode must be 0644'
+}
+
+test_valid_current_start_is_preserved() {
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '60\n' > "$state_start"
+
+    set_policy 80 >/dev/null 2>&1 || fail 'ThinkPad policy should apply'
+    assert_contains 'START_CHARGE_THRESH_BAT0=60' "$config_file" 'valid current start threshold should be preserved'
+}
+
+test_tuxedo_uses_runtime_discrete_sets() {
+    reset_case
+    test_plugin=tuxedo
+    test_start_values='40 50 60 70 80 95'
+    test_stop_values='60 70 80 90 100'
+
+    set_policy 70 >/dev/null 2>&1 || fail 'TUXEDO discrete policy should apply'
+    assert_contains 'START_CHARGE_THRESH_BAT1=40' "$config_file" 'TUXEDO should choose a compatible runtime start value'
+    assert_contains 'STOP_CHARGE_THRESH_BAT1=70' "$config_file" 'TUXEDO should write the selected runtime stop value'
+
+    rm -f -- "$config_file"
+    if set_policy 85 >/dev/null 2>&1; then
+        fail 'TUXEDO must reject values outside its runtime set'
+    fi
+    [ ! -f "$config_file" ] || fail 'invalid discrete values must not create a policy'
+}
+
+test_fixed_mode_normalizes_hidden_threshold() {
+    reset_case
+    test_plugin=macbook
+
+    set_policy 73 >/dev/null 2>&1 || fail 'fixed MacBook mode should ignore a stale hidden percentage'
+    assert_contains 'STOP_CHARGE_THRESH_BAT1=80' "$config_file" 'MacBook conservation mode must use 80'
+    assert_not_contains 'START_CHARGE_THRESH' "$config_file" 'derived start thresholds must not be owned by iNiR'
+}
+
+test_silent_tlp_error_rolls_back() {
+    reset_case
+    printf '%s\n' '# prior policy' 'START_CHARGE_THRESH_BAT1=50' 'STOP_CHARGE_THRESH_BAT1=90' > "$config_file"
+    cp "$config_file" "$case_dir/expected"
+    printf '50\n' > "$state_start"
+    printf '90\n' > "$state_stop"
+    test_behavior=silent-error-once
+
+    if set_policy 80 >/dev/null 2>&1; then
+        fail 'zero-exit TLP configuration errors must fail the transaction'
+    fi
+    cmp -s "$case_dir/expected" "$config_file" || fail 'silent TLP errors must restore the previous policy'
+}
+
+test_post_apply_mismatch_rolls_back() {
+    reset_case
+    printf '%s\n' '# prior policy' 'START_CHARGE_THRESH_BAT1=50' 'STOP_CHARGE_THRESH_BAT1=90' > "$config_file"
+    cp "$config_file" "$case_dir/expected"
+    printf '50\n' > "$state_start"
+    printf '90\n' > "$state_stop"
+    test_behavior=mismatch-once
+
+    if set_policy 80 >/dev/null 2>&1; then
+        fail 'post-apply hardware mismatch must fail the transaction'
+    fi
+    cmp -s "$case_dir/expected" "$config_file" || fail 'hardware mismatch must restore the previous policy'
+}
+
+test_disable_treats_fullcharge_as_best_effort() {
+    reset_case
+    printf '%s\n' 'STOP_CHARGE_THRESH_BAT1=80' > "$config_file"
+    test_fullcharge_rc=1
+
+    disable_policy >/dev/null 2>&1 || fail 'fullcharge failure alone must not retain iNiR ownership'
+    [ ! -e "$config_file" ] || fail 'disable must remove the iNiR drop-in'
+}
+
+test_legacy_read_signatures_use_api_mode() {
+    calls_file="$suite_tmp/read-signature-calls"
+    : > "$calls_file"
+
+    batdrv_read_threshold() {
+        printf '%s\n' "$*" >> "$calls_file"
+        printf '80'
+    }
+
+    _batdrv_plugin=asus
+    _natacpi=1
+    read_probe_thresholds
+    assert_eq 80 "$current_stop" 'ASUS stop threshold should be read'
+    assert_eq 0 "$(cat "$calls_file")" 'ASUS read API takes one verbosity argument'
+
+    : > "$calls_file"
+    _batdrv_plugin=toshiba
+    read_probe_thresholds
+    assert_eq 80 "$current_stop" 'Toshiba stop threshold should be read'
+    assert_eq 0 "$(cat "$calls_file")" 'Toshiba read API takes one verbosity argument'
+}
+
+test_tlp_settings_status_reads_effective_and_managed_values() {
+    reset_case
+    printf '%s\n' \
+        '# Managed by iNiR TLP Settings. Do not edit manually.' \
+        'CPU_BOOST_ON_BAT="1"' > "$tlp_settings_config_file"
+
+    output=$(tlp_settings_status)
+    printf '%s\n' "$output" | jq -e '
+        .schema == 1 and
+        .available == true and
+        .supported == true and
+        .configAvailable == true and
+        .enabled == true and
+        .tlpVersion == "1.10.2" and
+        .effective.CPU_BOOST_ON_BAT == "1" and
+        .managed.CPU_BOOST_ON_BAT == "1" and
+        .runtimeValues.PLATFORM_PROFILE_ON_AC ==
+            ["performance", "balanced", "low-power", "balanced-performance", "quiet", "cool"] and
+        .runtimeValues.PLATFORM_PROFILE_ON_BAT == .runtimeValues.PLATFORM_PROFILE_ON_AC and
+        .runtimeValues.PLATFORM_PROFILE_ON_SAV == .runtimeValues.PLATFORM_PROFILE_ON_AC
+    ' >/dev/null || fail 'TLP settings status must expose effective ownership and runtime platform choices'
+}
+
+test_tlp_settings_apply_batches_validated_overrides() {
+    reset_case
+
+    tlp_settings_apply \
+        --set CPU_BOOST_ON_BAT 1 \
+        --set SOUND_POWER_SAVE_ON_BAT 12 >/dev/null 2>&1 || fail 'valid TLP overrides should apply'
+
+    assert_contains 'CPU_BOOST_ON_BAT="1"' "$tlp_settings_config_file" 'CPU override must be written'
+    assert_contains 'SOUND_POWER_SAVE_ON_BAT="12"' "$tlp_settings_config_file" 'audio override must be written'
+    assert_not_contains 'CHARGE_THRESH' "$tlp_settings_config_file" 'general settings must not own charge thresholds'
+    assert_eq 644 "$(stat -c '%a' "$tlp_settings_config_file")" 'TLP settings drop-in mode must be 0644'
+    assert_eq 1 "$(cat "$calls_file")" 'a batch must restart TLP only once'
+}
+
+test_tlp_settings_accepts_documented_keep_and_userspace() {
+    reset_case
+
+    tlp_settings_apply \
+        --set DISK_APM_LEVEL_ON_AC 'keep 254' \
+        --set DISK_SPINDOWN_TIMEOUT_ON_BAT '_ keep' \
+        --set DISK_IOSCHED 'keep mq-deadline' \
+        --set CPU_SCALING_GOVERNOR_ON_AC userspace >/dev/null 2>&1 \
+        || fail 'TLP-documented keep/_ values and userspace governor should apply'
+
+    assert_contains 'DISK_APM_LEVEL_ON_AC="keep 254"' "$tlp_settings_config_file" \
+        'disk APM must preserve TLP keep semantics'
+    assert_contains 'DISK_SPINDOWN_TIMEOUT_ON_BAT="_ keep"' "$tlp_settings_config_file" \
+        'disk spin-down must accept the documented underscore synonym'
+    assert_contains 'DISK_IOSCHED="keep mq-deadline"' "$tlp_settings_config_file" \
+        'I/O scheduler must accept keep next to an explicit scheduler'
+    assert_contains 'CPU_SCALING_GOVERNOR_ON_AC="userspace"' "$tlp_settings_config_file" \
+        'CPU governor validation must include userspace'
+}
+
+test_tlp_profile_apply_migrates_legacy_config_syntax() {
+    reset_case
+    printf '%s\n' \
+        '# Managed by iNiR TLP Settings. Do not edit manually.' \
+        "CPU_BOOST_ON_BAT='1'" > "$tlp_settings_config_file"
+
+    tlp_settings_apply \
+        --set TLP_PROFILE_AC PRF \
+        --set TLP_PROFILE_BAT SAV \
+        --set TLP_PROFILE_DEFAULT AC >/dev/null 2>&1 \
+        || fail 'TLP profile mappings should apply'
+
+    assert_contains 'CPU_BOOST_ON_BAT="1"' "$tlp_settings_config_file" \
+        'Apply must migrate a legacy iNiR override to TLP-compatible quoting'
+    assert_contains 'TLP_PROFILE_AC="PRF"' "$tlp_settings_config_file" \
+        'AC profile mapping must be written'
+    assert_contains 'TLP_PROFILE_BAT="SAV"' "$tlp_settings_config_file" \
+        'battery profile mapping must be written'
+    assert_contains 'TLP_PROFILE_DEFAULT="AC"' "$tlp_settings_config_file" \
+        'fallback profile mapping must retain its legacy alias'
+    assert_not_contains "='" "$tlp_settings_config_file" \
+        'the managed drop-in must not retain TLP-invalid single quotes'
+
+    output=$(tlp_settings_status)
+    printf '%s\n' "$output" | jq -e '
+        .managed.TLP_PROFILE_AC == "PRF" and
+        .managed.TLP_PROFILE_BAT == "SAV" and
+        .managed.TLP_PROFILE_DEFAULT == "AC" and
+        .effective.TLP_PROFILE_AC == "PRF" and
+        .effective.TLP_PROFILE_BAT == "SAV" and
+        .effective.TLP_PROFILE_DEFAULT == "AC"
+    ' >/dev/null || fail 'profile mappings must survive effective-config verification'
+    assert_eq 1 "$(cat "$calls_file")" 'all profile mappings must run tlp start once'
+}
+
+test_tlp_settings_reject_unknown_unsafe_and_version_gated_values() {
+    reset_case
+
+    if tlp_settings_apply --set NOT_A_TLP_SETTING 1 >/dev/null 2>&1; then
+        fail 'unknown settings must be rejected'
+    fi
+    if tlp_settings_apply --set CPU_BOOST_ON_BAT '1;touch /tmp/nope' >/dev/null 2>&1; then
+        fail 'unsafe shell values must be rejected'
+    fi
+    if tlp_settings_apply --set SOUND_POWER_SAVE_ON_BAT 99999 >/dev/null 2>&1; then
+        fail 'out-of-range numeric values must be rejected'
+    fi
+    if tlp_settings_apply --set DEVICES_TO_DISABLE_ON_AC wifi >/dev/null 2>&1; then
+        fail 'TLP 1.11-only settings must be rejected on TLP 1.10'
+    fi
+    [ ! -e "$tlp_settings_config_file" ] || fail 'rejected values must not create a settings drop-in'
+}
+
+test_tlp_settings_unset_preserves_other_overrides() {
+    reset_case
+
+    tlp_settings_apply --set CPU_BOOST_ON_BAT 1 --set SOUND_POWER_SAVE_ON_BAT 12 >/dev/null 2>&1 || fail 'initial TLP overrides should apply'
+    tlp_settings_apply --unset CPU_BOOST_ON_BAT >/dev/null 2>&1 || fail 'unsetting one TLP override should apply'
+
+    assert_not_contains 'CPU_BOOST_ON_BAT=' "$tlp_settings_config_file" 'unset must remove only the selected key'
+    assert_contains 'SOUND_POWER_SAVE_ON_BAT="12"' "$tlp_settings_config_file" 'unset must preserve unrelated overrides'
+}
+
+test_tlp_settings_silent_error_rolls_back() {
+    reset_case
+    printf '%s\n' \
+        '# Managed by iNiR TLP Settings. Do not edit manually.' \
+        'CPU_BOOST_ON_BAT="0"' > "$tlp_settings_config_file"
+    cp "$tlp_settings_config_file" "$case_dir/expected-settings"
+    test_behavior=silent-error-once
+
+    if tlp_settings_apply --set CPU_BOOST_ON_BAT 1 >/dev/null 2>&1; then
+        fail 'silent TLP settings errors must fail the transaction'
+    fi
+    cmp -s "$case_dir/expected-settings" "$tlp_settings_config_file" || fail 'silent TLP settings errors must restore the prior drop-in'
+}
+
+test_tlp_settings_disable_skips_tlp_start() {
+    reset_case
+
+    tlp_settings_apply --set TLP_ENABLE 0 >/dev/null 2>&1 || fail 'TLP_ENABLE=0 should be saved'
+    assert_contains 'TLP_ENABLE="0"' "$tlp_settings_config_file" 'disabled state must be owned explicitly'
+    assert_eq 0 "$(cat "$calls_file")" 'TLP start must be skipped after disabling TLP'
+}
+
+test_tlp_platform_profiles_follow_runtime_choices() {
+    reset_case
+    printf '%s\n' 'performance balanced low-power quiet' > "$platform_profile_choices_file"
+
+    tlp_settings_apply --set PLATFORM_PROFILE_ON_AC quiet >/dev/null 2>&1 \
+        || fail 'TLP 1.10 should accept a vendor profile advertised by the kernel ABI'
+    assert_contains 'PLATFORM_PROFILE_ON_AC="quiet"' "$tlp_settings_config_file" \
+        'TLP 1.10 must preserve the runtime-advertised vendor profile'
+
+    reset_case
+    printf '%s\n' 'performance balanced low-power' > "$platform_profile_choices_file"
+    if tlp_settings_apply --set PLATFORM_PROFILE_ON_AC vendor-ultra >/dev/null 2>&1; then
+        fail 'TLP 1.10 must reject a platform profile which is not available at runtime'
+    fi
+    [ ! -e "$tlp_settings_config_file" ] || fail 'a rejected TLP 1.10 profile must not create an override'
+
+    reset_case
+    test_version=1.11.0-alpha.0
+    printf '%s\n' 'performance balanced low-power quiet' > "$platform_profile_choices_file"
+    tlp_settings_apply --set PLATFORM_PROFILE_ON_BAT 'vendor-ultra quiet' >/dev/null 2>&1 \
+        || fail 'TLP 1.11 should allow ordered fallback lists when at least one value is locally available'
+    assert_contains 'PLATFORM_PROFILE_ON_BAT="vendor-ultra quiet"' "$tlp_settings_config_file" \
+        'TLP 1.11 must retain the ordered fallback list verbatim'
+
+    reset_case
+    test_version=1.11.0-alpha.0
+    printf '%s\n' 'performance balanced low-power' > "$platform_profile_choices_file"
+    if tlp_settings_apply --set PLATFORM_PROFILE_ON_BAT 'vendor-ultra silent-max' >/dev/null 2>&1; then
+        fail 'TLP 1.11 must reject a fallback list with no runtime match'
+    fi
+
+    # A stale iNiR-owned value must stay readable after firmware capabilities
+    # change; otherwise the user could be locked out of the UI needed to unset it.
+    printf '%s\n' \
+        '# Managed by iNiR TLP Settings. Do not edit manually.' \
+        'PLATFORM_PROFILE_ON_AC="old-vendor"' > "$tlp_settings_config_file"
+    output=$(tlp_settings_status)
+    printf '%s\n' "$output" | jq -e '
+        .configAvailable == true and
+        .managed.PLATFORM_PROFILE_ON_AC == "old-vendor" and
+        .runtimeValues.PLATFORM_PROFILE_ON_AC == ["performance", "balanced", "low-power"]
+    ' >/dev/null || fail 'stale platform-profile ownership must remain observable and removable'
+}
+
+test_tlp_settings_reset_preserves_battery_policy() {
+    reset_case
+    printf '%s\n' 'STOP_CHARGE_THRESH_BAT1=80' > "$config_file"
+    printf '%s\n' \
+        '# Managed by iNiR TLP Settings. Do not edit manually.' \
+        'CPU_BOOST_ON_BAT="1"' > "$tlp_settings_config_file"
+
+    tlp_settings_reset >/dev/null 2>&1 || fail 'general TLP overrides should reset'
+    [ ! -e "$tlp_settings_config_file" ] || fail 'reset must remove the general iNiR drop-in'
+    [ -f "$config_file" ] || fail 'reset must preserve the separate battery-care policy'
+}
+
+test_tlp_settings_batch_applies_charge_and_overrides_once() {
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '0\n' > "$state_start"
+
+    tlp_settings_apply \
+        --charge-set 80 \
+        --set CPU_BOOST_ON_BAT 1 \
+        --set SOUND_POWER_SAVE_ON_BAT 12 >/dev/null 2>&1 \
+        || fail 'charge care and general settings should apply as one transaction'
+
+    assert_contains 'START_CHARGE_THRESH_BAT0=0' "$config_file" \
+        'batch apply must write the TLP-derived start threshold'
+    assert_contains 'STOP_CHARGE_THRESH_BAT0=80' "$config_file" \
+        'batch apply must write the requested stop threshold'
+    assert_contains 'CPU_BOOST_ON_BAT="1"' "$tlp_settings_config_file" \
+        'batch apply must write general overrides'
+    assert_contains 'SOUND_POWER_SAVE_ON_BAT="12"' "$tlp_settings_config_file" \
+        'batch apply must retain every staged override'
+    assert_eq 80 "$(cat "$state_stop")" 'batch apply must verify the hardware threshold'
+    assert_eq 1 "$(cat "$calls_file")" 'charge care and general settings must run tlp start once'
+}
+
+test_tlp_settings_batch_disables_charge_and_keeps_overrides() {
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '0\n' > "$state_start"
+
+    set_policy 80 >/dev/null 2>&1 || fail 'initial charge policy should apply'
+    printf '0\n' > "$calls_file"
+
+    tlp_settings_apply --charge-disable --set CPU_BOOST_ON_BAT 1 >/dev/null 2>&1 \
+        || fail 'charge disable and general overrides should share one transaction'
+
+    [ ! -e "$config_file" ] || fail 'batch disable must remove charge-policy ownership'
+    assert_contains 'CPU_BOOST_ON_BAT="1"' "$tlp_settings_config_file" \
+        'batch disable must preserve the staged general override'
+    assert_eq 100 "$(cat "$state_stop")" 'batch disable must restore full-charge hardware state'
+    assert_eq 1 "$(cat "$calls_file")" 'batch disable must run tlp start once'
+}
+
+test_tlp_settings_batch_disable_keeps_fullcharge_best_effort() {
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '0\n' > "$state_start"
+
+    set_policy 80 >/dev/null 2>&1 || fail 'initial charge policy should apply'
+    printf '0\n' > "$calls_file"
+    test_fullcharge_rc=1
+
+    tlp_settings_apply --charge-disable --set CPU_BOOST_ON_BAT 1 \
+        > "$case_dir/batch-disable-output" 2>&1 \
+        || fail 'fullcharge failure alone must not fail a mixed disable transaction'
+
+    [ ! -e "$config_file" ] || fail 'best-effort batch disable must remove charge-policy ownership'
+    assert_contains 'CPU_BOOST_ON_BAT="1"' "$tlp_settings_config_file" \
+        'best-effort batch disable must preserve the staged general override'
+    assert_contains 'Warning: TLP could not restore vendor full-charge thresholds' \
+        "$case_dir/batch-disable-output" \
+        'best-effort batch disable must report the hardware reset warning'
+    assert_eq 1 "$(cat "$calls_file")" \
+        'best-effort batch disable must still apply the remaining TLP configuration once'
+}
+
+test_tlp_settings_batch_rolls_back_both_dropins() {
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '%s\n' \
+        '# Managed by iNiR. Do not edit manually.' \
+        '# Battery/backend detected by TLP: BAT0 (thinkpad)' \
+        'START_CHARGE_THRESH_BAT0=0' \
+        'STOP_CHARGE_THRESH_BAT0=90' > "$config_file"
+    printf '%s\n' \
+        '# Managed by iNiR TLP Settings. Do not edit manually.' \
+        'CPU_BOOST_ON_BAT="0"' > "$tlp_settings_config_file"
+    cp "$config_file" "$case_dir/expected-charge"
+    cp "$tlp_settings_config_file" "$case_dir/expected-settings"
+    printf '0\n' > "$state_start"
+    printf '90\n' > "$state_stop"
+    test_behavior=silent-error-once
+
+    if tlp_settings_apply --charge-set 80 --set CPU_BOOST_ON_BAT 1 >/dev/null 2>&1; then
+        fail 'a rejected mixed batch must fail'
+    fi
+
+    cmp -s "$case_dir/expected-charge" "$config_file" \
+        || fail 'mixed-batch rollback must restore the charge drop-in'
+    cmp -s "$case_dir/expected-settings" "$tlp_settings_config_file" \
+        || fail 'mixed-batch rollback must restore the settings drop-in'
+    assert_eq 90 "$(cat "$state_stop")" 'mixed-batch rollback must restore hardware state'
+    assert_eq 2 "$(cat "$calls_file")" 'mixed-batch rollback must re-apply the previous policy once'
+}
+
+test_tlp_settings_ui_uses_schema_groups_and_batched_apply() {
+    settings_service="$repo_root/services/TlpSettingsService.qml"
+    runtime_service="$repo_root/services/TlpRuntimeCapabilities.qml"
+    services_qmldir="$repo_root/services/qmldir"
+    classic_page="$repo_root/modules/settings/TlpConfig.qml"
+    classic_row="$repo_root/modules/settings/TlpSettingRow.qml"
+    waffle_page="$repo_root/modules/waffle/settings/pages/WTlpPage.qml"
+    waffle_row="$repo_root/modules/waffle/settings/WTlpSettingRow.qml"
+    schema="$repo_root/assets/tlp/tlp-settings-schema.json"
+
+    jq -e '
+        .schema == 1 and
+        ([.categories[].settings[]] | length) == 125 and
+        ([.categories[].groups[]] | length) == 62 and
+        ([.categories[].groups[] |
+            select(.description == "" or (.description | contains("\n")) or (.description | length) > 120)] | length) == 0 and
+        ([.categories[].groups[] |
+            select(.id == "CPU_DRIVER_OPMODE" and (.description | startswith("Intel/AMD")))] | length) == 1 and
+        .descriptionAttribution.license == "GPL-2.0-or-later"
+    ' "$schema" >/dev/null || fail 'the UI schema must expose concise, hardware-aware setting groups'
+    assert_eq 'pragma ComponentBehavior: Bound' "$(sed -n '1p' "$settings_service")" \
+        'the settings service must follow the new-QML pragma convention'
+    assert_eq 'pragma ComponentBehavior: Bound' "$(sed -n '1p' "$runtime_service")" \
+        'the runtime capability service must follow the new-QML pragma convention'
+    assert_contains 'singleton TlpRuntimeCapabilities 1.0 TlpRuntimeCapabilities.qml' "$services_qmldir" \
+        'the runtime capability service must be registered in services/qmldir'
+    assert_contains 'property var categories: []' "$settings_service" \
+        'schema categories must remain a JavaScript array'
+    assert_contains 'property var runtimeValues: ({})' "$settings_service" \
+        'runtime platform-profile choices must be carried separately from the static schema'
+    assert_contains 'const capabilityValues = TlpRuntimeCapabilities.values' "$settings_service" \
+        'editors must prefer local kernel capability choices when they are available'
+    assert_contains 'root._array(root.runtimeValues[key])' "$settings_service" \
+        'editors must retain helper-reported platform-profile choices'
+    assert_contains 'TlpRuntimeCapabilities.isRdwSetting(key)' "$settings_service" \
+        'radio-event settings must be gated by the RDW runtime backend'
+    assert_contains '/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors' "$runtime_service" \
+        'CPU governor choices must come from the active kernel cpufreq interface'
+    assert_contains '/sys/power/mem_sleep' "$runtime_service" \
+        'suspend choices must come from the active kernel suspend interface'
+    assert_contains 'onTriggered: root.refresh()' "$runtime_service" \
+        'runtime capabilities must be refreshed while the settings process stays alive'
+    assert_contains 'DISK_IOSCHED: "keep"' "$settings_service" \
+        'the I/O scheduler example must demonstrate TLP\047s no-op default'
+    assert_contains 'key.startsWith("CPU_SCALING_GOVERNOR_")' "$settings_service" \
+        'the UI must retain TLP\047s documented userspace governor fallback when sysfs is unavailable'
+    assert_contains '"battery-care", "general", "processor", "graphics", "disks"' "$settings_service" \
+        'Battery care and common power domains must lead the adapted category layout'
+    assert_not_contains 'Array.isArray(category?.settings)' "$settings_service" \
+        'nested QML sequence wrappers must not hide category settings'
+    assert_contains 'function groupsForCategory(category, filterText): var {' "$settings_service" \
+        'the settings service must expose TLPUI-style groups'
+    assert_contains 'command.push("--charge-set"' "$settings_service" \
+        'charge care must join the same privileged batch'
+    assert_eq 1 "$(grep -Fc 'const command = ["/usr/bin/pkexec", root.helperPath, "--config-apply"]' "$settings_service")" \
+        'the settings service must build exactly one privileged Apply command' || return 1
+    assert_contains 'settingsPageName: Translation.tr("Battery")' "$classic_page" \
+        'the classic page must be named Battery'
+    assert_not_contains 'leftAlignedContent:' "$classic_page" \
+        'the TLP page must not require TLP-only changes in the shared category button'
+    assert_not_contains 'TlpSettingsService.categorySettingCount(modelData)' "$classic_page" \
+        'classic category labels must not append setting counts'
+    assert_contains 'id: profileBadge' "$classic_row" \
+        'the profile badge must be a peer of the editor for vertical alignment'
+    assert_contains 'readonly property real editorHeight: 38 * Appearance.fontSizeScale' "$classic_row" \
+        'classic TLP editors must share one compact height that follows UI scaling'
+    assert_contains 'readonly property real editorWidth: root.settingType === "list" ? 310 : 240' "$classic_row" \
+        'list editors must reserve enough width for balanced option wrapping'
+    assert_contains 'implicitHeight: Math.max(root.editorHeight, optionFlow.implicitHeight)' "$classic_row" \
+        'multi-line option flows must remain vertically centered in their row'
+    assert_contains 'ToolbarTextField {' "$classic_row" \
+        'free-form values must reuse the compact upstream text field'
+    assert_not_contains 'MaterialTextField {' "$classic_row" \
+        'free-form values must not compress the floating-label Material field'
+    assert_contains 'groupDescription: root.conciseGroupDescription(groupCard.modelData)' "$classic_page" \
+        'each classic override tooltip must receive only the concise group guidance'
+    assert_contains 'hoverEnabled: true' "$classic_row" \
+        'TLP override switches must own their tooltip hover behavior locally'
+    assert_contains 'text: root.toggleToolTip()' "$classic_row" \
+        'each override toggle must expose ownership and setting guidance on hover'
+    assert_contains 'function wrapToolTip(text: string): string {' "$classic_row" \
+        'setting guidance tooltips must wrap before crossing the settings window'
+    assert_contains 'Translation.tr("Parameter: %1")' "$classic_row" \
+        'raw TLP keys must stay available in the classic tooltip instead of the main row'
+    assert_contains 'Translation.tr("State: %1")' "$classic_row" \
+        'detailed ownership state must stay available in the classic tooltip'
+    assert_not_contains 'root.settingKey + "  ·  " + root.stateText()' "$classic_row" \
+        'classic rows must not repeat the raw key and state under every toggle'
+    assert_not_contains '+ "  ·  " + root.stateText()' "$classic_row" \
+        'classic compact profile rows must not append redundant state text'
+    assert_contains 'root.profile.length > 0 && !root.isProfileMapping' "$classic_row" \
+        'classic profile mappings must merge rather than duplicate their profile badge'
+    assert_contains 'font.pixelSize: Appearance.font.pixelSize.smallest' "$classic_page" \
+        'visible group guidance must remain visually secondary'
+    assert_contains 'profileGuidanceVisible' "$classic_page" \
+        'classic settings must centralize repeated profile guidance at category level'
+    assert_contains 'title: Translation.tr(String(modelData?.title ?? ""))' "$classic_page" \
+        'schema-driven classic group titles must pass through the translation boundary'
+    assert_contains 'text: Translation.tr(root.conciseGroupDescription(groupCard.modelData))' "$classic_page" \
+        'schema-driven classic group descriptions must pass through the translation boundary'
+    assert_contains 'pageTitle: Translation.tr("Battery")' "$waffle_page" \
+        'the Waffle page must be named Battery'
+    assert_contains 'description: ""' "$waffle_row" \
+        'Waffle rows must not render raw-key or state subtitles'
+    assert_not_contains '+ "  ·  " + root.stateText()' "$waffle_row" \
+        'Waffle compact profile rows must not append redundant state text'
+    assert_contains 'profileGuidanceVisible' "$waffle_page" \
+        'Waffle settings must centralize repeated profile guidance at category level'
+    assert_contains 'title: Translation.tr(String(modelData?.title ?? ""))' "$waffle_page" \
+        'schema-driven Waffle group titles must pass through the translation boundary'
+    assert_contains 'text: Translation.tr(root.conciseGroupDescription(groupCard.modelData))' "$waffle_page" \
+        'schema-driven Waffle group descriptions must pass through the translation boundary'
+    assert_not_contains 'TlpSettingsService.categorySettingCount(modelData)' "$waffle_page" \
+        'Waffle category labels must not append setting counts'
+    assert_contains 'model: root.visibleGroups' "$classic_page" \
+        'the classic page must render configuration groups'
+    assert_contains 'model: root.visibleGroups' "$waffle_page" \
+        'the Waffle page must render configuration groups'
+}
+
+test_tlp_settings_auto_apply_hooks_cover_navigation_and_close() {
+    settings_service="$repo_root/services/TlpSettingsService.qml"
+    classic_window="$repo_root/settings.qml"
+    waffle_window="$repo_root/waffleSettings.qml"
+    overlay="$repo_root/modules/settings/SettingsOverlay.qml"
+    classic_page="$repo_root/modules/settings/TlpConfig.qml"
+    waffle_page="$repo_root/modules/waffle/settings/pages/WTlpPage.qml"
+
+    assert_contains 'function applyOnLeave(): bool {' "$settings_service" \
+        'the service must distinguish automatic Apply from manual retry behavior'
+    assert_contains 'root._previousPage === 27' "$classic_window" \
+        'classic page navigation must apply staged Battery changes'
+    assert_contains 'root._previousPage === 18' "$waffle_window" \
+        'Waffle page navigation must apply staged Battery changes'
+    assert_contains 'root._prevPage === 27' "$overlay" \
+        'overlay page navigation must apply staged Battery changes'
+    assert_contains 'onClosing: close =>' "$classic_window" \
+        'classic window close must wait for the privileged transaction'
+    assert_contains 'onClosing: close =>' "$waffle_window" \
+        'Waffle window close must wait for the privileged transaction'
+    assert_contains 'onSelectedCategoryIndexChanged:' "$classic_page" \
+        'classic category changes must auto-apply staged edits'
+    assert_contains 'onSelectedCategoryIndexChanged:' "$waffle_page" \
+        'Waffle category changes must auto-apply staged edits'
+}
+
+test_quickshell_lifecycle_contract_is_status_driven() {
+    charge_service="$repo_root/services/TlpService.qml"
+    settings_service="$repo_root/services/TlpSettingsService.qml"
+
+    assert_contains 'if (root._matchesRequestedPolicy()) {' "$charge_service" \
+        'Quickshell startup must skip mutation when the requested policy already matches'
+    assert_contains 'command: ["/usr/libexec/inir-battery-charge-limit", "--status"]' "$charge_service" \
+        'battery lifecycle detection must use the unprivileged status command'
+    assert_contains 'onTriggered: root._detect()' "$charge_service" \
+        'battery lifecycle timer must remain detection-only'
+    assert_contains 'command: [root.helperPath, "--config-status"]' "$settings_service" \
+        'general TLP lifecycle detection must use the unprivileged status command'
+    assert_contains 'onTriggered: root.refresh()' "$settings_service" \
+        'general TLP lifecycle timer must remain refresh-only'
+    assert_not_contains 'systemctl suspend' "$charge_service" \
+        'Quickshell must not take ownership of TLP suspend/resume'
+    assert_not_contains 'power-off-monitors' "$charge_service" \
+        'display power events must not mutate TLP from the battery service'
+    assert_not_contains 'systemctl suspend' "$settings_service" \
+        'the TLP settings UI must not take ownership of suspend/resume'
+    assert_not_contains 'power-off-monitors' "$settings_service" \
+        'display power events must not mutate TLP from the settings service'
+}
+
+test_startup_timer_and_display_polling_are_read_only() {
+    local before_calls iteration charge_output settings_output
+
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '0\n' > "$state_start"
+
+    set_policy 80 >/dev/null 2>&1 || fail 'initial battery policy should apply'
+    tlp_settings_apply --set CPU_BOOST_ON_BAT 1 >/dev/null 2>&1 \
+        || fail 'initial general TLP override should apply'
+    cp "$config_file" "$case_dir/expected-battery-policy"
+    cp "$tlp_settings_config_file" "$case_dir/expected-settings-policy"
+    before_calls=$(cat "$calls_file")
+
+    iteration=0
+    while [ "$iteration" -lt 8 ]; do
+        charge_output=$(status)
+        printf '%s\n' "$charge_output" | jq -e '
+            .supported == true and .managed == true and .stateKnown == true and
+            .configBattery == "BAT0" and .managedBattery == "BAT0" and
+            .currentLimit == 80 and .managedLimit == 80
+        ' >/dev/null || fail 'status polling must keep a matching battery policy observable'
+
+        settings_output=$(tlp_settings_status)
+        printf '%s\n' "$settings_output" | jq -e '
+            .configAvailable == true and .managed.CPU_BOOST_ON_BAT == "1" and
+            .effective.CPU_BOOST_ON_BAT == "1"
+        ' >/dev/null || fail 'status polling must keep general overrides observable'
+        iteration=$((iteration + 1))
+    done
+
+    cmp -s "$case_dir/expected-battery-policy" "$config_file" \
+        || fail 'startup/timer/display polling must not rewrite the battery drop-in'
+    cmp -s "$case_dir/expected-settings-policy" "$tlp_settings_config_file" \
+        || fail 'startup/timer/display polling must not rewrite the settings drop-in'
+    assert_eq "$before_calls" "$(cat "$calls_file")" \
+        'startup/timer/display polling must not invoke tlp start'
+}
+
+test_tlp_resume_preserves_persistent_inir_policies() {
+    local before_calls charge_output settings_output
+
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '0\n' > "$state_start"
+
+    set_policy 80 >/dev/null 2>&1 || fail 'initial battery policy should apply'
+    tlp_settings_apply --set CPU_BOOST_ON_BAT 1 >/dev/null 2>&1 \
+        || fail 'initial general TLP override should apply'
+    cp "$config_file" "$case_dir/pre-sleep-battery-policy"
+    cp "$tlp_settings_config_file" "$case_dir/pre-sleep-settings-policy"
+    before_calls=$(cat "$calls_file")
+
+    simulate_tlp_resume
+
+    cmp -s "$case_dir/pre-sleep-battery-policy" "$config_file" \
+        || fail 'TLP resume must not rewrite the persistent battery drop-in'
+    cmp -s "$case_dir/pre-sleep-settings-policy" "$tlp_settings_config_file" \
+        || fail 'TLP resume must not rewrite the persistent settings drop-in'
+    assert_eq "$before_calls" "$(cat "$calls_file")" \
+        'TLP resume must not be represented as an iNiR tlp start mutation'
+    assert_eq 1 "$(cat "$resume_calls_file")" 'the simulated TLP resume hook must run once'
+
+    charge_output=$(status)
+    printf '%s\n' "$charge_output" | jq -e \
+        '.managed == true and .active == true and .currentLimit == 80 and .managedLimit == 80' \
+        >/dev/null || fail 'battery policy must remain effective after resume'
+    settings_output=$(tlp_settings_status)
+    printf '%s\n' "$settings_output" | jq -e \
+        '.managed.CPU_BOOST_ON_BAT == "1" and .effective.CPU_BOOST_ON_BAT == "1"' \
+        >/dev/null || fail 'general TLP override must remain effective after resume'
+}
+
+test_post_resume_hardware_drift_is_repaired_transactionally() {
+    local drift_output repaired_output
+
+    reset_case
+    test_plugin=thinkpad
+    test_battery=BAT0
+    test_config_battery=BAT0
+    printf '0\n' > "$state_start"
+
+    set_policy 80 >/dev/null 2>&1 || fail 'initial battery policy should apply'
+    cp "$config_file" "$case_dir/pre-drift-policy"
+
+    # Model firmware which returned to full-charge after resume. The next
+    # Quickshell status read exposes the mismatch; TlpService then requests the
+    # same policy through the transactional helper.
+    printf '99\n' > "$state_start"
+    printf '100\n' > "$state_stop"
+    drift_output=$(status)
+    printf '%s\n' "$drift_output" | jq -e \
+        '.managed == true and .stateKnown == true and
+         .currentStart == 99 and .managedStart == 0 and
+         .currentLimit == 100 and .managedLimit == 80' \
+        >/dev/null || fail 'post-resume hardware drift must be observable'
+
+    set_policy 80 >/dev/null 2>&1 || fail 'post-resume policy repair should apply'
+    cmp -s "$case_dir/pre-drift-policy" "$config_file" \
+        || fail 'repairing hardware drift must retain the same persistent policy'
+    assert_eq 2 "$(cat "$calls_file")" 'post-resume drift repair must use one additional tlp start'
+
+    repaired_output=$(status)
+    printf '%s\n' "$repaired_output" | jq -e \
+        '.managed == true and .active == true and
+         .currentStart == 0 and .managedStart == 0 and
+         .currentLimit == 80 and .managedLimit == 80' \
+        >/dev/null || fail 'post-resume repair must be verified from hardware state'
+}
+
+test_disabled_policy_stays_absent_across_runtime_events() {
+    local before_calls charge_output settings_output
+
+    reset_case
+    set_policy 80 >/dev/null 2>&1 || fail 'initial battery policy should apply'
+    disable_policy >/dev/null 2>&1 || fail 'battery policy should disable'
+    [ ! -e "$config_file" ] || fail 'disabled battery policy must have no owned drop-in'
+
+    tlp_settings_apply --set CPU_BOOST_ON_BAT 1 >/dev/null 2>&1 \
+        || fail 'general TLP overrides should remain independently usable'
+    cp "$tlp_settings_config_file" "$case_dir/disabled-settings-policy"
+    before_calls=$(cat "$calls_file")
+
+    status >/dev/null
+    tlp_settings_status >/dev/null
+    simulate_tlp_resume
+    status >/dev/null
+    tlp_settings_status >/dev/null
+
+    [ ! -e "$config_file" ] \
+        || fail 'restart, display polling and resume must not resurrect a disabled battery policy'
+    cmp -s "$case_dir/disabled-settings-policy" "$tlp_settings_config_file" \
+        || fail 'battery disable lifecycle must preserve unrelated general overrides'
+    assert_eq "$before_calls" "$(cat "$calls_file")" \
+        'read-only lifecycle events must not invoke an additional tlp start'
+
+    charge_output=$(status)
+    printf '%s\n' "$charge_output" | jq -e '.managed == false' >/dev/null \
+        || fail 'disabled battery policy must remain unmanaged after resume'
+    settings_output=$(tlp_settings_status)
+    printf '%s\n' "$settings_output" | jq -e '.managed.CPU_BOOST_ON_BAT == "1"' >/dev/null \
+        || fail 'general TLP override must survive the disabled battery lifecycle'
+}
+
+test_source_install_lifecycle() {
+    stage="$suite_tmp/install-stage"
+    helper_path="$stage/usr/libexec/inir-battery-charge-limit"
+    policy_path="$stage/usr/share/polkit-1/actions/org.inir.battery-charge-limit.policy"
+    dropin_path="$stage/etc/tlp.d/99-inir-battery-charge-limit.conf"
+    settings_dropin_path="$stage/etc/tlp.d/99-inir-tlp-settings.conf"
+    schema_path="$stage/usr/share/inir/tlp-settings-schema.json"
+
+    make -s -C "$repo_root" install-battery-helper DESTDIR="$stage" || fail 'source install target failed'
+    [ -x "$helper_path" ] || fail 'source install must install the executable helper'
+    [ -f "$policy_path" ] || fail 'source install must install the polkit action'
+    [ -f "$schema_path" ] || fail 'source install must install the root-owned TLP schema'
+    assert_eq 755 "$(stat -c '%a' "$helper_path")" 'installed helper mode must be 0755'
+    assert_eq 644 "$(stat -c '%a' "$policy_path")" 'installed policy mode must be 0644'
+    assert_eq 644 "$(stat -c '%a' "$schema_path")" 'installed schema mode must be 0644'
+
+    mkdir -p "$(dirname "$dropin_path")"
+    printf '%s\n' 'STOP_CHARGE_THRESH_BAT0=80' > "$dropin_path"
+    printf '%s\n' 'CPU_BOOST_ON_BAT="1"' > "$settings_dropin_path"
+    make -s -C "$repo_root" uninstall-battery-helper DESTDIR="$stage" || fail 'source uninstall target failed'
+    [ ! -e "$helper_path" ] || fail 'source uninstall must remove the helper'
+    [ ! -e "$policy_path" ] || fail 'source uninstall must remove the polkit action'
+    [ ! -e "$dropin_path" ] || fail 'source uninstall must remove the iNiR-owned TLP drop-in'
+    [ ! -e "$settings_dropin_path" ] || fail 'source uninstall must remove the iNiR-owned settings drop-in'
+    [ ! -e "$schema_path" ] || fail 'source uninstall must remove the root-owned TLP schema'
+}
+
+run_test() {
+    local name=$1
+    shift
+    tests_run=$((tests_run + 1))
+    if "$@"; then
+        printf 'ok %s - %s\n' "$tests_run" "$name"
+    else
+        exit 1
+    fi
+}
+
+printf '1..38\n'
+run_test 'status uses TLP plugin metadata' test_status_uses_tlp_plugin_metadata
+run_test 'generic plugin fails closed' test_generic_plugin_fails_closed
+run_test 'unsupported TLP version fails closed' test_unsupported_tlp_version_fails_closed
+run_test 'disabled TLP fails closed' test_disabled_tlp_fails_closed
+run_test 'unreadable TLP config fails closed' test_unreadable_tlp_config_fails_closed
+run_test 'missing TLP is reported safely' test_runtime_unavailable_is_reported_without_failure
+run_test 'missing battery preserves managed ownership' test_missing_battery_preserves_managed_ownership
+run_test 'plugin capability classes are vendor-specific' test_plugin_capability_classes
+run_test 'Dell derives valid BAT1 policy' test_dell_derives_valid_start_and_bat1_key
+run_test 'valid start threshold is preserved' test_valid_current_start_is_preserved
+run_test 'TUXEDO uses discrete runtime sets' test_tuxedo_uses_runtime_discrete_sets
+run_test 'fixed modes normalize hidden threshold' test_fixed_mode_normalizes_hidden_threshold
+run_test 'silent TLP errors roll back' test_silent_tlp_error_rolls_back
+run_test 'post-apply mismatch rolls back' test_post_apply_mismatch_rolls_back
+run_test 'disable keeps fullcharge best-effort' test_disable_treats_fullcharge_as_best_effort
+run_test 'legacy plugin reads use API signatures' test_legacy_read_signatures_use_api_mode
+run_test 'TLP settings status reports effective ownership and runtime choices' test_tlp_settings_status_reads_effective_and_managed_values
+run_test 'TLP settings apply batches validated overrides' test_tlp_settings_apply_batches_validated_overrides
+run_test 'TLP settings accept documented keep and userspace values' test_tlp_settings_accepts_documented_keep_and_userspace
+run_test 'TLP profile apply migrates legacy quoting' test_tlp_profile_apply_migrates_legacy_config_syntax
+run_test 'TLP settings reject invalid inputs and versions' test_tlp_settings_reject_unknown_unsafe_and_version_gated_values
+run_test 'TLP settings unset preserves other overrides' test_tlp_settings_unset_preserves_other_overrides
+run_test 'TLP settings silent errors roll back' test_tlp_settings_silent_error_rolls_back
+run_test 'TLP settings disable skips start' test_tlp_settings_disable_skips_tlp_start
+run_test 'TLP platform profiles follow runtime choices' test_tlp_platform_profiles_follow_runtime_choices
+run_test 'TLP settings reset preserves battery policy' test_tlp_settings_reset_preserves_battery_policy
+run_test 'TLP settings batch charge and overrides once' test_tlp_settings_batch_applies_charge_and_overrides_once
+run_test 'TLP settings batch charge disable and overrides' test_tlp_settings_batch_disables_charge_and_keeps_overrides
+run_test 'TLP settings batch disable keeps fullcharge best-effort' test_tlp_settings_batch_disable_keeps_fullcharge_best_effort
+run_test 'TLP settings batch rolls back both drop-ins' test_tlp_settings_batch_rolls_back_both_dropins
+run_test 'TLP settings UI exposes grouped batched controls' test_tlp_settings_ui_uses_schema_groups_and_batched_apply
+run_test 'TLP settings auto-apply covers navigation and close' test_tlp_settings_auto_apply_hooks_cover_navigation_and_close
+run_test 'Quickshell lifecycle contract is status-driven' test_quickshell_lifecycle_contract_is_status_driven
+run_test 'startup timer and display polling are read-only' test_startup_timer_and_display_polling_are_read_only
+run_test 'TLP resume preserves persistent iNiR policies' test_tlp_resume_preserves_persistent_inir_policies
+run_test 'post-resume hardware drift is repaired transactionally' test_post_resume_hardware_drift_is_repaired_transactionally
+run_test 'disabled policy stays absent across runtime events' test_disabled_policy_stays_absent_across_runtime_events
+run_test 'source install lifecycle owns exact artifacts' test_source_install_lifecycle

--- a/scripts/test-local-distribution.sh
+++ b/scripts/test-local-distribution.sh
@@ -18,9 +18,19 @@ step "shell syntax"
 bash -n \
     "$runtime_root/setup" \
     "$runtime_root/scripts/inir" \
+    "$runtime_root/scripts/test-tlp-integration-lifecycle.sh" \
     "$runtime_root/sdata/lib/"*.sh \
     "$runtime_root/sdata/subcmd-install/"*.sh \
     "$runtime_root/sdata/migrations/"*.sh
+sh -n \
+    "$runtime_root/assets/helpers/inir-battery-charge-limit" \
+    "$runtime_root/scripts/test-battery-charge-limit-helper.sh"
+
+step "battery charge-limit helper"
+sh "$runtime_root/scripts/test-battery-charge-limit-helper.sh"
+
+step "TLP integration lifecycle"
+bash "$runtime_root/scripts/test-tlp-integration-lifecycle.sh"
 
 step "session tray ordering"
 service_unit="$runtime_root/assets/systemd/inir.service"
@@ -291,7 +301,8 @@ for agent_file in "${agent_files[@]}"; do
 done
 # Maintainer and development tooling must be stripped by both install paths.
 dev_tooling_files=(release.sh wiki-sync.sh verify-docs.sh qml-check.fish
-    test-local-distribution.sh test-mascot-pack-flow.sh)
+    test-local-distribution.sh test-mascot-pack-flow.sh
+    test-battery-charge-limit-helper.sh test-tlp-integration-lifecycle.sh)
 dev_tooling_dirs=(agents tools l10n)
 for tool in "${dev_tooling_files[@]}" "${dev_tooling_dirs[@]}"; do
     pattern="--exclude='/$tool'"

--- a/scripts/test-tlp-integration-lifecycle.sh
+++ b/scripts/test-tlp-integration-lifecycle.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+migration="$repo_root/sdata/migrations/038-tlp-profile-backend.sh"
+pkgbuild="$repo_root/sdata/dist-arch/inir-deps/PKGBUILD"
+
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+assert_state() {
+  local unit=$1 expected=$2 actual
+  actual=$(cat "$tmp/state/$unit")
+  [[ "$actual" == "$expected" ]] \
+    || fail "$unit state: expected $expected, got $actual"
+}
+
+assert_log() {
+  local needle=$1
+  grep -Fqx -- "$needle" "$tmp/systemctl.log" \
+    || fail "missing systemctl action: $needle"
+}
+
+# The UI exposes the Radio Device Wizard, so Arch installs must include the
+# package which actually consumes those settings.
+grep -Eq '^[[:space:]]*tlp-rdw[[:space:]]*$' "$pkgbuild" \
+  || fail 'inir-deps must install tlp-rdw'
+
+mkdir -p "$tmp/bin" "$tmp/state"
+: > "$tmp/systemctl.log"
+
+cat > "$tmp/bin/systemctl" <<'MOCK_SYSTEMCTL'
+#!/usr/bin/env bash
+set -u
+state_dir=${MOCK_SYSTEMD_STATE:?}
+log=${MOCK_SYSTEMD_LOG:?}
+command=${1:-}
+shift || true
+
+unit_exists() {
+  [[ -f "$state_dir/$1" ]]
+}
+
+case "$command" in
+  cat)
+    unit_exists "${1:-}"
+    ;;
+  is-enabled)
+    quiet=0
+    if [[ "${1:-}" == "--quiet" ]]; then
+      quiet=1
+      shift
+    fi
+    unit=${1:-}
+    unit_exists "$unit" || exit 1
+    state=$(cat "$state_dir/$unit")
+    [[ $quiet -eq 1 ]] || printf '%s\n' "$state"
+    case "$state" in
+      enabled|enabled-runtime|linked|linked-runtime|alias|masked|masked-runtime|static|indirect|generated|transient)
+        exit 0
+        ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  enable)
+    now=0
+    if [[ "${1:-}" == "--now" ]]; then
+      now=1
+      shift
+    fi
+    unit=${1:-}
+    unit_exists "$unit" || exit 1
+    printf 'enabled\n' > "$state_dir/$unit"
+    if [[ $now -eq 1 ]]; then
+      printf 'enable --now %s\n' "$unit" >> "$log"
+    else
+      printf 'enable %s\n' "$unit" >> "$log"
+    fi
+    ;;
+  mask)
+    now=0
+    if [[ "${1:-}" == "--now" ]]; then
+      now=1
+      shift
+    fi
+    unit=${1:-}
+    unit_exists "$unit" || exit 1
+    printf 'masked\n' > "$state_dir/$unit"
+    if [[ $now -eq 1 ]]; then
+      printf 'mask --now %s\n' "$unit" >> "$log"
+    else
+      printf 'mask %s\n' "$unit" >> "$log"
+    fi
+    ;;
+  *)
+    printf 'unsupported mock systemctl command: %s %s\n' "$command" "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_SYSTEMCTL
+chmod 0755 "$tmp/bin/systemctl"
+
+cat > "$tmp/bin/tlp" <<'EOF_TLP'
+#!/bin/sh
+printf '%s\n' 'TLP version 1.10.2'
+EOF_TLP
+cat > "$tmp/bin/tlp-rdw" <<'EOF_RDW'
+#!/bin/sh
+exit 0
+EOF_RDW
+cat > "$tmp/bin/tlp-stat" <<'EOF_STAT'
+#!/bin/sh
+printf '%s\n' '--- TLP mock status ---'
+EOF_STAT
+chmod 0755 "$tmp/bin/tlp" "$tmp/bin/tlp-rdw" "$tmp/bin/tlp-stat"
+
+for spec in \
+  'tlp.service:disabled' \
+  'tlp-pd.service:disabled' \
+  'power-profiles-daemon.service:enabled' \
+  'tuned-ppd.service:masked' \
+  'NetworkManager-dispatcher.service:disabled' \
+  'systemd-rfkill.service:enabled' \
+  'systemd-rfkill.socket:enabled'; do
+  unit=${spec%%:*}
+  state=${spec#*:}
+  printf '%s\n' "$state" > "$tmp/state/$unit"
+done
+
+export MOCK_SYSTEMD_STATE="$tmp/state"
+export MOCK_SYSTEMD_LOG="$tmp/systemctl.log"
+export PATH="$tmp/bin:$PATH"
+
+# Migration files are sourced by the setup framework. Provide the same small
+# surface they expect while keeping the test fully unprivileged.
+STY_GREEN=''
+STY_RST=''
+pkg_sudo() { "$@"; }
+
+# shellcheck disable=SC1090
+source "$migration"
+
+if ! migration_check; then
+  fail 'migration must be pending with conflicting/disabled service state'
+fi
+
+migration_apply >/dev/null || fail 'migration_apply failed in mocked service environment'
+
+assert_state tlp.service enabled
+assert_state tlp-pd.service enabled
+assert_state power-profiles-daemon.service masked
+assert_state tuned-ppd.service masked
+assert_state NetworkManager-dispatcher.service enabled
+assert_state systemd-rfkill.service masked
+assert_state systemd-rfkill.socket masked
+
+assert_log 'mask --now power-profiles-daemon.service'
+assert_log 'enable --now tlp.service'
+assert_log 'enable --now tlp-pd.service'
+assert_log 'enable NetworkManager-dispatcher.service'
+assert_log 'mask --now systemd-rfkill.service'
+assert_log 'mask --now systemd-rfkill.socket'
+
+if migration_check; then
+  fail 'migration must be satisfied after applying all required service state'
+fi
+
+printf '%s\n' '1..1'
+printf '%s\n' 'ok 1 - TLP profile/radio lifecycle migration reaches an idempotent conflict-free state'

--- a/sdata/dist-arch/inir-deps/PKGBUILD
+++ b/sdata/dist-arch/inir-deps/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgname=inir-deps
 pkgver=2.29.1
-pkgrel=1
+pkgrel=4
 pkgdesc='iNiR desktop shell - dependency tracker (meta-package)'
 url='https://github.com/snowarch/inir'
 arch=(any)
@@ -127,6 +127,12 @@ depends=(
   glib2
   starship
   eza
+
+  #--- Power management ---
+  tlp
+  tlp-pd
+  tlp-rdw
+  ethtool
 
   #--- Input / HW ---
   upower

--- a/sdata/lib/functions.sh
+++ b/sdata/lib/functions.sh
@@ -184,6 +184,8 @@ RUNTIME_EXCLUDES=(
   --exclude='/release.sh' --exclude='/wiki-sync.sh' --exclude='/verify-docs.sh'
   --exclude='/qml-check.fish' --exclude='/test-local-distribution.sh'
   --exclude='/test-mascot-pack-flow.sh'
+  --exclude='/test-battery-charge-limit-helper.sh'
+  --exclude='/test-tlp-integration-lifecycle.sh'
   # Local art work files — the manifest always ships, the art does not
   --exclude='graphify-out/'
   --exclude='images/mascot/*.png' --exclude='images/mascot/*.gif'

--- a/sdata/lib/uninstall.sh
+++ b/sdata/lib/uninstall.sh
@@ -307,6 +307,39 @@ uninstall_reload_user_systemd() {
     fi
 }
 
+uninstall_remove_battery_charge_limit() {
+    local helper="/usr/libexec/inir-battery-charge-limit"
+    local policy="/usr/share/polkit-1/actions/org.inir.battery-charge-limit.policy"
+    local schema="/usr/share/inir/tlp-settings-schema.json"
+    local battery_dropin="/etc/tlp.d/99-inir-battery-charge-limit.conf"
+    local settings_dropin="/etc/tlp.d/99-inir-tlp-settings.conf"
+
+    if [[ ! -e "$helper" && ! -e "$policy" && ! -e "$schema" \
+        && ! -e "$battery_dropin" && ! -e "$settings_dropin" ]]; then
+        return 0
+    fi
+
+    tui_info "Removing iNiR TLP settings integration..."
+
+    # The helper removes only iNiR-owned drop-ins. User and distribution TLP
+    # files remain untouched. Cleanup still proceeds if TLP disappeared.
+    if [[ -x "$helper" ]]; then
+        if ! pkg_sudo "$helper" --config-reset; then
+            tui_warn "Could not fully re-apply TLP; removing the iNiR-owned settings drop-in directly."
+            pkg_sudo rm -f "$settings_dropin" || return 1
+        fi
+        if ! pkg_sudo "$helper" --disable; then
+            tui_warn "Could not fully re-apply TLP; removing the iNiR-owned drop-in directly."
+            pkg_sudo rm -f "$battery_dropin" || return 1
+        fi
+    else
+        pkg_sudo rm -f "$settings_dropin" "$battery_dropin" || return 1
+    fi
+
+    pkg_sudo rm -f "$helper" "$policy" "$schema" || return 1
+    tui_success "iNiR TLP settings integration removed (TLP preserved)"
+}
+
 uninstall_create_backup() {
     local backup_dir="${HOME}/.local/share/inir-uninstall-backup-$(date +%Y%m%d-%H%M%S)"
 
@@ -912,6 +945,13 @@ run_uninstall() {
     # Stop services
     uninstall_stop_services
 
+    # Remove privileged artifacts before deleting the user runtime which owns
+    # the corresponding UI. TLP itself and user-owned TLP files are preserved.
+    if ! uninstall_remove_battery_charge_limit; then
+        tui_error "Battery charge-limit cleanup failed; no user files were removed."
+        return 1
+    fi
+
     # Remove iNiR-exclusive files (always safe)
     uninstall_remove_inir_only
     uninstall_reload_user_systemd
@@ -988,6 +1028,12 @@ run_uninstall_quick() {
 
     # Stop services
     uninstall_stop_services
+
+    # The helper, policy and managed TLP drop-in are iNiR-exclusive.
+    if ! uninstall_remove_battery_charge_limit; then
+        tui_error "Battery charge-limit cleanup failed; no user files were removed."
+        return 1
+    fi
 
     # Remove only iNiR-exclusive files
     ask=false  # Disable prompts for shared configs

--- a/sdata/migrations/037-battery-charge-limit-helper.sh
+++ b/sdata/migrations/037-battery-charge-limit-helper.sh
@@ -1,0 +1,101 @@
+# Migration: Install the privileged TLP helper, schema and polkit action
+# The helper is deliberately installed outside the user-writable Quickshell runtime.
+# QML invokes it through pkexec; all privileged writes are constrained to iNiR's
+# own TLP drop-in and are validated/applied by TLP.
+
+MIGRATION_ID="037-battery-charge-limit-helper"
+MIGRATION_TITLE="Install iNiR TLP settings backend"
+MIGRATION_DESCRIPTION="Installs and updates the root-owned TLP helper, validation schema and polkit action."
+MIGRATION_TARGET_FILE="/usr/libexec/inir-battery-charge-limit"
+MIGRATION_REQUIRED=true
+
+migration_check() {
+  local helper="${REPO_ROOT}/assets/helpers/inir-battery-charge-limit"
+  local policy="${REPO_ROOT}/assets/polkit/org.inir.battery-charge-limit.policy"
+  local schema="${REPO_ROOT}/assets/tlp/tlp-settings-schema.json"
+  local installed_helper="/usr/libexec/inir-battery-charge-limit"
+  local installed_policy="/usr/share/polkit-1/actions/org.inir.battery-charge-limit.policy"
+  local installed_schema="/usr/share/inir/tlp-settings-schema.json"
+
+  [[ -f "$helper" && -f "$policy" && -f "$schema" ]] || return 0
+  [[ -x "$installed_helper" && -f "$installed_policy" && -f "$installed_schema" ]] || return 0
+  cmp -s "$helper" "$installed_helper" || return 0
+  cmp -s "$policy" "$installed_policy" || return 0
+  cmp -s "$schema" "$installed_schema" || return 0
+  return 1
+}
+
+migration_preview() {
+  echo -e "${STY_GREEN}+ sync /usr/libexec/inir-battery-charge-limit${STY_RST}"
+  echo -e "${STY_GREEN}+ sync /usr/share/polkit-1/actions/org.inir.battery-charge-limit.policy${STY_RST}"
+  echo -e "${STY_GREEN}+ sync /usr/share/inir/tlp-settings-schema.json${STY_RST}"
+}
+
+migration_diff() {
+  local helper="${REPO_ROOT}/assets/helpers/inir-battery-charge-limit"
+  local policy="${REPO_ROOT}/assets/polkit/org.inir.battery-charge-limit.policy"
+  local schema="${REPO_ROOT}/assets/tlp/tlp-settings-schema.json"
+  local installed_helper="/usr/libexec/inir-battery-charge-limit"
+  local installed_policy="/usr/share/polkit-1/actions/org.inir.battery-charge-limit.policy"
+  local installed_schema="/usr/share/inir/tlp-settings-schema.json"
+
+  echo "Current:"
+  if [[ -x "$installed_helper" ]] && cmp -s "$helper" "$installed_helper"; then
+    echo "  helper: up to date"
+  elif [[ -e "$installed_helper" ]]; then
+    echo "  helper: outdated"
+  else
+    echo "  helper: missing"
+  fi
+
+  if [[ -f "$installed_policy" ]] && cmp -s "$policy" "$installed_policy"; then
+    echo "  polkit action: up to date"
+  elif [[ -e "$installed_policy" ]]; then
+    echo "  polkit action: outdated"
+  else
+    echo "  polkit action: missing"
+  fi
+
+  if [[ -f "$installed_schema" ]] && cmp -s "$schema" "$installed_schema"; then
+    echo "  schema: up to date"
+  elif [[ -e "$installed_schema" ]]; then
+    echo "  schema: outdated"
+  else
+    echo "  schema: missing"
+  fi
+
+  echo ""
+  echo "After migration:"
+  echo "  helper: synchronized from repository asset"
+  echo "  polkit action: synchronized from repository asset"
+  echo "  schema: synchronized from repository asset"
+}
+
+migration_apply() {
+  if ! migration_check; then
+    return 0
+  fi
+
+  local helper="${REPO_ROOT}/assets/helpers/inir-battery-charge-limit"
+  local policy="${REPO_ROOT}/assets/polkit/org.inir.battery-charge-limit.policy"
+  local schema="${REPO_ROOT}/assets/tlp/tlp-settings-schema.json"
+
+  [[ -f "$helper" ]] || {
+    echo "Battery charge-limit helper asset is missing: $helper" >&2
+    return 1
+  }
+  [[ -f "$policy" ]] || {
+    echo "Battery charge-limit polkit policy asset is missing: $policy" >&2
+    return 1
+  }
+  [[ -f "$schema" ]] || {
+    echo "TLP settings schema asset is missing: $schema" >&2
+    return 1
+  }
+
+  pkg_sudo install -Dm755 "$helper" /usr/libexec/inir-battery-charge-limit || return 1
+  pkg_sudo install -Dm644 "$policy" /usr/share/polkit-1/actions/org.inir.battery-charge-limit.policy || return 1
+  pkg_sudo install -Dm644 "$schema" /usr/share/inir/tlp-settings-schema.json || return 1
+
+  echo "iNiR TLP helper, schema and polkit action synchronized."
+}

--- a/sdata/migrations/037-battery-charge-limit-helper.sh
+++ b/sdata/migrations/037-battery-charge-limit-helper.sh
@@ -1,7 +1,5 @@
-# Migration: Install the privileged TLP helper, schema and polkit action
-# The helper is deliberately installed outside the user-writable Quickshell runtime.
-# QML invokes it through pkexec; all privileged writes are constrained to iNiR's
-# own TLP drop-in and are validated/applied by TLP.
+# Install the root-owned TLP helper, schema and polkit action outside the
+# user-writable Quickshell runtime; privileged writes stay helper-controlled.
 
 MIGRATION_ID="037-battery-charge-limit-helper"
 MIGRATION_TITLE="Install iNiR TLP settings backend"

--- a/sdata/migrations/038-tlp-profile-backend.sh
+++ b/sdata/migrations/038-tlp-profile-backend.sh
@@ -1,12 +1,6 @@
-# Migration: Enable TLP and its desktop-compatible profile/radio backends.
-# TLP 1.9+ provides tlp-pd, which implements the same D-Bus API used by
-# Quickshell.Services.UPower.PowerProfiles. TLP's Radio Device Wizard (tlp-rdw)
-# is driven by NetworkManager's dispatcher on distributions which package it.
-#
-# TLP upstream explicitly treats power-profiles-daemon as conflicting and, on
-# Arch, recommends masking systemd-rfkill units for reliable radio switching.
-# Keep those system-level prerequisites in the setup migration rather than in
-# the user-writable Quickshell runtime.
+# Enable TLP's Power Profiles and radio backends.
+# tlp-pd implements the standard Power Profiles D-Bus API; TLP documents PPD
+# conflicts and recommends masking systemd-rfkill on Arch for radio switching.
 
 MIGRATION_ID="038-tlp-profile-backend"
 MIGRATION_TITLE="Enable TLP power management"
@@ -39,17 +33,13 @@ _tlp_radio_backend_available() {
 }
 
 migration_check() {
-  # This repository supports distributions where tlp-pd is not packaged yet.
-  # Treat that as "not applicable", not as a required-migration failure. If the
-  # packages appear later, required migrations are re-checked and this will run.
+  # Missing tlp-pd means this migration is not applicable yet.
   _tlp_profile_backend_available || return 1
 
   systemctl is-enabled --quiet tlp.service 2>/dev/null || return 0
   systemctl is-enabled --quiet tlp-pd.service 2>/dev/null || return 0
 
-  # TLP >= 1.6 deliberately skips overlapping platform/CPU settings when the
-  # real power-profiles-daemon process is running. Do not leave a service which
-  # can reclaim the same D-Bus/kernel controls enabled beside tlp-pd.
+  # Do not leave competing PPD implementations enabled beside tlp-pd.
   if _tlp_unit_exists power-profiles-daemon.service \
       && ! _tlp_unit_masked power-profiles-daemon.service; then
     return 0
@@ -64,8 +54,7 @@ migration_check() {
     return 0
   fi
 
-  # TLP's Arch installation guidance recommends masking systemd-rfkill to keep
-  # radio state restoration from racing TLP's own switching rules.
+  # Avoid systemd-rfkill racing TLP radio restoration on Arch.
   if _tlp_unit_exists systemd-rfkill.service \
       && ! _tlp_unit_masked systemd-rfkill.service; then
     return 0
@@ -131,9 +120,7 @@ migration_apply() {
     return 0
   fi
 
-  # Stop/mask competing D-Bus implementations before starting tlp-pd. This is
-  # exactly the fallback TLP recommends on distributions which permit parallel
-  # package installation. If the package manager already removed them, no-op.
+  # Stop competing PPD implementations before starting tlp-pd.
   for unit in power-profiles-daemon.service tuned-ppd.service; do
     if _tlp_unit_exists "$unit" && ! _tlp_unit_masked "$unit"; then
       pkg_sudo systemctl mask --now "$unit" || return 1

--- a/sdata/migrations/038-tlp-profile-backend.sh
+++ b/sdata/migrations/038-tlp-profile-backend.sh
@@ -1,0 +1,161 @@
+# Migration: Enable TLP and its desktop-compatible profile/radio backends.
+# TLP 1.9+ provides tlp-pd, which implements the same D-Bus API used by
+# Quickshell.Services.UPower.PowerProfiles. TLP's Radio Device Wizard (tlp-rdw)
+# is driven by NetworkManager's dispatcher on distributions which package it.
+#
+# TLP upstream explicitly treats power-profiles-daemon as conflicting and, on
+# Arch, recommends masking systemd-rfkill units for reliable radio switching.
+# Keep those system-level prerequisites in the setup migration rather than in
+# the user-writable Quickshell runtime.
+
+MIGRATION_ID="038-tlp-profile-backend"
+MIGRATION_TITLE="Enable TLP power management"
+MIGRATION_DESCRIPTION="Enables TLP/tlp-pd, avoids conflicting Power Profiles daemons, and prepares TLP radio switching when tlp-rdw is installed."
+MIGRATION_TARGET_FILE="systemd system services"
+MIGRATION_REQUIRED=true
+
+_tlp_unit_exists() {
+  local unit=$1
+  [[ -e "/usr/lib/systemd/system/${unit}" \
+      || -e "/lib/systemd/system/${unit}" \
+      || -L "/etc/systemd/system/${unit}" ]] \
+      || systemctl cat "$unit" >/dev/null 2>&1
+}
+
+_tlp_unit_masked() {
+  [[ "$(systemctl is-enabled "$1" 2>/dev/null || true)" == "masked" ]]
+}
+
+_tlp_profile_backend_available() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  command -v tlp >/dev/null 2>&1 || return 1
+  _tlp_unit_exists tlp.service || return 1
+  _tlp_unit_exists tlp-pd.service || return 1
+}
+
+_tlp_radio_backend_available() {
+  command -v tlp-rdw >/dev/null 2>&1 || return 1
+  _tlp_unit_exists NetworkManager-dispatcher.service || return 1
+}
+
+migration_check() {
+  # This repository supports distributions where tlp-pd is not packaged yet.
+  # Treat that as "not applicable", not as a required-migration failure. If the
+  # packages appear later, required migrations are re-checked and this will run.
+  _tlp_profile_backend_available || return 1
+
+  systemctl is-enabled --quiet tlp.service 2>/dev/null || return 0
+  systemctl is-enabled --quiet tlp-pd.service 2>/dev/null || return 0
+
+  # TLP >= 1.6 deliberately skips overlapping platform/CPU settings when the
+  # real power-profiles-daemon process is running. Do not leave a service which
+  # can reclaim the same D-Bus/kernel controls enabled beside tlp-pd.
+  if _tlp_unit_exists power-profiles-daemon.service \
+      && ! _tlp_unit_masked power-profiles-daemon.service; then
+    return 0
+  fi
+  if _tlp_unit_exists tuned-ppd.service \
+      && ! _tlp_unit_masked tuned-ppd.service; then
+    return 0
+  fi
+
+  if _tlp_radio_backend_available \
+      && ! systemctl is-enabled --quiet NetworkManager-dispatcher.service 2>/dev/null; then
+    return 0
+  fi
+
+  # TLP's Arch installation guidance recommends masking systemd-rfkill to keep
+  # radio state restoration from racing TLP's own switching rules.
+  if _tlp_unit_exists systemd-rfkill.service \
+      && ! _tlp_unit_masked systemd-rfkill.service; then
+    return 0
+  fi
+  if _tlp_unit_exists systemd-rfkill.socket \
+      && ! _tlp_unit_masked systemd-rfkill.socket; then
+    return 0
+  fi
+
+  return 1
+}
+
+migration_preview() {
+  echo -e "${STY_GREEN}+ Enable tlp.service when available${STY_RST}"
+  echo -e "${STY_GREEN}+ Enable tlp-pd.service when available${STY_RST}"
+  echo -e "${STY_GREEN}+ Mask conflicting power-profiles-daemon/tuned-ppd units when present${STY_RST}"
+  echo -e "${STY_GREEN}+ Enable NetworkManager dispatcher when tlp-rdw is installed${STY_RST}"
+  echo -e "${STY_GREEN}+ Mask systemd-rfkill service/socket when present${STY_RST}"
+  echo ""
+  echo "tlp-pd provides the standard Power Profiles D-Bus API used by iNiR."
+  echo "tlp-rdw handles the network/dock radio rules exposed in Battery settings."
+}
+
+migration_diff() {
+  echo "TLP:"
+  if command -v tlp >/dev/null 2>&1; then
+    tlp --version 2>/dev/null || true
+  else
+    echo "  not installed (migration not applicable)"
+  fi
+  echo ""
+  echo "Services:"
+  systemctl is-enabled tlp.service 2>/dev/null || echo "  tlp.service: disabled/missing"
+  systemctl is-enabled tlp-pd.service 2>/dev/null || echo "  tlp-pd.service: disabled/missing"
+
+  if _tlp_unit_exists power-profiles-daemon.service; then
+    printf '  power-profiles-daemon.service: '
+    systemctl is-enabled power-profiles-daemon.service 2>/dev/null || true
+  fi
+  if _tlp_unit_exists tuned-ppd.service; then
+    printf '  tuned-ppd.service: '
+    systemctl is-enabled tuned-ppd.service 2>/dev/null || true
+  fi
+  if _tlp_radio_backend_available; then
+    printf '  NetworkManager-dispatcher.service: '
+    systemctl is-enabled NetworkManager-dispatcher.service 2>/dev/null || true
+  else
+    echo "  tlp-rdw: unavailable (radio-event integration will be skipped)"
+  fi
+  for unit in systemd-rfkill.service systemd-rfkill.socket; do
+    if _tlp_unit_exists "$unit"; then
+      printf '  %s: ' "$unit"
+      systemctl is-enabled "$unit" 2>/dev/null || true
+    fi
+  done
+}
+
+migration_apply() {
+  local unit
+
+  if ! _tlp_profile_backend_available; then
+    echo "TLP/tlp-pd is not available on this installation; leaving the existing PowerProfiles backend unchanged."
+    return 0
+  fi
+
+  # Stop/mask competing D-Bus implementations before starting tlp-pd. This is
+  # exactly the fallback TLP recommends on distributions which permit parallel
+  # package installation. If the package manager already removed them, no-op.
+  for unit in power-profiles-daemon.service tuned-ppd.service; do
+    if _tlp_unit_exists "$unit" && ! _tlp_unit_masked "$unit"; then
+      pkg_sudo systemctl mask --now "$unit" || return 1
+    fi
+  done
+
+  pkg_sudo systemctl enable --now tlp.service || return 1
+  pkg_sudo systemctl enable --now tlp-pd.service || return 1
+
+  if _tlp_radio_backend_available; then
+    pkg_sudo systemctl enable NetworkManager-dispatcher.service || return 1
+  fi
+
+  for unit in systemd-rfkill.service systemd-rfkill.socket; do
+    if _tlp_unit_exists "$unit" && ! _tlp_unit_masked "$unit"; then
+      pkg_sudo systemctl mask --now "$unit" || return 1
+    fi
+  done
+
+  if command -v tlp-stat >/dev/null 2>&1; then
+    echo ""
+    echo "TLP status after migration:"
+    pkg_sudo tlp-stat -s 2>/dev/null || true
+  fi
+}

--- a/services/Battery.qml
+++ b/services/Battery.qml
@@ -3,7 +3,6 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import Quickshell
-import Quickshell.Io
 import Quickshell.Services.UPower
 import qs.modules.common
 import qs.modules.common.functions
@@ -13,14 +12,13 @@ Singleton {
     id: root
 
     function _log(...args): void {
-        if (Quickshell.env("QS_DEBUG") === "1") console.log(...args);
+        if (Quickshell.env("QS_DEBUG") === "1") console.log(...args)
     }
 
     property bool available: UPower.displayDevice.isLaptopBattery
     property var chargeState: UPower.displayDevice.state
     property bool isCharging: chargeState == UPowerDeviceState.Charging
     property bool isPluggedIn: isCharging || chargeState == UPowerDeviceState.PendingCharge
-    // Discharging-based, not !isPluggedIn: FullyCharged on AC must not count as "on battery"
     readonly property bool onBattery: available && (chargeState == UPowerDeviceState.Discharging || chargeState == UPowerDeviceState.PendingDischarge)
     property real percentage: UPower.displayDevice?.percentage ?? 1
     readonly property bool allowAutomaticSuspend: Config.options?.battery?.automaticSuspend ?? false
@@ -41,358 +39,80 @@ Singleton {
     property real timeToFull: UPower.displayDevice.timeToFull
 
     // ─── Charge limit ───
-    readonly property bool chargeLimitEnabled: Config.options?.battery?.chargeLimit?.enable ?? false
-    readonly property int chargeLimitThreshold: Config.options?.battery?.chargeLimit?.threshold ?? 80
-    property string _chargeLimitBackend: ""
-    property string _chargeLimitSysfsPath: ""
-    property int _rawChargeLimitValue: -1
-    property int _pendingChargeLimitAction: -1 // -1 none, 0 disable, 1 enable
-    property int _currentChargeLimit: -1
-    property bool _chargeLimitActive: false
-    readonly property bool chargeLimitSupported: _chargeLimitBackend.length > 0 && _chargeLimitSysfsPath.length > 0
-    readonly property bool chargeLimitAdjustable: _chargeLimitBackend === "threshold"
-        || _chargeLimitBackend === "smapi"
-        || _chargeLimitBackend === "sony"
-        || _chargeLimitBackend === "huawei"
-    readonly property bool chargeLimitActive: _chargeLimitActive
-    readonly property int currentChargeLimit: _currentChargeLimit
-
-    Component.onCompleted: {
-        if (root.available) {
-            _detectChargeLimitPath()
-        }
+    readonly property bool chargeLimitEnabled: {
+        void Config.revision
+        return Config.options?.battery?.chargeLimit?.enable ?? false
     }
-
-    onAvailableChanged: {
-        if (available && _chargeLimitSysfsPath.length === 0) {
-            _detectChargeLimitPath()
-        }
+    readonly property int chargeLimitThreshold: {
+        void Config.revision
+        return Config.options?.battery?.chargeLimit?.threshold ?? 80
     }
-
-    function _detectChargeLimitPath(): void {
-        if (!chargeLimitDetector.running) {
-            chargeLimitDetector.running = true
-        }
-    }
-
-    Process {
-        id: chargeLimitDetector
-        command: ["/bin/sh", "-c",
-            "for dir in /sys/class/power_supply/*; do " +
-            "[ -d \"$dir\" ] || continue; " +
-            "[ \"$(cat \"$dir/type\" 2>/dev/null)\" = \"Battery\" ] || continue; " +
-            "if [ -f \"$dir/present\" ] && [ \"$(cat \"$dir/present\" 2>/dev/null)\" = \"0\" ]; then continue; fi; " +
-            "for attr in charge_control_end_threshold charge_stop_threshold; do " +
-            "[ -f \"$dir/$attr\" ] && printf 'threshold|%s\\n' \"$dir/$attr\" && exit 0; " +
-            "done; " +
-            "done; " +
-            "for p in /sys/devices/platform/smapi/BAT*/stop_charge_thresh; do [ -f \"$p\" ] && printf 'smapi|%s\\n' \"$p\" && exit 0; done; " +
-            "for p in /sys/bus/platform/drivers/ideapad_acpi/*/conservation_mode; do [ -f \"$p\" ] && printf 'ideapad|%s\\n' \"$p\" && exit 0; done; " +
-            "[ -f /sys/devices/platform/lg-laptop/battery_care_limit ] && printf 'lg-legacy|%s\\n' /sys/devices/platform/lg-laptop/battery_care_limit && exit 0; " +
-            "[ -f /sys/devices/platform/samsung/battery_life_extender ] && printf 'samsung|%s\\n' /sys/devices/platform/samsung/battery_life_extender && exit 0; " +
-            "[ -f /sys/devices/platform/sony-laptop/battery_care_limiter ] && printf 'sony|%s\\n' /sys/devices/platform/sony-laptop/battery_care_limiter && exit 0; " +
-            "[ -f /sys/devices/platform/huawei-wmi/charge_control_thresholds ] && printf 'huawei|%s\\n' /sys/devices/platform/huawei-wmi/charge_control_thresholds && exit 0; " +
-            "printf '\\n'"
-        ]
-        stdout: SplitParser {
-            onRead: data => {
-                const result = data.trim()
-                if (result.length > 0) {
-                    const parts = result.split("|")
-                    root._chargeLimitBackend = parts[0] ?? ""
-                    root._chargeLimitSysfsPath = parts[1] ?? ""
-                    _log("[Battery] Charge limit backend: " + root._chargeLimitBackend + " (" + root._chargeLimitSysfsPath + ")")
-                    root._readChargeLimit()
-                }
-            }
-        }
-    }
-
-    // Reconcile only after the initial sysfs read. This avoids asking polkit to
-    // write a value the firmware already has.
-    Timer {
-        id: chargeLimitApplyDelay
-        interval: 250
-        repeat: false
-        onTriggered: {
-            if (root.chargeLimitEnabled)
-                root._applyChargeLimit()
-        }
-    }
-
-    function _readChargeLimit(): void {
-        if (_chargeLimitSysfsPath.length === 0 || chargeLimitReader.running) return
-        chargeLimitReader.command = ["/bin/cat", _chargeLimitSysfsPath]
-        chargeLimitReader.running = true
-    }
-
-    function _updateChargeLimitState(rawValue: int): void {
-        switch (_chargeLimitBackend) {
-        case "ideapad":
-            _chargeLimitActive = rawValue === 1
-            _currentChargeLimit = rawValue === 0 ? 100 : -1
-            break
-        case "samsung":
-            _chargeLimitActive = rawValue === 1
-            _currentChargeLimit = rawValue === 1 ? 80 : 100
-            break
-        default:
-            _chargeLimitActive = rawValue > 0 && rawValue < 100
-            _currentChargeLimit = rawValue
-            break
-        }
-    }
-
-    function _normalizedChargeLimitThreshold(): int {
-        if (_chargeLimitBackend === "sony") {
-            if (chargeLimitThreshold <= 65) return 50
-            if (chargeLimitThreshold <= 90) return 80
-            return 100
-        }
-
-        return chargeLimitThreshold
-    }
-
-    function _desiredChargeLimitValue(enable: bool): int {
-        switch (_chargeLimitBackend) {
-        case "ideapad":
-        case "samsung":
-            return enable ? 1 : 0
-        case "lg-legacy":
-            return enable ? 80 : 100
-        default:
-            return enable ? _normalizedChargeLimitThreshold() : 100
-        }
-    }
-
-    function _chargeLimitMatches(enable: bool): bool {
-        return _rawChargeLimitValue >= 0
-            && _rawChargeLimitValue === _desiredChargeLimitValue(enable)
-    }
-
-    function _buildChargeLimitWriteCommand(enable: bool) {
-        switch (_chargeLimitBackend) {
-        case "ideapad":
-        case "samsung":
-            return [
-                "/usr/bin/pkexec", "/bin/sh", "-c",
-                "printf '%s' \"$1\" > \"$2\"",
-                "battery-charge-limit",
-                String(_desiredChargeLimitValue(enable)),
-                _chargeLimitSysfsPath,
-            ]
-        case "lg-legacy":
-            return [
-                "/usr/bin/pkexec", "/bin/sh", "-c",
-                "printf '%s' \"$1\" > \"$2\"",
-                "battery-charge-limit",
-                String(_desiredChargeLimitValue(enable)),
-                _chargeLimitSysfsPath,
-            ]
-        case "huawei":
-            return [
-                "/usr/bin/pkexec", "/bin/sh", "-c",
-                "printf '%s %s' \"$1\" \"$2\" > \"$3\"",
-                "battery-charge-limit",
-                "0",
-                String(_desiredChargeLimitValue(enable)),
-                _chargeLimitSysfsPath,
-            ]
-        case "threshold":
-        case "smapi":
-        case "sony":
-            return [
-                "/usr/bin/pkexec", "/bin/sh", "-c",
-                "printf '%s' \"$1\" > \"$2\"",
-                "battery-charge-limit",
-                String(_desiredChargeLimitValue(enable)),
-                _chargeLimitSysfsPath,
-            ]
-        default:
-            return []
-        }
-    }
-
-    Process {
-        id: chargeLimitReader
-        stdout: SplitParser {
-            onRead: data => {
-                const trimmed = data.trim()
-                const val = _chargeLimitBackend === "huawei"
-                    ? parseInt(trimmed.split(/\s+/).slice(-1)[0])
-                    : parseInt(trimmed)
-
-                if (!isNaN(val)) {
-                    const initialRead = root._rawChargeLimitValue < 0
-                    root._rawChargeLimitValue = val
-                    root._updateChargeLimitState(val)
-                    const pendingAction = root._pendingChargeLimitAction
-                    if (pendingAction >= 0) {
-                        root._pendingChargeLimitAction = -1
-                        Qt.callLater(() => {
-                            if (pendingAction === 1)
-                                root._applyChargeLimit()
-                            else
-                                root._resetChargeLimit()
-                        })
-                    } else if (initialRead && root.chargeLimitEnabled) {
-                        chargeLimitApplyDelay.restart()
-                    }
-                }
-            }
-        }
-    }
-
-    // Periodically re-read the threshold so the UI stays in sync
-    Timer {
-        id: chargeLimitPoll
-        interval: 30000
-        repeat: true
-        running: root.chargeLimitSupported
-        onTriggered: root._readChargeLimit()
-    }
-
-    function _applyChargeLimit(): void {
-        if (!chargeLimitSupported) return
-        if (chargeLimitWriter.running || chargeLimitResetter.running) {
-            _pendingChargeLimitAction = 1
-            return
-        }
-        if (_rawChargeLimitValue < 0) {
-            _pendingChargeLimitAction = 1
-            _readChargeLimit()
-            return
-        }
-        if (_chargeLimitMatches(true)) {
-            _pendingChargeLimitAction = -1
-            _log("[Battery] Charge limit already applied")
-            return
-        }
-        _pendingChargeLimitAction = -1
-        const command = _buildChargeLimitWriteCommand(true)
-        if (command.length === 0) return
-        chargeLimitWriter.command = command
-        chargeLimitWriter.running = true
-    }
-
-    function _resetChargeLimit(): void {
-        if (!chargeLimitSupported) return
-        if (chargeLimitWriter.running || chargeLimitResetter.running) {
-            _pendingChargeLimitAction = 0
-            return
-        }
-        if (_rawChargeLimitValue < 0) {
-            _pendingChargeLimitAction = 0
-            _readChargeLimit()
-            return
-        }
-        if (_chargeLimitMatches(false)) {
-            _pendingChargeLimitAction = -1
-            _log("[Battery] Charge limit already removed")
-            return
-        }
-        _pendingChargeLimitAction = -1
-        const command = _buildChargeLimitWriteCommand(false)
-        if (command.length === 0) return
-        chargeLimitResetter.command = command
-        chargeLimitResetter.running = true
-    }
-
-    Process {
-        id: chargeLimitWriter
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode === 0) {
-                root._readChargeLimit()
-                _log("[Battery] Charge limit applied")
-            } else {
-                root._pendingChargeLimitAction = -1
-                console.warn("[Battery] Failed to set charge limit (exit code " + exitCode + ")")
-            }
-        }
-    }
-
-    Process {
-        id: chargeLimitResetter
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode === 0) {
-                root._readChargeLimit()
-                _log("[Battery] Charge limit removed")
-            } else {
-                root._pendingChargeLimitAction = -1
-                console.warn("[Battery] Failed to reset charge limit (exit code " + exitCode + ")")
-            }
-        }
-    }
-
-    onChargeLimitEnabledChanged: {
-        if (!chargeLimitSupported) return
-        chargeLimitApplyDelay.stop()
-        if (chargeLimitEnabled) {
-            _applyChargeLimit()
-        } else {
-            _resetChargeLimit()
-        }
-    }
-
-    onChargeLimitThresholdChanged: {
-        if (!chargeLimitSupported || !chargeLimitEnabled || !chargeLimitAdjustable) return
-        _applyChargeLimit()
-    }
+    readonly property bool chargeLimitAvailable: TlpService.available
+    readonly property bool chargeLimitSupported: TlpService.supported
+    readonly property bool chargeLimitAdjustable: TlpService.adjustable
+    readonly property bool chargeLimitStateKnown: TlpService.stateKnown
+    readonly property bool chargeLimitActive: TlpService.active
+    readonly property bool chargeLimitManaged: TlpService.managed
+    readonly property int currentChargeLimit: TlpService.currentLimit
+    readonly property int effectiveChargeLimitThreshold: TlpService.effectiveRequestedLimit
+    readonly property string chargeLimitKind: TlpService.limitKind
+    readonly property bool chargeLimitContinuous: TlpService.continuous
+    readonly property bool chargeLimitDiscrete: TlpService.discrete
+    readonly property int chargeLimitMinimum: TlpService.minimumLimit
+    readonly property int chargeLimitMaximum: TlpService.maximumLimit
+    readonly property int chargeLimitStepSize: TlpService.limitStepSize
+    readonly property var chargeLimitAllowedValues: TlpService.allowedLimits
+    readonly property string chargeLimitStatusReason: TlpService.statusReason
 
     // ─── Battery warnings ───
     onIsLowAndNotChargingChanged: {
-        if (!root.available || !isLowAndNotCharging) return;
+        if (!root.available || !isLowAndNotCharging) return
         Quickshell.execDetached([
-            "/usr/bin/notify-send", 
-            Translation.tr("Low battery"), 
-            Translation.tr("Consider plugging in your device"), 
+            "/usr/bin/notify-send",
+            Translation.tr("Low battery"),
+            Translation.tr("Consider plugging in your device"),
             "-u", "critical",
             "-a", "Shell",
             "--hint=int:transient:1",
         ])
-
-        if (root.soundEnabled) Audio.playEvent("batteryLow");
+        if (root.soundEnabled) Audio.playEvent("batteryLow")
     }
 
     onIsCriticalAndNotChargingChanged: {
-        if (!root.available || !isCriticalAndNotCharging) return;
+        if (!root.available || !isCriticalAndNotCharging) return
         Quickshell.execDetached([
-            "/usr/bin/notify-send", 
-            Translation.tr("Critically low battery"), 
-            Translation.tr("Please charge!\nAutomatic suspend triggers at %1%").arg(Config.options?.battery?.suspend ?? 5), 
+            "/usr/bin/notify-send",
+            Translation.tr("Critically low battery"),
+            Translation.tr("Please charge!\nAutomatic suspend triggers at %1%").arg(Config.options?.battery?.suspend ?? 5),
             "-u", "critical",
             "-a", "Shell",
             "--hint=int:transient:1",
-        ]);
-
-        if (root.soundEnabled) Audio.playEvent("batteryCritical");
+        ])
+        if (root.soundEnabled) Audio.playEvent("batteryCritical")
     }
 
     onIsSuspendingAndNotChargingChanged: {
-        if (root.available && isSuspendingAndNotCharging) {
+        if (root.available && isSuspendingAndNotCharging)
             Session.suspend()
-        }
     }
 
     onIsFullAndChargingChanged: {
-        if (!root.available || !isFullAndCharging) return;
+        if (!root.available || !isFullAndCharging) return
         Quickshell.execDetached([
             "/usr/bin/notify-send",
             Translation.tr("Battery full"),
             Translation.tr("Please unplug the charger"),
             "-a", "Shell",
             "--hint=int:transient:1",
-        ]);
-
-        if (root.soundEnabled) Audio.playEvent("batteryFull");
+        ])
+        if (root.soundEnabled) Audio.playEvent("batteryFull")
     }
 
     onIsPluggedInChanged: {
-        if (!root.available || !root.soundEnabled) return;
-        if (isPluggedIn) {
+        if (!root.available || !root.soundEnabled) return
+        if (isPluggedIn)
             Audio.playEvent("powerPlug")
-        } else {
+        else
             Audio.playEvent("powerUnplug")
-        }
     }
 }

--- a/services/Battery.qml
+++ b/services/Battery.qml
@@ -12,13 +12,14 @@ Singleton {
     id: root
 
     function _log(...args): void {
-        if (Quickshell.env("QS_DEBUG") === "1") console.log(...args)
+        if (Quickshell.env("QS_DEBUG") === "1") console.log(...args);
     }
 
     property bool available: UPower.displayDevice.isLaptopBattery
     property var chargeState: UPower.displayDevice.state
     property bool isCharging: chargeState == UPowerDeviceState.Charging
     property bool isPluggedIn: isCharging || chargeState == UPowerDeviceState.PendingCharge
+    // Discharging-based, not !isPluggedIn: FullyCharged on AC must not count as "on battery"
     readonly property bool onBattery: available && (chargeState == UPowerDeviceState.Discharging || chargeState == UPowerDeviceState.PendingDischarge)
     property real percentage: UPower.displayDevice?.percentage ?? 1
     readonly property bool allowAutomaticSuspend: Config.options?.battery?.automaticSuspend ?? false
@@ -66,53 +67,58 @@ Singleton {
 
     // ─── Battery warnings ───
     onIsLowAndNotChargingChanged: {
-        if (!root.available || !isLowAndNotCharging) return
+        if (!root.available || !isLowAndNotCharging) return;
         Quickshell.execDetached([
-            "/usr/bin/notify-send",
-            Translation.tr("Low battery"),
-            Translation.tr("Consider plugging in your device"),
+            "/usr/bin/notify-send", 
+            Translation.tr("Low battery"), 
+            Translation.tr("Consider plugging in your device"), 
             "-u", "critical",
             "-a", "Shell",
             "--hint=int:transient:1",
         ])
-        if (root.soundEnabled) Audio.playEvent("batteryLow")
+
+        if (root.soundEnabled) Audio.playEvent("batteryLow");
     }
 
     onIsCriticalAndNotChargingChanged: {
-        if (!root.available || !isCriticalAndNotCharging) return
+        if (!root.available || !isCriticalAndNotCharging) return;
         Quickshell.execDetached([
-            "/usr/bin/notify-send",
-            Translation.tr("Critically low battery"),
-            Translation.tr("Please charge!\nAutomatic suspend triggers at %1%").arg(Config.options?.battery?.suspend ?? 5),
+            "/usr/bin/notify-send", 
+            Translation.tr("Critically low battery"), 
+            Translation.tr("Please charge!\nAutomatic suspend triggers at %1%").arg(Config.options?.battery?.suspend ?? 5), 
             "-u", "critical",
             "-a", "Shell",
             "--hint=int:transient:1",
-        ])
-        if (root.soundEnabled) Audio.playEvent("batteryCritical")
+        ]);
+
+        if (root.soundEnabled) Audio.playEvent("batteryCritical");
     }
 
     onIsSuspendingAndNotChargingChanged: {
-        if (root.available && isSuspendingAndNotCharging)
+        if (root.available && isSuspendingAndNotCharging) {
             Session.suspend()
+        }
     }
 
     onIsFullAndChargingChanged: {
-        if (!root.available || !isFullAndCharging) return
+        if (!root.available || !isFullAndCharging) return;
         Quickshell.execDetached([
             "/usr/bin/notify-send",
             Translation.tr("Battery full"),
             Translation.tr("Please unplug the charger"),
             "-a", "Shell",
             "--hint=int:transient:1",
-        ])
-        if (root.soundEnabled) Audio.playEvent("batteryFull")
+        ]);
+
+        if (root.soundEnabled) Audio.playEvent("batteryFull");
     }
 
     onIsPluggedInChanged: {
-        if (!root.available || !root.soundEnabled) return
-        if (isPluggedIn)
+        if (!root.available || !root.soundEnabled) return;
+        if (isPluggedIn) {
             Audio.playEvent("powerPlug")
-        else
+        } else {
             Audio.playEvent("powerUnplug")
+        }
     }
 }

--- a/services/PolkitService.qml
+++ b/services/PolkitService.qml
@@ -27,7 +27,9 @@ Singleton {
     property bool interactionAvailable: impl?.interactionAvailable ?? false
 
     readonly property string rawMessage: String(flow?.message ?? "").trim()
-    readonly property bool batteryChargeLimitRequest: rawMessage.includes("battery-charge-limit")
+    readonly property string actionId: String(flow?.actionId ?? "").trim()
+    readonly property bool batteryChargeLimitRequest: actionId === "org.inir.battery-charge-limit"
+        || rawMessage.includes("battery-charge-limit")
     readonly property string cleanMessage: {
         if (batteryChargeLimitRequest)
             return Translation.tr("Do you want to allow this app to make changes to your device?")

--- a/services/PowerProfilePersistence.qml
+++ b/services/PowerProfilePersistence.qml
@@ -1,7 +1,9 @@
 pragma Singleton
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import Quickshell.Services.UPower
 import qs.modules.common
 
@@ -9,6 +11,8 @@ Singleton {
     id: root
 
     property bool _initialized: false
+    property bool _tlpProbeDone: false
+    property bool _tlpPdManaged: false
 
     function _profileToString(profile): string {
         switch (profile) {
@@ -29,10 +33,17 @@ Singleton {
     }
 
     function _applyPreferredProfile(): void {
-        if (!Config.ready || root._initialized)
+        if (!Config.ready || root._initialized || !root._tlpProbeDone)
             return
 
         root._initialized = true
+
+        // When tlp-pd is enabled it owns profile selection, including AC/BAT
+        // automatic switching. Restoring iNiR's last observed profile here
+        // would turn an automatically selected TLP profile into a forced one
+        // on the next shell start.
+        if (root._tlpPdManaged)
+            return
 
         const restore = Config.options?.powerProfiles?.restoreOnStart ?? true
         const preferred = Config.options?.powerProfiles?.preferredProfile ?? ""
@@ -52,28 +63,55 @@ Singleton {
         }
     }
 
+    function _probeTlpPd(): void {
+        if (!tlpPdProbe.running)
+            tlpPdProbe.running = true
+    }
+
     Connections {
         target: Config
-        function onReadyChanged() {
-            if (Config.ready) {
-                Qt.callLater(() => root._applyPreferredProfile())
-            }
+        function onReadyChanged(): void {
+            if (Config.ready)
+                root._probeTlpPd()
         }
     }
 
-    // Covers the path where Config was ALREADY ready before this singleton was
-    // instantiated (hot-reload, or deferred loading after Config.ready fired) —
-    // onReadyChanged never re-arms in that case. _applyPreferredProfile is
-    // idempotent via _initialized, so running both is safe.
+    // Covers the path where Config was already ready before this singleton was
+    // instantiated (hot-reload or deferred loading after Config.ready fired).
     Component.onCompleted: {
-        if (Config.ready) {
-            Qt.callLater(() => root._applyPreferredProfile())
+        if (Config.ready)
+            root._probeTlpPd()
+    }
+
+    Process {
+        id: tlpPdProbe
+        command: ["/usr/bin/systemctl", "is-enabled", "--quiet", "tlp-pd.service"]
+        onExited: (exitCode, exitStatus) => {
+            root._tlpPdManaged = exitCode === 0
+            root._tlpProbeDone = true
+            if (Config.ready)
+                Qt.callLater(() => root._applyPreferredProfile())
         }
+    }
+
+    // Migrations, package updates, or manual service changes can enable/disable
+    // tlp-pd while the shell stays alive. Re-probe read-only state so profile
+    // persistence never keeps acting on a stale startup decision.
+    Timer {
+        interval: 30000
+        repeat: true
+        running: Config.ready
+        onTriggered: root._probeTlpPd()
     }
 
     Connections {
         target: PowerProfiles
-        function onProfileChanged() {
+        function onProfileChanged(): void {
+            // TLP/tlp-pd owns this state when enabled; do not persist its
+            // automatically selected AC/BAT profile as iNiR's user preference.
+            if (root._tlpPdManaged)
+                return
+
             const s = root._profileToString(PowerProfiles.profile)
             if (s.length === 0)
                 return

--- a/services/PowerProfilePersistence.qml
+++ b/services/PowerProfilePersistence.qml
@@ -38,10 +38,7 @@ Singleton {
 
         root._initialized = true
 
-        // When tlp-pd is enabled it owns profile selection, including AC/BAT
-        // automatic switching. Restoring iNiR's last observed profile here
-        // would turn an automatically selected TLP profile into a forced one
-        // on the next shell start.
+        // tlp-pd owns automatic profile selection; don't overwrite it with persisted state.
         if (root._tlpPdManaged)
             return
 
@@ -76,8 +73,7 @@ Singleton {
         }
     }
 
-    // Covers the path where Config was already ready before this singleton was
-    // instantiated (hot-reload or deferred loading after Config.ready fired).
+    // Also probe when this singleton loads after Config is already ready.
     Component.onCompleted: {
         if (Config.ready)
             root._probeTlpPd()
@@ -94,9 +90,7 @@ Singleton {
         }
     }
 
-    // Migrations, package updates, or manual service changes can enable/disable
-    // tlp-pd while the shell stays alive. Re-probe read-only state so profile
-    // persistence never keeps acting on a stale startup decision.
+    // Re-probe if package, migration, or service state changes at runtime.
     Timer {
         interval: 30000
         repeat: true
@@ -107,8 +101,7 @@ Singleton {
     Connections {
         target: PowerProfiles
         function onProfileChanged(): void {
-            // TLP/tlp-pd owns this state when enabled; do not persist its
-            // automatically selected AC/BAT profile as iNiR's user preference.
+            // Don't persist tlp-pd's automatic AC/BAT selection as a user preference.
             if (root._tlpPdManaged)
                 return
 

--- a/services/TlpRuntimeCapabilities.qml
+++ b/services/TlpRuntimeCapabilities.qml
@@ -1,0 +1,119 @@
+pragma ComponentBehavior: Bound
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Singleton {
+    id: root
+
+    property var values: ({})
+    property bool rdwProbeDone: false
+    property bool rdwAvailable: false
+
+    function _tokens(text: string): var {
+        return String(text ?? "")
+            .replace(/[\[\]]/g, "")
+            .trim()
+            .split(/\s+/)
+            .filter(token => token.length > 0)
+    }
+
+    function _setValues(keys, entries): void {
+        const next = Object.assign({}, root.values)
+        for (const key of keys)
+            next[key] = Array.from(entries ?? [])
+        root.values = next
+    }
+
+    function isRdwSetting(key: string): bool {
+        const name = String(key ?? "")
+        return name === "DEVICES_TO_DISABLE_ON_LAN_CONNECT"
+            || name === "DEVICES_TO_DISABLE_ON_WIFI_CONNECT"
+            || name === "DEVICES_TO_DISABLE_ON_WWAN_CONNECT"
+            || name === "DEVICES_TO_ENABLE_ON_LAN_DISCONNECT"
+            || name === "DEVICES_TO_ENABLE_ON_WIFI_DISCONNECT"
+            || name === "DEVICES_TO_ENABLE_ON_WWAN_DISCONNECT"
+            || name === "DEVICES_TO_ENABLE_ON_DOCK"
+            || name === "DEVICES_TO_DISABLE_ON_DOCK"
+            || name === "DEVICES_TO_ENABLE_ON_UNDOCK"
+            || name === "DEVICES_TO_DISABLE_ON_UNDOCK"
+    }
+
+    function refreshRdw(): void {
+        if (!rdwBinaryProbe.running && !rdwDispatcherProbe.running)
+            rdwBinaryProbe.running = true
+    }
+
+    function refresh(): void {
+        governorFile.reload()
+        memSleepFile.reload()
+        root.refreshRdw()
+    }
+
+    FileView {
+        id: governorFile
+        path: "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors"
+
+        onLoaded: root._setValues([
+            "CPU_SCALING_GOVERNOR_ON_AC",
+            "CPU_SCALING_GOVERNOR_ON_BAT",
+            "CPU_SCALING_GOVERNOR_ON_SAV"
+        ], root._tokens(governorFile.text()))
+
+        onLoadFailed: root._setValues([
+            "CPU_SCALING_GOVERNOR_ON_AC",
+            "CPU_SCALING_GOVERNOR_ON_BAT",
+            "CPU_SCALING_GOVERNOR_ON_SAV"
+        ], [])
+    }
+
+    FileView {
+        id: memSleepFile
+        path: "/sys/power/mem_sleep"
+
+        onLoaded: root._setValues([
+            "MEM_SLEEP_ON_AC",
+            "MEM_SLEEP_ON_BAT"
+        ], root._tokens(memSleepFile.text()))
+
+        onLoadFailed: root._setValues([
+            "MEM_SLEEP_ON_AC",
+            "MEM_SLEEP_ON_BAT"
+        ], [])
+    }
+
+    Process {
+        id: rdwBinaryProbe
+        command: ["/usr/bin/test", "-x", "/usr/bin/tlp-rdw"]
+
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0) {
+                rdwDispatcherProbe.running = true
+                return
+            }
+            root.rdwAvailable = false
+            root.rdwProbeDone = true
+        }
+    }
+
+    Process {
+        id: rdwDispatcherProbe
+        command: ["/usr/bin/systemctl", "is-enabled", "--quiet", "NetworkManager-dispatcher.service"]
+
+        onExited: (exitCode, exitStatus) => {
+            root.rdwAvailable = exitCode === 0
+            root.rdwProbeDone = true
+        }
+    }
+
+    Component.onCompleted: root.refresh()
+
+    Timer {
+        interval: 30000
+        repeat: true
+        running: true
+        onTriggered: root.refresh()
+    }
+}

--- a/services/TlpService.qml
+++ b/services/TlpService.qml
@@ -1,0 +1,300 @@
+pragma ComponentBehavior: Bound
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.common
+
+Singleton {
+    id: root
+
+    property bool available: false
+    property bool supported: false
+    property bool adjustable: false
+    property bool stateKnown: false
+    property bool active: false
+    property bool managed: false
+    property int currentLimit: -1
+    property int currentStart: -1
+    property string backend: ""
+    property string tlpVersion: ""
+    property string statusReason: ""
+    property string limitKind: "none"
+    property int minimumLimit: 1
+    property int maximumLimit: 100
+    property int limitStepSize: 1
+    property var allowedLimits: []
+    property int fixedLimit: -1
+    property string configBattery: ""
+    property string managedBattery: ""
+    property int managedLimit: -1
+    property bool busy: false
+
+    // Nested JsonAdapter assignments do not emit reliable per-property change
+    // notifications. Depend on Config.revision explicitly so a settings-window
+    // write is observed by this process immediately (including disable).
+    readonly property int requestedLimit: {
+        void Config.revision
+        return Config.options?.battery?.chargeLimit?.threshold ?? 80
+    }
+    readonly property int effectiveRequestedLimit: root._normalizeRequestedLimit(root.requestedLimit)
+    readonly property bool enabled: {
+        void Config.revision
+        return Config.options?.battery?.chargeLimit?.enable ?? false
+    }
+    readonly property bool discrete: root.limitKind === "discrete"
+    readonly property bool continuous: root.limitKind === "continuous"
+
+    property bool _statusSeen: false
+    property bool _reconcileAfterDetect: false
+    property bool _redetectAfterCurrent: false
+
+    function _log(...args): void {
+        if (Quickshell.env("QS_DEBUG") === "1") console.log(...args)
+    }
+
+    function _clearStatus(): void {
+        root.available = false
+        root.supported = false
+        root.adjustable = false
+        root.stateKnown = false
+        root.active = false
+        root.managed = false
+        root.currentLimit = -1
+        root.currentStart = -1
+        root.backend = ""
+        root.tlpVersion = ""
+        root.statusReason = ""
+        root.limitKind = "none"
+        root.minimumLimit = 1
+        root.maximumLimit = 100
+        root.limitStepSize = 1
+        root.allowedLimits = []
+        root.fixedLimit = -1
+        root.configBattery = ""
+        root.managedBattery = ""
+        root.managedLimit = -1
+    }
+
+    function _detect(): void {
+        if (!detector.running)
+            detector.running = true
+    }
+
+    function refresh(): void {
+        if (detector.running) {
+            root._redetectAfterCurrent = true
+            return
+        }
+        root._detect()
+    }
+
+    function _numberOr(value, fallback: int): int {
+        return typeof value === "number" && isFinite(value) ? Math.round(value) : fallback
+    }
+
+    function _normalizeRequestedLimit(value: int): int {
+        const requested = Number(value)
+
+        if ((root.limitKind === "fixed" || root.limitKind === "mode") && root.fixedLimit >= 0)
+            return root.fixedLimit
+
+        if (root.limitKind === "continuous") {
+            const minimum = root.minimumLimit >= 0 ? root.minimumLimit : 1
+            const maximum = root.maximumLimit >= minimum ? root.maximumLimit : 100
+            const step = Math.max(1, root.limitStepSize)
+            const clamped = Math.max(minimum, Math.min(maximum, requested))
+            return Math.max(minimum, Math.min(maximum,
+                minimum + Math.round((clamped - minimum) / step) * step))
+        }
+
+        if (root.limitKind === "discrete" && root.allowedLimits.length > 0) {
+            let nearest = Number(root.allowedLimits[0])
+            let distance = Math.abs(nearest - requested)
+            for (let index = 1; index < root.allowedLimits.length; ++index) {
+                const candidate = Number(root.allowedLimits[index])
+                const candidateDistance = Math.abs(candidate - requested)
+                if (candidateDistance < distance) {
+                    nearest = candidate
+                    distance = candidateDistance
+                }
+            }
+            return nearest
+        }
+
+        return isFinite(requested) ? Math.round(requested) : 80
+    }
+
+    function _parseStatus(line: string): void {
+        let data
+        try {
+            data = JSON.parse(String(line ?? "").trim())
+        } catch (error) {
+            root._clearStatus()
+            return
+        }
+
+        if (data?.schema !== 1) {
+            root._clearStatus()
+            return
+        }
+
+        root.available = data.available === true
+        root.supported = data.supported === true
+        root.adjustable = data.adjustable === true
+        root.stateKnown = data.stateKnown === true
+        root.active = data.active === true
+        root.currentLimit = root._numberOr(data.currentLimit, -1)
+        root.currentStart = root._numberOr(data.currentStart, -1)
+        root.backend = String(data.plugin ?? "")
+        root.tlpVersion = String(data.tlpVersion ?? "")
+        root.statusReason = String(data.reason ?? "")
+        root.limitKind = String(data.limitKind ?? "none")
+        root.minimumLimit = root._numberOr(data.minimumLimit, 1)
+        root.maximumLimit = root._numberOr(data.maximumLimit, 100)
+        root.limitStepSize = Math.max(1, root._numberOr(data.stepSize, 1))
+        root.allowedLimits = Array.isArray(data.allowedLimits)
+            ? data.allowedLimits.filter(value => typeof value === "number" && isFinite(value)).map(value => Math.round(value))
+            : []
+        root.fixedLimit = root._numberOr(data.fixedLimit, -1)
+        root.configBattery = String(data.configBattery ?? "")
+        root.managedBattery = String(data.managedBattery ?? "")
+        root.managedLimit = root._numberOr(data.managedLimit, -1)
+        root.managed = data.managed === true
+        root._statusSeen = true
+    }
+
+    function _matchesRequestedPolicy(): bool {
+        // Disabled means iNiR must stop owning a TLP drop-in. A charge limit
+        // from the user's own TLP configuration may legitimately remain active.
+        if (!root.enabled)
+            return !root.managed
+
+        if (!root.supported || !root.managed || !root.stateKnown)
+            return false
+
+        if (root.managedBattery !== root.configBattery)
+            return false
+        if (root.managedLimit !== root.effectiveRequestedLimit)
+            return false
+
+        return root.currentLimit === root.effectiveRequestedLimit
+    }
+
+    function apply(): void {
+        if (!Config.ready)
+            return
+
+        // Preserve the latest requested config change while a privileged apply
+        // or status refresh is already in flight. One reconciliation runs later.
+        if (root.busy || detector.running) {
+            root._reconcileAfterDetect = true
+            return
+        }
+
+        if (root._matchesRequestedPolicy()) {
+            root._reconcileAfterDetect = false
+            root._log("[TLP] Battery charge policy already matches iNiR ownership/state")
+            return
+        }
+
+        // Enabling requires a battery-care interface. Disabling only requires
+        // iNiR to own a drop-in, even if the battery was removed in the meantime.
+        if (root.enabled && !root.supported) {
+            root._reconcileAfterDetect = false
+            return
+        }
+        if (!root.enabled && !root.managed) {
+            root._reconcileAfterDetect = false
+            return
+        }
+
+        root._reconcileAfterDetect = false
+        root.busy = true
+        applyProcess.command = root.enabled
+            ? ["/usr/bin/pkexec", "/usr/libexec/inir-battery-charge-limit", "--set", String(root.effectiveRequestedLimit)]
+            : ["/usr/bin/pkexec", "/usr/libexec/inir-battery-charge-limit", "--disable"]
+        applyProcess.running = true
+    }
+
+    Component.onCompleted: {
+        root._reconcileAfterDetect = Config.ready
+        root._detect()
+    }
+
+    Connections {
+        target: Config
+
+        function onConfigChanged(): void {
+            // Let revision-dependent bindings settle before comparing the
+            // requested policy with the last hardware status.
+            Qt.callLater(() => root.apply())
+        }
+
+        function onReadyChanged(): void {
+            if (!Config.ready)
+                return
+            root._reconcileAfterDetect = true
+            root._detect()
+        }
+    }
+
+    Process {
+        id: detector
+        command: ["/usr/libexec/inir-battery-charge-limit", "--status"]
+
+        stdout: SplitParser {
+            onRead: data => root._parseStatus(data)
+        }
+
+        onStarted: root._statusSeen = false
+
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode !== 0 || !root._statusSeen) {
+                root._clearStatus()
+                if (root._redetectAfterCurrent) {
+                    root._redetectAfterCurrent = false
+                    Qt.callLater(() => root._detect())
+                } else {
+                    root._reconcileAfterDetect = false
+                }
+                return
+            }
+
+            if (root._redetectAfterCurrent) {
+                root._redetectAfterCurrent = false
+                Qt.callLater(() => root._detect())
+                return
+            }
+
+            const reconcile = root._reconcileAfterDetect
+            root._reconcileAfterDetect = false
+            if (reconcile)
+                Qt.callLater(() => root.apply())
+        }
+    }
+
+    Process {
+        id: applyProcess
+
+        onExited: (exitCode, exitStatus) => {
+            root.busy = false
+            if (exitCode !== 0)
+                console.warn("[TLP] Failed to apply battery charge policy (exit code " + exitCode + ")")
+            else
+                root._log("[TLP] Battery charge policy applied")
+
+            // Always refresh from the non-privileged status path. If config
+            // changed while pkexec was active, keep the pending reconciliation.
+            root._detect()
+        }
+    }
+
+    Timer {
+        interval: 30000
+        repeat: true
+        running: true
+        onTriggered: root._detect()
+    }
+}

--- a/services/TlpService.qml
+++ b/services/TlpService.qml
@@ -31,9 +31,7 @@ Singleton {
     property int managedLimit: -1
     property bool busy: false
 
-    // Nested JsonAdapter assignments do not emit reliable per-property change
-    // notifications. Depend on Config.revision explicitly so a settings-window
-    // write is observed by this process immediately (including disable).
+    // Config.revision makes nested JsonAdapter writes observable here.
     readonly property int requestedLimit: {
         void Config.revision
         return Config.options?.battery?.chargeLimit?.threshold ?? 80
@@ -166,8 +164,7 @@ Singleton {
     }
 
     function _matchesRequestedPolicy(): bool {
-        // Disabled means iNiR must stop owning a TLP drop-in. A charge limit
-        // from the user's own TLP configuration may legitimately remain active.
+        // Disabled requires only iNiR ownership to be absent; user TLP limits may remain.
         if (!root.enabled)
             return !root.managed
 
@@ -186,8 +183,7 @@ Singleton {
         if (!Config.ready)
             return
 
-        // Preserve the latest requested config change while a privileged apply
-        // or status refresh is already in flight. One reconciliation runs later.
+        // Coalesce config changes while status or apply is in flight.
         if (root.busy || detector.running) {
             root._reconcileAfterDetect = true
             return
@@ -199,8 +195,7 @@ Singleton {
             return
         }
 
-        // Enabling requires a battery-care interface. Disabling only requires
-        // iNiR to own a drop-in, even if the battery was removed in the meantime.
+        // Enabling needs hardware support; disabling only needs owned state to remove.
         if (root.enabled && !root.supported) {
             root._reconcileAfterDetect = false
             return
@@ -227,8 +222,7 @@ Singleton {
         target: Config
 
         function onConfigChanged(): void {
-            // Let revision-dependent bindings settle before comparing the
-            // requested policy with the last hardware status.
+            // Let revision-dependent bindings settle before comparing state.
             Qt.callLater(() => root.apply())
         }
 
@@ -285,8 +279,7 @@ Singleton {
             else
                 root._log("[TLP] Battery charge policy applied")
 
-            // Always refresh from the non-privileged status path. If config
-            // changed while pkexec was active, keep the pending reconciliation.
+            // Re-read status after mutation; preserve any queued reconciliation.
             root._detect()
         }
     }

--- a/services/TlpSettingsService.qml
+++ b/services/TlpSettingsService.qml
@@ -1,0 +1,790 @@
+pragma ComponentBehavior: Bound
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.common
+
+Singleton {
+    id: root
+
+    signal mutationFinished(string kind, bool success)
+
+    readonly property string helperPath: "/usr/libexec/inir-battery-charge-limit"
+    readonly property string schemaPath: Quickshell.shellPath("assets/tlp/tlp-settings-schema.json")
+
+    // Keep the parsed schema as a plain JavaScript array. A QML list<var>
+    // coerces nested arrays into sequence wrappers, for which Array.isArray()
+    // is false; that made every category appear empty in the settings UI.
+    property var categories: []
+    readonly property var navigationCategories: {
+        // Put the device's charge policy and the most commonly tuned power
+        // domains first. The schema itself keeps TLPUI's source order so the
+        // helper and attribution data remain easy to audit.
+        const preferredOrder = [
+            "battery-care", "general", "processor", "graphics", "disks",
+            "pcie", "usb", "network", "radio", "radio-device-wizard", "audio"
+        ]
+        const result = root._array(root.categories).slice()
+        result.sort((left, right) => {
+            const leftRank = preferredOrder.indexOf(String(left?.id ?? ""))
+            const rightRank = preferredOrder.indexOf(String(right?.id ?? ""))
+            return (leftRank < 0 ? preferredOrder.length : leftRank)
+                - (rightRank < 0 ? preferredOrder.length : rightRank)
+        })
+        return result
+    }
+    property var effectiveValues: ({})
+    property var managedValues: ({})
+    // Runtime-only choices reported by the privileged helper's unprivileged
+    // status path. Platform profiles are firmware/kernel capabilities, so the
+    // UI must not pretend the three common names are exhaustive.
+    property var runtimeValues: ({})
+    property var pendingValues: ({})
+    property var pendingChargePolicy: null
+    property bool schemaLoaded: false
+    property bool statusLoaded: false
+    property bool available: false
+    property bool supported: false
+    property bool configAvailable: false
+    property bool enabled: false
+    property bool busy: false
+    property string tlpVersion: ""
+    property string statusReason: ""
+    property string configFile: "/etc/tlp.d/99-inir-tlp-settings.conf"
+    property string lastError: ""
+    property bool _refreshPending: false
+    property string _mutationKind: ""
+    property bool _discardOnFailure: false
+
+    readonly property bool hasPendingChanges: Object.keys(root.pendingValues).length > 0
+        || root.pendingChargePolicy !== null
+    readonly property int pendingCount: Object.keys(root.pendingValues).length
+        + (root.pendingChargePolicy !== null ? 1 : 0)
+    readonly property int managedCount: Object.keys(root.managedValues).length
+    readonly property bool managedConfigPresent: root.managedCount > 0
+        || root.statusReason === "managed-config-invalid"
+    readonly property bool canResetOverrides: root.managedConfigPresent
+        && !root.hasPendingChanges
+        && !root.busy
+    readonly property bool applyingOnLeave: root.busy && root._mutationKind === "apply-on-leave"
+
+    function _clone(value): var {
+        return JSON.parse(JSON.stringify(value ?? {}))
+    }
+
+    function _clearStatus(reason: string): void {
+        root.statusLoaded = false
+        root.available = false
+        root.supported = false
+        root.configAvailable = false
+        root.enabled = false
+        root.tlpVersion = ""
+        root.statusReason = reason
+        root.effectiveValues = ({})
+        root.managedValues = ({})
+        root.runtimeValues = ({})
+    }
+
+    function _array(value): var {
+        if (value === undefined || value === null)
+            return []
+        try {
+            return Array.from(value)
+        } catch (error) {
+            return []
+        }
+    }
+
+    function _versionMinor(version: string): int {
+        const parts = String(version ?? "").split(".")
+        if (parts.length < 2 || Number(parts[0]) !== 1)
+            return -1
+        const minor = Number(parts[1])
+        return Number.isFinite(minor) ? minor : -1
+    }
+
+    function _keepUnavailableSetting(key: string): bool {
+        return root.isManaged(key)
+            || Object.prototype.hasOwnProperty.call(root.pendingValues, key)
+    }
+
+    function settingAvailable(definition): bool {
+        const key = String(definition?.key ?? "")
+        const required = String(definition?.minVersion ?? "")
+        if (required) {
+            const currentMinor = root._versionMinor(root.tlpVersion)
+            const requiredMinor = root._versionMinor(required)
+            if (currentMinor < 0 || requiredMinor < 0 || currentMinor < requiredMinor)
+                return false
+        }
+
+        if (key.startsWith("DISK_IDLE_SECS_")) {
+            // TLP 1.10 explicitly says not to change this legacy laptop-mode
+            // setting, and kernel 7.0 ignores it. Keep only an existing/staged
+            // iNiR override visible so users can remove old ownership.
+            return root._keepUnavailableSetting(key)
+        }
+
+        if (key.startsWith("PLATFORM_PROFILE_")
+                && root.statusLoaded
+                && Object.prototype.hasOwnProperty.call(root.runtimeValues, key)
+                && root._array(root.runtimeValues[key]).length === 0) {
+            // TLP may still populate intrinsic PLATFORM_PROFILE defaults on a
+            // machine with no platform-profile firmware interface. Do not let
+            // those defaults create fake UI capabilities. Keep only an iNiR-
+            // owned/staged row visible so a stale override remains removable.
+            return root._keepUnavailableSetting(key)
+        }
+
+        const capabilityValues = TlpRuntimeCapabilities.values
+        if (Object.prototype.hasOwnProperty.call(capabilityValues, key)
+                && root._array(capabilityValues[key]).length === 0)
+            return root._keepUnavailableSetting(key)
+
+        if (TlpRuntimeCapabilities.isRdwSetting(key)
+                && TlpRuntimeCapabilities.rdwProbeDone
+                && !TlpRuntimeCapabilities.rdwAvailable)
+            return root._keepUnavailableSetting(key)
+
+        return true
+    }
+
+    function settingsForCategory(category): var {
+        const settings = root._array(category?.settings)
+        return settings
+            .filter(setting => root.settingAvailable(setting))
+            .map(setting => {
+                const multipleFrom = String(setting?.multipleFromVersion ?? "")
+                if (!multipleFrom)
+                    return setting
+                const currentMinor = root._versionMinor(root.tlpVersion)
+                const requiredMinor = root._versionMinor(multipleFrom)
+                if (currentMinor < requiredMinor)
+                    return setting
+                const adapted = root._clone(setting)
+                adapted.type = "list"
+                return adapted
+            })
+    }
+
+    function categoryLabel(category): string {
+        const id = String(category?.id ?? "")
+        const labels = ({
+            "battery-care": "Battery care",
+            "disks": "Storage",
+            "pcie": "PCIe devices",
+            "radio": "Radios",
+            "radio-device-wizard": "Radio events"
+        })
+        return labels[id] ?? String(category?.name ?? id)
+    }
+
+    function groupsForCategory(category, filterText): var {
+        const settings = root.settingsForCategory(category)
+        const metadata = root._array(category?.groups)
+        const metadataById = ({})
+        for (const entry of metadata)
+            metadataById[String(entry?.id ?? "")] = entry
+
+        const orderedIds = []
+        const grouped = ({})
+        for (const setting of settings) {
+            const groupId = String(setting?.group ?? setting?.key ?? "")
+            if (!Object.prototype.hasOwnProperty.call(grouped, groupId)) {
+                const meta = metadataById[groupId] ?? ({})
+                grouped[groupId] = {
+                    id: groupId,
+                    title: root.groupLabel(groupId, String(meta.title ?? "")),
+                    description: String(meta.description ?? ""),
+                    settings: []
+                }
+                orderedIds.push(groupId)
+            }
+            grouped[groupId].settings.push(setting)
+        }
+
+        for (const groupId of orderedIds) {
+            if (groupId === "TLP_PROFILE")
+                continue
+            const group = grouped[groupId]
+            const profiled = group.settings.filter(setting => {
+                const profile = String(setting?.profile ?? "")
+                return profile === "AC" || profile === "BAT" || profile === "SAV"
+            })
+            if (profiled.length < 2)
+                continue
+            const guidance = "When overriding this group, set every shown profile together to avoid values spilling between TLP profiles."
+            group.description = group.description.length > 0
+                ? group.description + " " + guidance
+                : guidance
+        }
+
+        const query = String(filterText ?? "").trim().toLowerCase()
+        return orderedIds.map(groupId => {
+            const group = grouped[groupId]
+            if (!query)
+                return group
+
+            const groupMatches = group.id.toLowerCase().includes(query)
+                || group.title.toLowerCase().includes(query)
+                || group.description.toLowerCase().includes(query)
+            if (groupMatches)
+                return group
+
+            const adapted = root._clone(group)
+            adapted.settings = group.settings.filter(setting =>
+                String(setting?.key ?? "").toLowerCase().includes(query)
+                || String(setting?.description ?? "").toLowerCase().includes(query)
+                || root.settingLabel(setting).toLowerCase().includes(query))
+            return adapted
+        }).filter(group => group.settings.length > 0)
+    }
+
+    function settingLabel(definition): string {
+        const acronyms = ({
+            TLP: "TLP", CPU: "CPU", GPU: "GPU", AMDGPU: "AMD GPU",
+            USB: "USB", PCIE: "PCIe", WIFI: "Wi-Fi", WOL: "Wake-on-LAN",
+            SATA: "SATA", AHCI: "AHCI", APM: "APM", PM: "PM",
+            NMI: "NMI", HWP: "HWP", DPM: "DPM", IOSCHED: "I/O scheduler"
+        })
+        let key = String(definition?.key ?? "")
+        if (key.startsWith("TLP_PROFILE_") && String(definition?.profile ?? "").length > 0)
+            key = "TLP_PROFILE"
+        key = key.replace(/_ON_(AC|BAT|SAV)/, "")
+            .replace(/_DEFAULT$/, "")
+        return key.split("_").filter(Boolean).map(word => {
+            if (Object.prototype.hasOwnProperty.call(acronyms, word))
+                return acronyms[word]
+            if (word === "MIN") return "Minimum"
+            if (word === "MAX") return "Maximum"
+            if (word === "PWR") return "Power"
+            if (word === "FREQ") return "Frequency"
+            if (word === "SECS") return "Seconds"
+            if (word === "OPMODE") return "Mode"
+            if (word === "PERF") return "Performance"
+            if (word === "POWEROFF") return "Power off"
+            return word.charAt(0) + word.slice(1).toLowerCase()
+        }).join(" ")
+    }
+
+    function groupLabel(groupId: string, fallbackTitle: string): string {
+        const labels = ({
+            TLP_ENABLE: "TLP power management",
+            TLP_DISABLE_DEFAULTS: "Intrinsic defaults",
+            TLP_WARN_LEVEL: "Warnings",
+            TLP_MSG_COLORS: "Message colors",
+            TLP_AUTO_SWITCH: "Automatic profile switching",
+            TLP_PROFILE: "Power profiles",
+            TLP_PS_IGNORE: "Power-source detection",
+            SOUND_POWER_SAVE: "Audio power saving",
+            SOUND_POWER_SAVE_CONTROLLER: "Audio controller",
+            DISK_IDLE_SECS: "Disk idle sync",
+            MAX_LOST_WORK_SECS: "Writeback interval",
+            DISK_DEVICES: "Target disks",
+            DISK_APM_LEVEL: "Disk APM level",
+            DISK_APM_CLASS_DENYLIST: "APM exclusions",
+            DISK_SPINDOWN_TIMEOUT: "Disk spin-down",
+            DISK_IOSCHED: "I/O scheduler",
+            SATA_LINKPWR: "SATA link power",
+            SATA_LINKPWR_DENYLIST: "SATA link exclusions",
+            AHCI_RUNTIME_PM: "Disk runtime power",
+            AHCI_RUNTIME_PM_TIMEOUT: "Runtime suspend delay",
+            BAY_POWEROFF: "Optical-drive power",
+            BAY_DEVICE: "Optical-drive device",
+            INTEL_GPU_POWER_PROFILE: "Intel GPU power profile",
+            INTEL_GPU_FREQ: "Intel GPU frequencies",
+            RADEON_DPM_PERF_LEVEL: "AMD GPU performance level",
+            AMDGPU_ABM_LEVEL: "AMD panel power saving",
+            WIFI_PWR: "Wi-Fi power saving",
+            WOL_DISABLE: "Wake-on-LAN",
+            PCIE_ASPM: "PCIe link power",
+            RUNTIME_PM: "PCIe runtime power",
+            RUNTIME_PM_DENYLIST: "PCIe device exclusions",
+            RUNTIME_PM_DRIVER_DENYLIST: "PCIe driver exclusions",
+            RUNTIME_PM_DEVICE: "Forced PCIe runtime state",
+            CPU_DRIVER_OPMODE: "CPU driver mode",
+            CPU_SCALING_GOVERNOR: "CPU scaling governor",
+            CPU_SCALING_FREQ: "CPU frequency limits",
+            CPU_ENERGY_PERF_POLICY: "CPU energy policy",
+            CPU_PERF: "CPU performance limits",
+            CPU_BOOST: "CPU boost",
+            CPU_HWP_DYN_BOOST: "Intel HWP dynamic boost",
+            NMI_WATCHDOG: "NMI watchdog",
+            PLATFORM_PROFILE: "Platform profile",
+            MEM_SLEEP: "Suspend mode",
+            DEVICES_TO_DISABLE_ON_STARTUP: "Disable radios at startup",
+            DEVICES_TO_ENABLE_ON_STARTUP: "Enable radios at startup",
+            DEVICES_TO_ENABLE_ON_AC: "Radios on AC",
+            DEVICES_TO_DISABLE_ON_BAT: "Radios on battery",
+            DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE: "Idle radios on battery",
+            PROFILE_RADIO: "Profile-based radio rules",
+            DEVICES_TO_DISABLE_ON_CONNECT: "On network connect",
+            DEVICES_TO_ENABLE_ON_DISCONNECT: "On network disconnect",
+            DEVICES_ON_DOCK: "On dock",
+            DEVICES_ON_UNDOCK: "On undock",
+            USB_AUTOSUSPEND: "USB autosuspend",
+            USB_DENYLIST: "USB autosuspend exclusions",
+            USB_EXCLUDE_AUDIO: "USB audio",
+            USB_EXCLUDE_BTUSB: "USB Bluetooth",
+            USB_EXCLUDE_PHONE: "USB phones",
+            USB_EXCLUDE_PRINTER: "USB printers",
+            USB_EXCLUDE_WWAN: "USB WWAN",
+            USB_ALLOWLIST: "USB autosuspend allowlist",
+            RESTORE_THRESHOLDS_ON_BAT: "Restore charge thresholds"
+        })
+        if (Object.prototype.hasOwnProperty.call(labels, groupId))
+            return labels[groupId]
+        const generated = root.settingLabel({ key: groupId })
+        return generated.length > 0 ? generated : String(fallbackTitle ?? "")
+    }
+
+    function groupUsesCompactProfileRows(group): bool {
+        const settings = root._array(group?.settings)
+        if (settings.length < 2)
+            return false
+        const firstLabel = root.settingLabel(settings[0])
+        if (!firstLabel)
+            return false
+        return settings.every(setting =>
+            String(setting?.profile ?? "").length > 0
+            && root.settingLabel(setting) === firstLabel)
+    }
+
+    function exampleValue(definition): string {
+        const examples = ({
+            TLP_MSG_COLORS: "91 93 1 92",
+            DISK_DEVICES: "nvme0n1 sda",
+            DISK_APM_LEVEL_ON_AC: "254 254",
+            DISK_APM_LEVEL_ON_BAT: "128 128",
+            DISK_SPINDOWN_TIMEOUT_ON_AC: "0 0",
+            DISK_SPINDOWN_TIMEOUT_ON_BAT: "0 0",
+            // TLP's documented default is keep. It is also the safest example:
+            // it demonstrates the syntax without changing the kernel scheduler.
+            DISK_IOSCHED: "keep",
+            SATA_LINKPWR_DENYLIST: "host1",
+            BAY_DEVICE: "sr0",
+            RUNTIME_PM_DENYLIST: "11:22.3 44:55.6",
+            RUNTIME_PM_DRIVER_DENYLIST: "amdgpu mei_me nouveau nvidia xhci_hcd",
+            RUNTIME_PM_ENABLE: "11:22.3",
+            RUNTIME_PM_DISABLE: "44:55.6",
+            CPU_SCALING_MIN_FREQ_ON_AC: "0",
+            CPU_SCALING_MAX_FREQ_ON_AC: "0",
+            CPU_SCALING_MIN_FREQ_ON_BAT: "0",
+            CPU_SCALING_MAX_FREQ_ON_BAT: "0",
+            CPU_SCALING_MIN_FREQ_ON_SAV: "0",
+            CPU_SCALING_MAX_FREQ_ON_SAV: "0",
+            USB_DENYLIST: "1111:2222 3333:4444",
+            USB_ALLOWLIST: "1111:2222 3333:4444"
+        })
+        return String(examples[String(definition?.key ?? "")] ?? "")
+    }
+
+    function optionValues(definition): var {
+        const key = String(definition?.key ?? "")
+        const capabilityValues = TlpRuntimeCapabilities.values
+        const hasCapabilityValues = Object.prototype.hasOwnProperty.call(capabilityValues, key)
+        const hasHelperRuntimeValues = Object.prototype.hasOwnProperty.call(root.runtimeValues, key)
+        const result = hasCapabilityValues
+            ? root._array(capabilityValues[key]).map(value => String(value))
+            : hasHelperRuntimeValues
+                ? root._array(root.runtimeValues[key]).map(value => String(value))
+                : root._array(definition?.values).map(value => String(value))
+
+        // TLP 1.10 documents userspace for passive/guided pstate and
+        // acpi-cpufreq even though TLPUI 1.10's static schema omitted it. A
+        // successful sysfs capability probe is more authoritative than this
+        // fallback, so only augment the static-schema path.
+        if (!hasCapabilityValues
+                && key.startsWith("CPU_SCALING_GOVERNOR_")
+                && !result.includes("userspace"))
+            result.push("userspace")
+
+        // Preserve an effective or staged value even if hardware capabilities
+        // changed since it was configured. This keeps the real TLP state
+        // visible and lets the user explicitly remove the stale override.
+        const current = String(root.value(key) ?? "").trim()
+        if (current.length > 0) {
+            for (const token of current.split(/\s+/)) {
+                if (token.length > 0 && !result.includes(token))
+                    result.push(token)
+            }
+        }
+        return result
+    }
+
+    function profileLabel(profile): string {
+        switch (String(profile ?? "")) {
+        case "AC": return "AC"
+        case "BAT": return "Battery"
+        case "SAV": return "Power saver"
+        case "DEFAULT": return "Fallback"
+        default: return ""
+        }
+    }
+
+    function displayValue(definition, value): string {
+        const raw = String(value ?? "")
+        const key = String(definition?.key ?? "")
+        if (key === "TLP_WARN_LEVEL") {
+            const labels = ({
+                "0": "Disabled", "1": "Background only",
+                "2": "Commands only", "3": "Background and commands"
+            })
+            return labels[raw] ?? raw
+        }
+        if (key === "TLP_AUTO_SWITCH") {
+            const labels = ({ "0": "Disabled", "1": "Automatic", "2": "Smart" })
+            return labels[raw] ?? raw
+        }
+        if (key === "TLP_DISABLE_DEFAULTS")
+            return raw === "1" ? "Disable intrinsic defaults" : "Use intrinsic defaults"
+        if (key === "WOL_DISABLE") {
+            const labels = ({ N: "Allow Wake-on-LAN", Y: "Disable Wake-on-LAN" })
+            return labels[raw] ?? raw
+        }
+        if (key === "SOUND_POWER_SAVE_CONTROLLER") {
+            const labels = ({ N: "Keep controller active", Y: "Power down controller" })
+            return labels[raw] ?? raw
+        }
+        if (key.startsWith("BAY_POWEROFF_")) {
+            const labels = ({ "0": "Keep drive powered", "1": "Power off drive" })
+            return labels[raw] ?? raw
+        }
+        if (key.startsWith("USB_EXCLUDE_")) {
+            const labels = ({ "0": "Allow autosuspend", "1": "Exclude from autosuspend" })
+            return labels[raw] ?? raw
+        }
+        if (key.startsWith("TLP_PROFILE_")) {
+            const labels = ({
+                AC: "AC (legacy)", PRF: "Performance", BAT: "Battery (legacy)",
+                BAL: "Balanced", SAV: "Power saver"
+            })
+            return labels[raw] ?? raw
+        }
+        const common = ({
+            "0": "Disabled", "1": "Enabled", N: "No", Y: "Yes",
+            off: "Off", on: "On", auto: "Automatic", default: "System default",
+            power_saving: "Power saving", powersave: "Power saving",
+            powersupersave: "Maximum power saving", performance: "Performance",
+            balanced: "Balanced", "balanced-performance": "Balanced performance",
+            "low-power": "Low power", quiet: "Quiet", cool: "Cool",
+            balance_performance: "Balanced performance", balance_power: "Balanced power",
+            power: "Maximum power saving", active: "Active", passive: "Passive",
+            guided: "Guided", s2idle: "s2idle (light sleep)",
+            deep: "deep (suspend to RAM)", min_power: "Minimum power",
+            med_power_with_dipm: "Medium power with DIPM",
+            medium_power: "Medium power", max_performance: "Maximum performance",
+            bluetooth: "Bluetooth", nfc: "NFC", wifi: "Wi-Fi", wwan: "WWAN",
+            userspace: "Userspace", keep: "Keep current/default", _: "Keep current/default"
+        })
+        return common[raw] ?? raw.replace(/_/g, " ")
+    }
+
+    function settingNotice(definition): string {
+        const key = String(definition?.key ?? "")
+        const current = String(root.value(key) ?? "")
+        if (key === "TLP_ENABLE" && current === "0")
+            return "A reboot is required for complete restoration after disabling TLP."
+        if (key === "WOL_DISABLE" && current === "N")
+            return "Allowing Wake-on-LAN requires a reboot before the new setting is fully effective."
+        if (key.startsWith("DISK_IDLE_SECS_"))
+            return "Legacy laptop-mode setting: TLP recommends not changing it, and kernel 7.0 ignores it. Disable this override unless you explicitly need legacy behavior."
+        if (key.startsWith("MEM_SLEEP_"))
+            return "Changing the system suspend mode can cause instability or data loss on unsupported hardware."
+        return ""
+    }
+
+    function isManaged(key: string): bool {
+        const pending = root.pendingValues[key]
+        if (pending !== undefined)
+            return pending.managed === true
+        return Object.prototype.hasOwnProperty.call(root.managedValues, key)
+    }
+
+    function value(key: string): string {
+        const pending = root.pendingValues[key]
+        if (pending !== undefined) {
+            if (pending.managed === true)
+                return String(pending.value ?? "")
+            // Keep the last effective value visible while an unset is staged;
+            // the value inherited after Apply is authoritative only after TLP
+            // has re-read its remaining configuration files.
+            return String(root.effectiveValues[key] ?? root.managedValues[key] ?? "")
+        }
+        if (Object.prototype.hasOwnProperty.call(root.managedValues, key))
+            return String(root.managedValues[key] ?? "")
+        return String(root.effectiveValues[key] ?? "")
+    }
+
+    function effectiveValue(key: string): string {
+        return String(root.effectiveValues[key] ?? "")
+    }
+
+    function chargeEnabled(): bool {
+        void Config.revision
+        if (root.pendingChargePolicy !== null)
+            return root.pendingChargePolicy.enabled === true
+        return Config.options?.battery?.chargeLimit?.enable ?? false
+    }
+
+    function chargeThreshold(): int {
+        void Config.revision
+        if (root.pendingChargePolicy !== null)
+            return Number(root.pendingChargePolicy.threshold ?? 80)
+        return Number(Config.options?.battery?.chargeLimit?.threshold ?? 80)
+    }
+
+    function _stageChargePolicy(enabled: bool, threshold: int): void {
+        void Config.revision
+        const originalEnabled = Config.options?.battery?.chargeLimit?.enable ?? false
+        const originalThreshold = Number(Config.options?.battery?.chargeLimit?.threshold ?? 80)
+        const normalizedThreshold = Math.max(1, Math.min(100, Math.round(Number(threshold))))
+        if (enabled === originalEnabled && normalizedThreshold === originalThreshold)
+            root.pendingChargePolicy = null
+        else
+            root.pendingChargePolicy = {
+                enabled: enabled,
+                threshold: normalizedThreshold
+            }
+        root.lastError = ""
+    }
+
+    function stageChargeEnabled(enabled: bool, threshold: int): void {
+        root._stageChargePolicy(enabled, threshold)
+    }
+
+    function stageChargeThreshold(threshold: int): void {
+        root._stageChargePolicy(root.chargeEnabled(), threshold)
+    }
+
+    function stageSet(key: string, value): void {
+        const next = root._clone(root.pendingValues)
+        const normalized = String(value ?? "")
+        if (Object.prototype.hasOwnProperty.call(root.managedValues, key)
+                && String(root.managedValues[key] ?? "") === normalized)
+            delete next[key]
+        else
+            next[key] = { managed: true, value: normalized }
+        root.pendingValues = next
+        root.lastError = ""
+    }
+
+    function stageUnset(key: string): void {
+        const next = root._clone(root.pendingValues)
+        if (Object.prototype.hasOwnProperty.call(root.managedValues, key))
+            next[key] = { managed: false, value: "" }
+        else
+            delete next[key]
+        root.pendingValues = next
+        root.lastError = ""
+    }
+
+    function discard(): void {
+        root.pendingValues = ({})
+        root.pendingChargePolicy = null
+        root.lastError = ""
+    }
+
+    function refresh(): void {
+        if (statusProcess.running || root.busy) {
+            root._refreshPending = true
+            return
+        }
+        root._refreshPending = false
+        statusProcess.running = true
+    }
+
+    function _startApply(kind: string, discardOnFailure: bool): bool {
+        if (root.busy || !root.hasPendingChanges)
+            return false
+
+        const command = ["/usr/bin/pkexec", root.helperPath, "--config-apply"]
+        if (root.pendingChargePolicy !== null) {
+            if (root.pendingChargePolicy.enabled === true)
+                command.push("--charge-set", String(root.pendingChargePolicy.threshold ?? 80))
+            else
+                command.push("--charge-disable")
+        }
+        const keys = Object.keys(root.pendingValues).sort()
+        for (const key of keys) {
+            const operation = root.pendingValues[key]
+            if (operation.managed === true)
+                command.push("--set", key, String(operation.value ?? ""))
+            else
+                command.push("--unset", key)
+        }
+
+        root.busy = true
+        root.lastError = ""
+        root._mutationKind = kind
+        root._discardOnFailure = discardOnFailure
+        mutationProcess.command = command
+        mutationProcess.running = true
+        return true
+    }
+
+    function apply(): bool {
+        return root._startApply("apply", false)
+    }
+
+    function applyOnLeave(): bool {
+        if (root.busy) {
+            if (root._mutationKind === "apply") {
+                root._mutationKind = "apply-on-leave"
+                root._discardOnFailure = false
+            }
+            return false
+        }
+        return root._startApply("apply-on-leave", false)
+    }
+
+    function reset(): void {
+        if (root.busy)
+            return
+        root.busy = true
+        root.lastError = ""
+        root._mutationKind = "reset"
+        root._discardOnFailure = false
+        mutationProcess.command = ["/usr/bin/pkexec", root.helperPath, "--config-reset"]
+        mutationProcess.running = true
+    }
+
+    function _parseStatus(payload: string): void {
+        let data
+        try {
+            data = JSON.parse(String(payload ?? "").trim())
+        } catch (error) {
+            root._clearStatus("invalid-status")
+            return
+        }
+
+        if (data?.schema !== 1) {
+            root._clearStatus("invalid-status")
+            return
+        }
+
+        root.available = data.available === true
+        root.supported = data.supported === true
+        root.configAvailable = data.configAvailable === true
+        root.enabled = data.enabled === true
+        root.tlpVersion = String(data.tlpVersion ?? "")
+        root.statusReason = String(data.reason ?? "")
+        root.configFile = String(data.configFile ?? root.configFile)
+        root.effectiveValues = root._clone(data.effective)
+        root.managedValues = root._clone(data.managed)
+        root.runtimeValues = root._clone(data.runtimeValues)
+        root.statusLoaded = true
+    }
+
+    FileView {
+        id: schemaFile
+        path: root.schemaPath
+
+        onLoaded: {
+            try {
+                const data = JSON.parse(schemaFile.text())
+                if (data?.schema !== 1 || !Array.isArray(data.categories))
+                    throw new Error("unsupported schema")
+                root.categories = data.categories
+                root.schemaLoaded = true
+                root.refresh()
+            } catch (error) {
+                root.categories = []
+                root.schemaLoaded = false
+                root._clearStatus("schema-invalid")
+                console.warn("[TLP Settings] Failed to load schema:", error)
+            }
+        }
+
+        onLoadFailed: error => {
+            root.categories = []
+            root.schemaLoaded = false
+            root._clearStatus("schema-unavailable")
+            console.warn("[TLP Settings] Schema is unavailable:", error)
+        }
+    }
+
+    Process {
+        id: statusProcess
+        command: [root.helperPath, "--config-status"]
+
+        stdout: StdioCollector {
+            id: statusOutput
+        }
+
+        stderr: StdioCollector {
+            id: statusError
+        }
+
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0)
+                root._parseStatus(statusOutput.text)
+            else {
+                root._clearStatus("status-failed")
+                root.lastError = statusError.text.trim()
+            }
+
+            if (root._refreshPending)
+                Qt.callLater(() => root.refresh())
+        }
+    }
+
+    Process {
+        id: mutationProcess
+
+        stdout: StdioCollector {
+            id: mutationOutput
+        }
+
+        stderr: StdioCollector {
+            id: mutationError
+        }
+
+        onExited: (exitCode, exitStatus) => {
+            const kind = root._mutationKind
+            const discardOnFailure = root._discardOnFailure
+            const success = exitCode === 0
+            const appliedChargePolicy = root.pendingChargePolicy === null
+                ? null : root._clone(root.pendingChargePolicy)
+            root.busy = false
+            if (success) {
+                root.pendingValues = ({})
+                if (kind === "apply" || kind === "apply-on-leave") {
+                    root.pendingChargePolicy = null
+                    if (appliedChargePolicy !== null) {
+                        // Refresh first. The Config notification then waits for
+                        // this authoritative status read instead of launching a
+                        // second privileged charge-policy reconciliation.
+                        TlpService.refresh()
+                        Config.setNestedValues({
+                            "battery.chargeLimit.enable": appliedChargePolicy.enabled === true,
+                            "battery.chargeLimit.threshold": Number(appliedChargePolicy.threshold ?? 80)
+                        })
+                    }
+                }
+                root.lastError = ""
+            } else {
+                const detail = mutationError.text.trim() || mutationOutput.text.trim()
+                root.lastError = detail || "TLP settings operation failed (exit code " + exitCode + ")"
+                console.warn("[TLP Settings]", root.lastError)
+                if (discardOnFailure) {
+                    root.pendingValues = ({})
+                    root.pendingChargePolicy = null
+                }
+            }
+            root._mutationKind = ""
+            root._discardOnFailure = false
+            root.refresh()
+            root.mutationFinished(kind, success)
+        }
+    }
+
+    Timer {
+        interval: 30000
+        repeat: true
+        running: root.schemaLoaded
+        onTriggered: root.refresh()
+    }
+}

--- a/services/TlpSettingsService.qml
+++ b/services/TlpSettingsService.qml
@@ -19,9 +19,6 @@ Singleton {
     // is false; that made every category appear empty in the settings UI.
     property var categories: []
     readonly property var navigationCategories: {
-        // Put the device's charge policy and the most commonly tuned power
-        // domains first. The schema itself keeps TLPUI's source order so the
-        // helper and attribution data remain easy to audit.
         const preferredOrder = [
             "battery-care", "general", "processor", "graphics", "disks",
             "pcie", "usb", "network", "radio", "radio-device-wizard", "audio"
@@ -37,9 +34,7 @@ Singleton {
     }
     property var effectiveValues: ({})
     property var managedValues: ({})
-    // Runtime-only choices reported by the privileged helper's unprivileged
-    // status path. Platform profiles are firmware/kernel capabilities, so the
-    // UI must not pretend the three common names are exhaustive.
+    // Platform-profile choices are runtime firmware capabilities, not a fixed list.
     property var runtimeValues: ({})
     property var pendingValues: ({})
     property var pendingChargePolicy: null
@@ -56,7 +51,6 @@ Singleton {
     property string lastError: ""
     property bool _refreshPending: false
     property string _mutationKind: ""
-    property bool _discardOnFailure: false
 
     readonly property bool hasPendingChanges: Object.keys(root.pendingValues).length > 0
         || root.pendingChargePolicy !== null
@@ -68,7 +62,6 @@ Singleton {
     readonly property bool canResetOverrides: root.managedConfigPresent
         && !root.hasPendingChanges
         && !root.busy
-    readonly property bool applyingOnLeave: root.busy && root._mutationKind === "apply-on-leave"
 
     function _clone(value): var {
         return JSON.parse(JSON.stringify(value ?? {}))
@@ -121,9 +114,8 @@ Singleton {
         }
 
         if (key.startsWith("DISK_IDLE_SECS_")) {
-            // TLP 1.10 explicitly says not to change this legacy laptop-mode
-            // setting, and kernel 7.0 ignores it. Keep only an existing/staged
-            // iNiR override visible so users can remove old ownership.
+            // TLP 1.10 discourages this legacy setting and kernel 7.0 ignores it;
+            // keep only an owned/staged row so an old override remains removable.
             return root._keepUnavailableSetting(key)
         }
 
@@ -131,10 +123,8 @@ Singleton {
                 && root.statusLoaded
                 && Object.prototype.hasOwnProperty.call(root.runtimeValues, key)
                 && root._array(root.runtimeValues[key]).length === 0) {
-            // TLP may still populate intrinsic PLATFORM_PROFILE defaults on a
-            // machine with no platform-profile firmware interface. Do not let
-            // those defaults create fake UI capabilities. Keep only an iNiR-
-            // owned/staged row visible so a stale override remains removable.
+            // Intrinsic defaults can exist without firmware support; keep only
+            // owned/staged rows so stale overrides remain removable.
             return root._keepUnavailableSetting(key)
         }
 
@@ -360,8 +350,6 @@ Singleton {
             DISK_APM_LEVEL_ON_BAT: "128 128",
             DISK_SPINDOWN_TIMEOUT_ON_AC: "0 0",
             DISK_SPINDOWN_TIMEOUT_ON_BAT: "0 0",
-            // TLP's documented default is keep. It is also the safest example:
-            // it demonstrates the syntax without changing the kernel scheduler.
             DISK_IOSCHED: "keep",
             SATA_LINKPWR_DENYLIST: "host1",
             BAY_DEVICE: "sr0",
@@ -392,18 +380,13 @@ Singleton {
                 ? root._array(root.runtimeValues[key]).map(value => String(value))
                 : root._array(definition?.values).map(value => String(value))
 
-        // TLP 1.10 documents userspace for passive/guided pstate and
-        // acpi-cpufreq even though TLPUI 1.10's static schema omitted it. A
-        // successful sysfs capability probe is more authoritative than this
-        // fallback, so only augment the static-schema path.
+        // TLP documents "userspace" here even though TLPUI 1.10 omits it.
         if (!hasCapabilityValues
                 && key.startsWith("CPU_SCALING_GOVERNOR_")
                 && !result.includes("userspace"))
             result.push("userspace")
 
-        // Preserve an effective or staged value even if hardware capabilities
-        // changed since it was configured. This keeps the real TLP state
-        // visible and lets the user explicitly remove the stale override.
+        // Preserve stale owned/staged values so users can still unset them.
         const current = String(root.value(key) ?? "").trim()
         if (current.length > 0) {
             for (const token of current.split(/\s+/)) {
@@ -508,9 +491,7 @@ Singleton {
         if (pending !== undefined) {
             if (pending.managed === true)
                 return String(pending.value ?? "")
-            // Keep the last effective value visible while an unset is staged;
-            // the value inherited after Apply is authoritative only after TLP
-            // has re-read its remaining configuration files.
+            // Inherited post-Apply state is authoritative only after TLP re-reads config.
             return String(root.effectiveValues[key] ?? root.managedValues[key] ?? "")
         }
         if (Object.prototype.hasOwnProperty.call(root.managedValues, key))
@@ -596,7 +577,7 @@ Singleton {
         statusProcess.running = true
     }
 
-    function _startApply(kind: string, discardOnFailure: bool): bool {
+    function _startApply(kind: string): bool {
         if (root.busy || !root.hasPendingChanges)
             return false
 
@@ -619,25 +600,13 @@ Singleton {
         root.busy = true
         root.lastError = ""
         root._mutationKind = kind
-        root._discardOnFailure = discardOnFailure
         mutationProcess.command = command
         mutationProcess.running = true
         return true
     }
 
     function apply(): bool {
-        return root._startApply("apply", false)
-    }
-
-    function applyOnLeave(): bool {
-        if (root.busy) {
-            if (root._mutationKind === "apply") {
-                root._mutationKind = "apply-on-leave"
-                root._discardOnFailure = false
-            }
-            return false
-        }
-        return root._startApply("apply-on-leave", false)
+        return root._startApply("apply")
     }
 
     function reset(): void {
@@ -646,7 +615,6 @@ Singleton {
         root.busy = true
         root.lastError = ""
         root._mutationKind = "reset"
-        root._discardOnFailure = false
         mutationProcess.command = ["/usr/bin/pkexec", root.helperPath, "--config-reset"]
         mutationProcess.running = true
     }
@@ -744,19 +712,16 @@ Singleton {
 
         onExited: (exitCode, exitStatus) => {
             const kind = root._mutationKind
-            const discardOnFailure = root._discardOnFailure
             const success = exitCode === 0
             const appliedChargePolicy = root.pendingChargePolicy === null
                 ? null : root._clone(root.pendingChargePolicy)
             root.busy = false
             if (success) {
                 root.pendingValues = ({})
-                if (kind === "apply" || kind === "apply-on-leave") {
+                if (kind === "apply") {
                     root.pendingChargePolicy = null
                     if (appliedChargePolicy !== null) {
-                        // Refresh first. The Config notification then waits for
-                        // this authoritative status read instead of launching a
-                        // second privileged charge-policy reconciliation.
+                        // Refresh authoritative status before Config can reconcile again.
                         TlpService.refresh()
                         Config.setNestedValues({
                             "battery.chargeLimit.enable": appliedChargePolicy.enabled === true,
@@ -769,13 +734,8 @@ Singleton {
                 const detail = mutationError.text.trim() || mutationOutput.text.trim()
                 root.lastError = detail || "TLP settings operation failed (exit code " + exitCode + ")"
                 console.warn("[TLP Settings]", root.lastError)
-                if (discardOnFailure) {
-                    root.pendingValues = ({})
-                    root.pendingChargePolicy = null
-                }
             }
             root._mutationKind = ""
-            root._discardOnFailure = false
             root.refresh()
             root.mutationFinished(kind, success)
         }

--- a/services/qmldir
+++ b/services/qmldir
@@ -45,6 +45,9 @@ singleton Notifications 1.0 Notifications.qml
 singleton PolkitService 1.0 PolkitService.qml
 PolkitServiceImpl 1.0 PolkitServiceImpl.qml
 singleton PowerProfilePersistence 1.0 PowerProfilePersistence.qml
+singleton TlpRuntimeCapabilities 1.0 TlpRuntimeCapabilities.qml
+singleton TlpService 1.0 TlpService.qml
+singleton TlpSettingsService 1.0 TlpSettingsService.qml
 singleton Privacy 1.0 Privacy.qml
 singleton RecorderStatus 1.0 RecorderStatus.qml
 singleton ResourceUsage 1.0 ResourceUsage.qml

--- a/settings.qml
+++ b/settings.qml
@@ -32,8 +32,6 @@ ApplicationWindow {
         return entry;
     })
     property int currentPage: 0
-    property int _previousPage: 0
-    property bool _quitAfterTlpMutation: false
     property int _requestedStartPage: -1
     property string _requestedStartSection: ""
     property bool _navigationInitialized: false
@@ -58,15 +56,7 @@ ApplicationWindow {
         }
     }
 
-    onCurrentPageChanged: {
-        if (root._navigationInitialized
-                && root._previousPage === 27
-                && root.currentPage !== 27
-                && TlpSettingsService.hasPendingChanges)
-            TlpSettingsService.applyOnLeave()
-        root._previousPage = root.currentPage
-        root._persistCurrentPage()
-    }
+    onCurrentPageChanged: root._persistCurrentPage()
     property bool uiReady: Config.ready
 
     // Easy mode helpers — derived list filtered to essentials when on
@@ -451,19 +441,7 @@ ApplicationWindow {
     }
 
     visible: true
-    onClosing: close => {
-        if (root._quitAfterTlpMutation) {
-            close.accepted = false
-            return
-        }
-        if (TlpSettingsService.busy || TlpSettingsService.hasPendingChanges) {
-            close.accepted = false
-            root._quitAfterTlpMutation = true
-            TlpSettingsService.applyOnLeave()
-            return
-        }
-        Qt.quit()
-    }
+    onClosing: Qt.quit()
     title: "illogical-impulse Settings"
 
     Component.onCompleted: {
@@ -480,19 +458,6 @@ ApplicationWindow {
     Connections {
         target: Persistent
         function onReadyChanged() { root.initializeNavigation() }
-    }
-
-    Connections {
-        target: TlpSettingsService
-
-        function onMutationFinished(kind, success): void {
-            if (!root._quitAfterTlpMutation)
-                return
-            if (!success && TlpSettingsService.hasPendingChanges)
-                TlpSettingsService.discard()
-            root._quitAfterTlpMutation = false
-            Qt.quit()
-        }
     }
 
     // Apply theme when Config is ready

--- a/settings.qml
+++ b/settings.qml
@@ -32,6 +32,8 @@ ApplicationWindow {
         return entry;
     })
     property int currentPage: 0
+    property int _previousPage: 0
+    property bool _quitAfterTlpMutation: false
     property int _requestedStartPage: -1
     property string _requestedStartSection: ""
     property bool _navigationInitialized: false
@@ -56,7 +58,15 @@ ApplicationWindow {
         }
     }
 
-    onCurrentPageChanged: root._persistCurrentPage()
+    onCurrentPageChanged: {
+        if (root._navigationInitialized
+                && root._previousPage === 27
+                && root.currentPage !== 27
+                && TlpSettingsService.hasPendingChanges)
+            TlpSettingsService.applyOnLeave()
+        root._previousPage = root.currentPage
+        root._persistCurrentPage()
+    }
     property bool uiReady: Config.ready
 
     // Easy mode helpers — derived list filtered to essentials when on
@@ -441,7 +451,19 @@ ApplicationWindow {
     }
 
     visible: true
-    onClosing: Qt.quit()
+    onClosing: close => {
+        if (root._quitAfterTlpMutation) {
+            close.accepted = false
+            return
+        }
+        if (TlpSettingsService.busy || TlpSettingsService.hasPendingChanges) {
+            close.accepted = false
+            root._quitAfterTlpMutation = true
+            TlpSettingsService.applyOnLeave()
+            return
+        }
+        Qt.quit()
+    }
     title: "illogical-impulse Settings"
 
     Component.onCompleted: {
@@ -458,6 +480,19 @@ ApplicationWindow {
     Connections {
         target: Persistent
         function onReadyChanged() { root.initializeNavigation() }
+    }
+
+    Connections {
+        target: TlpSettingsService
+
+        function onMutationFinished(kind, success): void {
+            if (!root._quitAfterTlpMutation)
+                return
+            if (!success && TlpSettingsService.hasPendingChanges)
+                TlpSettingsService.discard()
+            root._quitAfterTlpMutation = false
+            Qt.quit()
+        }
     }
 
     // Apply theme when Config is ready

--- a/waffleSettings.qml
+++ b/waffleSettings.qml
@@ -121,8 +121,6 @@ ApplicationWindow {
     ]
     
     property int currentPage: 0
-    property int _previousPage: 0
-    property bool _quitAfterTlpMutation: false
     property int _requestedStartPage: -1
     property bool _navigationInitialized: false
 
@@ -142,30 +140,10 @@ ApplicationWindow {
         root.tryOpenPendingSection()
     }
 
-    onCurrentPageChanged: {
-        if (root._navigationInitialized
-                && root._previousPage === 18
-                && root.currentPage !== 18
-                && TlpSettingsService.hasPendingChanges)
-            TlpSettingsService.applyOnLeave()
-        root._previousPage = root.currentPage
-        root._persistCurrentPage()
-    }
+    onCurrentPageChanged: root._persistCurrentPage()
     
     visible: true
-    onClosing: close => {
-        if (root._quitAfterTlpMutation) {
-            close.accepted = false
-            return
-        }
-        if (TlpSettingsService.busy || TlpSettingsService.hasPendingChanges) {
-            close.accepted = false
-            root._quitAfterTlpMutation = true
-            TlpSettingsService.applyOnLeave()
-            return
-        }
-        Qt.quit()
-    }
+    onClosing: Qt.quit()
     title: "Settings — iNiR"
 
     function tryOpenPendingSection(): void {
@@ -198,19 +176,6 @@ ApplicationWindow {
     Connections {
         target: Persistent
         function onReadyChanged() { root.initializeNavigation() }
-    }
-
-    Connections {
-        target: TlpSettingsService
-
-        function onMutationFinished(kind, success): void {
-            if (!root._quitAfterTlpMutation)
-                return
-            if (!success && TlpSettingsService.hasPendingChanges)
-                TlpSettingsService.discard()
-            root._quitAfterTlpMutation = false
-            Qt.quit()
-        }
     }
     
     Connections {

--- a/waffleSettings.qml
+++ b/waffleSettings.qml
@@ -112,10 +112,17 @@ ApplicationWindow {
             name: Translation.tr("Shell Layout"),
             icon: "desktop",
             component: Qt.resolvedUrl("modules/waffle/settings/pages/WShellLayoutPage.qml")
+        },
+        {
+            name: Translation.tr("Battery"),
+            icon: "battery-saver",
+            component: Qt.resolvedUrl("modules/waffle/settings/pages/WTlpPage.qml")
         }
     ]
     
     property int currentPage: 0
+    property int _previousPage: 0
+    property bool _quitAfterTlpMutation: false
     property int _requestedStartPage: -1
     property bool _navigationInitialized: false
 
@@ -135,10 +142,30 @@ ApplicationWindow {
         root.tryOpenPendingSection()
     }
 
-    onCurrentPageChanged: root._persistCurrentPage()
+    onCurrentPageChanged: {
+        if (root._navigationInitialized
+                && root._previousPage === 18
+                && root.currentPage !== 18
+                && TlpSettingsService.hasPendingChanges)
+            TlpSettingsService.applyOnLeave()
+        root._previousPage = root.currentPage
+        root._persistCurrentPage()
+    }
     
     visible: true
-    onClosing: Qt.quit()
+    onClosing: close => {
+        if (root._quitAfterTlpMutation) {
+            close.accepted = false
+            return
+        }
+        if (TlpSettingsService.busy || TlpSettingsService.hasPendingChanges) {
+            close.accepted = false
+            root._quitAfterTlpMutation = true
+            TlpSettingsService.applyOnLeave()
+            return
+        }
+        Qt.quit()
+    }
     title: "Settings — iNiR"
 
     function tryOpenPendingSection(): void {
@@ -171,6 +198,19 @@ ApplicationWindow {
     Connections {
         target: Persistent
         function onReadyChanged() { root.initializeNavigation() }
+    }
+
+    Connections {
+        target: TlpSettingsService
+
+        function onMutationFinished(kind, success): void {
+            if (!root._quitAfterTlpMutation)
+                return
+            if (!success && TlpSettingsService.hasPendingChanges)
+                TlpSettingsService.discard()
+            root._quitAfterTlpMutation = false
+            Qt.quit()
+        }
     }
     
     Connections {


### PR DESCRIPTION
<!-- PRs target the `prerelease` branch (development). `main` is the stable branch users install from. -->

## Summary

Replace PowerProfilesDaemon (PPD) with TLP/tlp-pd and expose more of TLP's power-management settings through Quickshell.

The main goal is to keep the existing power profile experience while allowing deeper control over things such as CPU behavior, platform/GPU profiles, scaling governors/frequencies, disks, PCIe, USB, radio devices, and battery charge limits. Power profile switching through tlp-pd also follows AC/BAT changes automatically. Nothing related to current settings so I believe it should be safe.

The settings UI is available for both Material ii and Waffle. TLP settings are staged first and only written after pressing **Apply**, so navigating away from the page or closing Settings should not unexpectedly trigger a privileged action.

There are quite a lot of TLP options exposed right now. I don't think every option is necessarily useful for iNiR, and there are also some settings that I don't fully understand or cannot test on my hardware. Feel free to cherry-pick the useful parts, or close the PR if this approach does not fit your dotfile.

## Testing

Describe what you ran and what you observed, not just "it works".

- [x] `inir restart && inir logs`: no new errors
- [x] Exercised the exact flow that changed
- [x] Both panel families checked (if shared code changed)
  - Material ii and Waffle TLP/Battery settings were opened and exercised
  - Power profile switching works automatically when switching between AC and battery on my machine
  - Staged TLP settings require an explicit **Apply** instead of applying when leaving the page
- [x] Screenshots or a recording attached (if the change is visual)

## AI usage

Most of us use AI tools now, that's fine, just be upfront so review can
focus on the right things:

- [x] AI-assisted (tool/model: GPT-5.6 Sol)
- [x] I removed AI attributions and boilerplate (co-author trailers, "generated with" footers, narrating comments)

## Notes

1. Power/profile capabilities vary between laptop models and firmware. I have **not tested all supported hardware**, so some TLP options may behave differently or be unavailable on other machines.
2. The Polkit Agent currently appears underneath the Settings window when using Material ii. Authentication still works, and I haven't seen the same problem with Waffle.
3. Some text/component alignment in the TLP settings UI still needs polishing.
4. The privileged helper only manages iNiR-owned TLP configuration files; user/distribution TLP configuration is kept separate.
5. TLP/tlp-pd was already installed on my machine while developing and testing this PR. I have not  tested migration from a lap that is actively using PowerProfilesDaemon before installing TLP.

Closes #
