### PR TITLE
Route process launches through systemd scopes and daemon units

### DIFF
--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -17,6 +17,7 @@ Singleton {
     // Boot greeting lifecycle — singleton preserves across hot-reload so greeting shows once per session
     property bool bootGreetingOpen: false
     property bool bootGreetingDone: false
+    property bool startupLockDone: false
     property bool barOpen: true
     property bool crosshairOpen: false
     property bool sidebarLeftOpen: false

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ install-shell:
 	@find $(SHELL_INSTALL_DIR)/assets/images/mascot -maxdepth 1 -type f \( -name 'inir-mascot-*.png' -o -name 'inir-mascot-*.gif' -o -name PROMPTS.md \) -delete
 	@rm -rf $(SHELL_INSTALL_DIR)/assets/images/mascot/frames
 	@# Strip maintainer and development tooling — useless on a user's machine
-	@rm -rf $(SHELL_INSTALL_DIR)/scripts/agents $(SHELL_INSTALL_DIR)/translations/tools $(SHELL_INSTALL_DIR)/translations/l10n
+	@rm -rf $(SHELL_INSTALL_DIR)/scripts/agents $(SHELL_INSTALL_DIR)/scripts/tests $(SHELL_INSTALL_DIR)/translations/tools $(SHELL_INSTALL_DIR)/translations/l10n
 	@rm -f $(SHELL_INSTALL_DIR)/scripts/release.sh $(SHELL_INSTALL_DIR)/scripts/wiki-sync.sh $(SHELL_INSTALL_DIR)/scripts/verify-docs.sh $(SHELL_INSTALL_DIR)/scripts/qml-check.fish $(SHELL_INSTALL_DIR)/scripts/test-local-distribution.sh $(SHELL_INSTALL_DIR)/scripts/test-mascot-pack-flow.sh
 	@find $(SHELL_INSTALL_DIR)/scripts -type f \( -name "*.sh" -o -name "*.fish" -o -name "*.py" \) -exec chmod +x {} +
 	@printf '{\n  "version": "%s",\n  "commit": "manual",\n  "installed_at": "%s",\n  "installedAt": "%s",\n  "source": "make-install",\n  "repo_path": "",\n  "repoPath": "",\n  "install_mode": "package-managed",\n  "installMode": "package-managed",\n  "update_strategy": "package-manager",\n  "updateStrategy": "package-manager",\n  "package_manager": "manual",\n  "packageManager": "manual",\n  "package_name": "source-install",\n  "packageName": "source-install",\n  "package_update_hint": "sudo make install",\n  "packageUpdateHint": "sudo make install"\n}\n' "$$(cat VERSION)" "$$(date -Iseconds)" "$$(date -Iseconds)" > $(SHELL_INSTALL_DIR)/version.json

--- a/defaults/niri/config.d/70-binds.kdl
+++ b/defaults/niri/config.d/70-binds.kdl
@@ -69,7 +69,7 @@ binds {
 
     Mod+T { spawn "inir" "terminal"; }
     Mod+Return { spawn "inir" "terminal"; }
-    Super+E { spawn "nautilus"; }
+    Super+E { spawn "inir" "files"; }
     Super+W { spawn "inir" "browser"; }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -539,6 +539,39 @@ Display brightness control.
 
 ---
 
+### browser
+
+Launch the configured browser. Launches are
+routed through the shell so long-running processes are raised by `ShellExec.launch`
+inside a transient systemd scope.
+
+| Function | Description |
+|----------|-------------|
+| `open` | Open the configured browser (`apps.browser`) |
+| `openUrl <url>` | Open the configured browser with a URL |
+
+```kdl
+bind "Super+W" { spawn "inir" "browser"; }
+```
+
+---
+
+### files
+
+Launch the configured file manager. Launches are
+routed through the shell so long-running processes are raised by `ShellExec.launch`
+inside a transient systemd scope.
+
+| Function | Description |
+|----------|-------------|
+| `open` | Open the configured file manager (`apps.files`), or `nautilus` if none is set |
+
+```kdl
+bind "Super+E" { spawn "inir" "files"; }
+```
+
+---
+
 ### mpris
 
 Media player control. Automatically detects and uses YtMusic controls when active, otherwise uses the active MPRIS player.

--- a/modules/common/functions/ShellExec.qml
+++ b/modules/common/functions/ShellExec.qml
@@ -39,180 +39,278 @@ Singleton {
         return root._fishAvailable === 1
     }
 
-    function execDetachedArgs(args, description = "", workingDirectory = ""): void {
-        const argv = Array.from(args ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
-        if (argv.length === 0) return
-
-        const desc = String(description ?? "").trim()
-        const workDir = String(workingDirectory ?? "").trim()
-        // A transient scope, never a service. Launchers like zeditor and
-        // /usr/bin/code fork the real process and exit immediately; a service
-        // treats that first exit as the unit finishing and kills the rest of
-        // the cgroup, so the app dies the instant it starts. A scope lives as
-        // long as any process in it. systemd-run is exec'd rather than tested
-        // for success, because in scope mode it only returns once the app is
-        // gone and a fallback there would relaunch it.
-        const script = `
-            # Rebuild the application-facing environment from the live user
-            # session. Quickshell intentionally carries shell-only Qt scaling,
-            # rendering and optional GPU policy that must not leak into apps.
-            manager_env=""
-            if [ -x /usr/bin/systemctl ]; then
-                if [ -x /usr/bin/timeout ]; then
-                    manager_env="$(/usr/bin/timeout 1s /usr/bin/systemctl --user show-environment 2>/dev/null || true)"
-                else
-                    manager_env="$(/usr/bin/systemctl --user show-environment 2>/dev/null || true)"
-                fi
+    // Restore session environment from systemd manager before launching apps
+    readonly property string _envRestoreScript: `
+        manager_env=""
+        if [ -x /usr/bin/systemctl ]; then
+            if [ -x /usr/bin/timeout ]; then
+                manager_env="$(/usr/bin/timeout 1s /usr/bin/systemctl --user show-environment 2>/dev/null || true)"
+            else
+                manager_env="$(/usr/bin/systemctl --user show-environment 2>/dev/null || true)"
             fi
+        fi
 
-            manager_value() {
-                [ -n "$manager_env" ] || return 0
-                while IFS='=' read -r _key _entry_value; do
-                    [ "$_key" = "$1" ] || continue
-                    printf '%s' "$_entry_value"
-                    return 0
-                done <<< "$manager_env"
-            }
+        declare -A _mgr_map
+        if [ -n "$manager_env" ]; then
+            while IFS='=' read -r _k _v; do
+                [ -n "$_k" ] && _mgr_map["$_k"]="$_v"
+            done <<< "$manager_env"
+        fi
 
-            restore_from_manager() {
-                _name="$1"
-                _value="$(manager_value "$_name")"
-                if [ -n "$_value" ]; then
-                    export "$_name=$_value"
-                else
-                    unset "$_name"
-                fi
-            }
+        manager_value() {
+            printf '%s' "\${_mgr_map[\$1]:-}"
+        }
 
-            import_if_missing() {
-                _name="$1"
-                [[ -v $_name ]] && return 0
-                _value="$(manager_value "$_name")"
-                [ -n "$_value" ] && export "$_name=$_value"
-            }
+        restore_from_manager() {
+            local _name="$1"
+            if [[ -v _mgr_map["$_name"] ]]; then
+                export "$_name=\${_mgr_map[\$_name]}"
+            else
+                unset "$_name"
+            fi
+        }
 
-            # apply_shell_scale()/apply_qt_runtime_env() own these for iNiR's
-            # process only. Restore the user's session values for launched apps.
-            for _var in \
-                QT_SCALE_FACTOR QT_SCALE_FACTOR_ROUNDING_POLICY \
-                QT_WAYLAND_FORCE_DPI QT_FONT_DPI QT_AUTO_SCREEN_SCALE_FACTOR \
-                QT_SCREEN_SCALE_FACTORS GDK_SCALE GDK_DPI_SCALE \
-                QSG_ATLAS_WIDTH QSG_ATLAS_HEIGHT QT_LOGGING_RULES \
-                QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE QS_DISABLE_CRASH_HANDLER \
-                ELECTRON_OZONE_PLATFORM_HINT; do
-                restore_from_manager "$_var"
+        import_if_missing() {
+            local _name="$1"
+            [[ -v $_name ]] && return 0
+            [[ -v _mgr_map["$_name"] ]] && export "$_name=\${_mgr_map[\$_name]}"
+        }
+
+        for _var in \
+            QT_SCALE_FACTOR QT_SCALE_FACTOR_ROUNDING_POLICY \
+            QT_WAYLAND_FORCE_DPI QT_FONT_DPI QT_AUTO_SCREEN_SCALE_FACTOR \
+            QT_SCREEN_SCALE_FACTORS GDK_SCALE GDK_DPI_SCALE \
+            QSG_ATLAS_WIDTH QSG_ATLAS_HEIGHT QT_LOGGING_RULES \
+            QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE QS_DISABLE_CRASH_HANDLER; do
+            restore_from_manager "$_var"
+        done
+
+        for _var in $INIR_SHELL_GPU_POLICY_VARS; do
+            restore_from_manager "$_var"
+        done
+        unset INIR_SHELL_GPU_POLICY_VARS INIR_DISABLE_HOT_RELOAD
+
+        for _var in \
+            XDG_RUNTIME_DIR XDG_SESSION_TYPE XDG_CURRENT_DESKTOP \
+            XDG_SESSION_DESKTOP DESKTOP_SESSION XCURSOR_THEME XCURSOR_SIZE \
+            LANG LC_ALL XDG_MENU_PREFIX GDK_BACKEND XAUTHORITY \
+            DBUS_SESSION_BUS_ADDRESS SSH_AUTH_SOCK ELECTRON_OZONE_PLATFORM_HINT; do
+            import_if_missing "$_var"
+        done
+        [ -n "$WAYLAND_DISPLAY" ] && [ -z "$ELECTRON_OZONE_PLATFORM_HINT" ] && export ELECTRON_OZONE_PLATFORM_HINT=auto
+
+        _manager_path="$(manager_value PATH)"
+        if [ -n "$_manager_path" ]; then
+            _merged_path="$_manager_path"
+            IFS=: read -r -a _path_parts <<< "$PATH"
+            for _path_dir in "\${_path_parts[@]}"; do
+                [ -n "$_path_dir" ] || continue
+                case ":$_merged_path:" in
+                    *":$_path_dir:"*) ;;
+                    *) _merged_path="$_merged_path:$_path_dir" ;;
+                esac
             done
+            export PATH="$_merged_path"
+        fi
 
-            # The launcher marks exactly which GPU variables iNiR injected for
-            # the shell. Restore user values (or unset them) before games/apps.
-            for _var in $INIR_SHELL_GPU_POLICY_VARS; do
-                restore_from_manager "$_var"
-            done
-            unset INIR_SHELL_GPU_POLICY_VARS INIR_DISABLE_HOT_RELOAD
-
-            # If startup raced the compositor/session import, fill in the late
-            # variables now rather than keeping Quickshell's frozen snapshot.
-            for _var in \
-                XDG_RUNTIME_DIR XDG_SESSION_TYPE XDG_CURRENT_DESKTOP \
-                XDG_SESSION_DESKTOP DESKTOP_SESSION XCURSOR_THEME XCURSOR_SIZE \
-                LANG LC_ALL XDG_MENU_PREFIX GDK_BACKEND XAUTHORITY \
-                DBUS_SESSION_BUS_ADDRESS SSH_AUTH_SOCK; do
-                import_if_missing "$_var"
-            done
-
-            _manager_path="$(manager_value PATH)"
-            if [ -n "$_manager_path" ]; then
-                _merged_path="$_manager_path"
-                IFS=: read -r -a _path_parts <<< "$PATH"
-                for _path_dir in "\${_path_parts[@]}"; do
-                    [ -n "$_path_dir" ] || continue
-                    case ":$_merged_path:" in
-                        *":$_path_dir:"*) ;;
-                        *) _merged_path="$_merged_path:$_path_dir" ;;
+        valid_display() {
+            local _disp="$1"
+            [ -n "$_disp" ] || return 1
+            case "$_disp" in
+                :*)
+                    local _xnum="\${_disp%%.*}"
+                    _xnum="\${_xnum#:}"
+                    case "$_xnum" in
+                        ''|*[!0-9]*) return 1 ;;
                     esac
-                done
-                export PATH="$_merged_path"
-            fi
+                    local _xsock="/tmp/.X11-unix/X$_xnum"
+                    [ -S "$_xsock" ] && [ -O "$_xsock" ]
+                    ;;
+                *) return 0 ;;
+            esac
+        }
 
-            # DISPLAY is not required to be :0. Display managers often own :0
-            # while the user's Niri/xwayland-satellite session owns :1 or later.
-            valid_display() {
-                _display="$1"
-                [ -n "$_display" ] || return 1
-                case "$_display" in
-                    :*)
-                        _xnum="$(printf '%s' "$_display" | cut -d. -f1 | sed 's/^://')"
-                        case "$_xnum" in
-                            ''|*[!0-9]*) return 1 ;;
-                        esac
-                        _xsock="/tmp/.X11-unix/X$_xnum"
-                        [ -S "$_xsock" ] || return 1
-                        [ "$(stat -c %u "$_xsock" 2>/dev/null)" = "$(id -u)" ] || return 1
-                        return 0
-                        ;;
-                    *) return 0 ;;
-                esac
-            }
+        _manager_display="$(manager_value DISPLAY)"
+        if valid_display "$_manager_display"; then
+            export DISPLAY="$_manager_display"
+        elif ! valid_display "$DISPLAY"; then
+            unset DISPLAY
+            for _x in /tmp/.X11-unix/X*; do
+                [ -S "$_x" ] && [ -O "$_x" ] || continue
+                local _xfile="\${_x##*/}"
+                export DISPLAY=":\${_xfile#X}"
+                break
+            done
+        fi
 
-            _manager_display="$(manager_value DISPLAY)"
-            if valid_display "$_manager_display"; then
-                export DISPLAY="$_manager_display"
-            elif ! valid_display "$DISPLAY"; then
-                unset DISPLAY
-                for _x in /tmp/.X11-unix/X*; do
-                    [ -S "$_x" ] || continue
-                    [ "$(stat -c %u "$_x" 2>/dev/null)" = "$(id -u)" ] || continue
-                    export DISPLAY=":$(basename "$_x" | sed 's/^X//')"
-                    break
-                done
-            fi
+        valid_wayland_display() {
+            local _wdisp="$1"
+            [ -n "$_wdisp" ] || return 1
+            case "$_wdisp" in
+                /*) [ -S "$_wdisp" ] ;;
+                *) [ -n "$XDG_RUNTIME_DIR" ] && [ -S "$XDG_RUNTIME_DIR/$_wdisp" ] ;;
+            esac
+        }
 
-            valid_wayland_display() {
-                _wayland_display="$1"
-                [ -n "$_wayland_display" ] || return 1
-                case "$_wayland_display" in
-                    /*) [ -S "$_wayland_display" ] ;;
-                    *) [ -n "$XDG_RUNTIME_DIR" ] && [ -S "$XDG_RUNTIME_DIR/$_wayland_display" ] ;;
-                esac
-            }
+        _manager_wayland="$(manager_value WAYLAND_DISPLAY)"
+        if valid_wayland_display "$_manager_wayland"; then
+            export WAYLAND_DISPLAY="$_manager_wayland"
+        elif ! valid_wayland_display "$WAYLAND_DISPLAY"; then
+            unset WAYLAND_DISPLAY
+            for _wayland in "$XDG_RUNTIME_DIR"/wayland-[0-9]*; do
+                [ -S "$_wayland" ] || continue
+                export WAYLAND_DISPLAY="\${_wayland##*/}"
+                break
+            done
+        fi
 
-            _manager_wayland="$(manager_value WAYLAND_DISPLAY)"
-            if valid_wayland_display "$_manager_wayland"; then
-                export WAYLAND_DISPLAY="$_manager_wayland"
-            elif ! valid_wayland_display "$WAYLAND_DISPLAY"; then
-                unset WAYLAND_DISPLAY
-                for _wayland in "$XDG_RUNTIME_DIR"/wayland-[0-9]*; do
-                    [ -S "$_wayland" ] || continue
-                    export WAYLAND_DISPLAY="$(basename "$_wayland")"
-                    break
-                done
-            fi
+        import_if_missing _JAVA_AWT_WM_NONREPARENTING
+        if valid_display "$DISPLAY" && [ -z "$_JAVA_AWT_WM_NONREPARENTING" ]; then
+            export _JAVA_AWT_WM_NONREPARENTING=1
+        fi
+    `
 
-            # Recommended by xwayland-satellite for Java/AWT clients. Keep an
-            # explicit user value authoritative.
-            import_if_missing _JAVA_AWT_WM_NONREPARENTING
-            if valid_display "$DISPLAY" && [ -z "$_JAVA_AWT_WM_NONREPARENTING" ]; then
-                export _JAVA_AWT_WM_NONREPARENTING=1
-            fi
+    // Run command in a transient systemd user scope
+    function launch(opts: var): void {
+        const program = String(opts?.program ?? "").trim()
+        const args = Array.from(opts?.args ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
+        if (program.length === 0) return
+
+        const scopeName = String(opts?.scope ?? "app").trim().toLowerCase().replace(/[^a-z0-9_.-]/g, "-")
+        const description = String(opts?.description ?? "").trim()
+        const desc = description.length > 0 ? description : scopeName
+        const workDir = String(opts?.workingDirectory ?? "").trim()
+        const unitPrefix = `inir-${scopeName}`
+
+        const script = root._envRestoreScript + `
             systemd_run="$1"
             desc="$2"
-            workdir="$3"
-            shift 3
+            unit_prefix="$3"
+            workdir="$4"
+            shift 4
+            unit="\${unit_prefix}-\$\$"
 
             if [ -n "$workdir" ] && [ -d "$workdir" ]; then
                 cd -- "$workdir" || true
             fi
 
             if [ -x "$systemd_run" ] && [ -S "$XDG_RUNTIME_DIR/systemd/private" ]; then
-                if [ -n "$desc" ]; then
-                    exec "$systemd_run" --user --quiet --collect --same-dir --scope \
-                        --description="$desc" -- "$@"
-                fi
-                exec "$systemd_run" --user --quiet --collect --same-dir --scope -- "$@"
+                exec "$systemd_run" --user --quiet --collect --same-dir --scope \
+                    --unit="$unit" --description="$desc" -- "$@"
             fi
             exec "$@"
         `
-        Quickshell.execDetached([root.bashPath, "-lc", script, "inir-scope", root.systemdRunPath, desc, workDir, ...argv])
+        Quickshell.execDetached([root.bashPath, "-c", script, "inir-scope", root.systemdRunPath, desc, unitPrefix, workDir, program, ...args])
+        console.debug(`[launcher] scope=${scopeName} cmd=${program} args=[${args.join(", ")}]`)
+    }
+
+    // Run foreground daemon in a transient systemd service
+    function launchDaemon(opts: var): void {
+        const program = String(opts?.program ?? "").trim()
+        const args = Array.from(opts?.args ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
+        if (program.length === 0) return
+
+        const scopeName = String(opts?.scope ?? "app").trim().toLowerCase().replace(/[^a-z0-9_.-]/g, "-")
+        const description = String(opts?.description ?? "").trim()
+        const desc = description.length > 0 ? description : scopeName
+        const restart = String(opts?.restart ?? "").trim()
+        const ifActive = String(opts?.ifActive ?? "replace").trim() || "replace"
+        const unitName = `inir-${scopeName}`
+
+        const script = root._envRestoreScript + `
+            systemd_run="$1"; desc="$2"; unit="$3"; restart_prop="$4"; if_active="$5"; program="$6"; shift 6
+
+            if [[ "$program" = /* ]]; then
+                bin_path="$program"
+            else
+                bin_path="$(type -P "$program" 2>/dev/null || command -v "$program" 2>/dev/null || true)"
+            fi
+
+            if [ -z "$bin_path" ] || [ ! -x "$bin_path" ]; then
+                echo "[launcher] binary '$program' not found or not executable" >&2
+                exit 127
+            fi
+
+            if ! command -v systemctl >/dev/null 2>&1 || ! command -v "$systemd_run" >/dev/null 2>&1 || [ ! -S "$XDG_RUNTIME_DIR/systemd/private" ]; then
+                exec "$bin_path" "$@"
+            fi
+
+            if systemctl --user is-active --quiet "$unit" 2>/dev/null; then
+                if [ "$if_active" = "reuse" ]; then
+                    exit 0
+                fi
+                systemctl --user stop "$unit" >/dev/null 2>&1 || true
+            fi
+
+            # Clear failed unit state
+            systemctl --user reset-failed "$unit" >/dev/null 2>&1 || true
+
+            extra_args=(
+                -E "PATH=$PATH"
+                -E "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+                -E "DISPLAY=$DISPLAY"
+                -E "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+            )
+            if [ -n "$restart_prop" ]; then
+                extra_args+=(--property="Restart=$restart_prop")
+            fi
+
+            output=$("$systemd_run" --user --quiet --collect --unit="$unit" --description="$desc" \
+                    "\${extra_args[@]}" -- "$bin_path" "$@" 2>&1)
+            status=$?
+
+            if [ $status -eq 0 ]; then
+                exit 0
+            fi
+
+            if systemctl --user is-active --quiet "$unit" 2>/dev/null; then
+                exit 0
+            fi
+
+            echo "[launcher] systemd-run failed to start service $unit: $output" >&2
+            exit 1
+        `
+        Quickshell.execDetached([root.bashPath, "-c", script, "inir-daemon", root.systemdRunPath, desc, unitName, restart, ifActive, program, ...args])
+        console.debug(`[launcher] daemon=${scopeName} cmd=${program} args=[${args.join(", ")}]`)
+    }
+
+    readonly property var _privilegedGuiTable: [
+        { basename: "gparted", wrap: true, injectQt5: false, prefix: false },
+        { basename: "ventoygui", wrap: true, injectQt5: true, prefix: true }
+    ]
+
+    function privilegedGuiArgv(command: var): var {
+        const argv = Array.from(command ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
+        if (argv.length === 0) return argv
+        const base = argv[0].split("/").pop().toLowerCase()
+        let match = null
+        for (let i = 0; i < root._privilegedGuiTable.length; i++) {
+            const row = root._privilegedGuiTable[i]
+            if (base === row.basename || (row.prefix && base.startsWith(row.basename + "."))) {
+                match = row
+                break
+            }
+        }
+        if (!match || !match.wrap) return argv
+        let graphical = argv
+        if (match.injectQt5) {
+            const hasFrontend = argv.slice(1).some(arg => /^--(gtk[234]|qt[456])$/.test(arg.toLowerCase()))
+            if (!hasFrontend)
+                graphical = [argv[0], "--qt5", ...argv.slice(1)]
+        }
+        return [`${Directories.scriptsPath}/launch-privileged-gui.sh`, ...graphical]
+    }
+
+    function execDetachedArgs(args, description = "", workingDirectory = ""): void {
+        const argv = Array.from(args ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
+        if (argv.length === 0) return
+        root.launch({
+            program: argv[0],
+            args: argv.slice(1),
+            scope: "app",
+            description,
+            workingDirectory
+        })
     }
 
     function execCmd(cmd: string, workingDirectory = ""): void {
@@ -220,31 +318,31 @@ Singleton {
         if (c.length === 0) return
 
         if (supportsFish()) {
-            root.execDetachedArgs([root.fishPath, "-c", c], "", workingDirectory)
+            root.launch({ program: root.fishPath, args: ["-c", c], scope: "app", workingDirectory })
             return
         }
 
-        root.execDetachedArgs([root.bashPath, "-lc", c], "", workingDirectory)
+        root.launch({ program: root.bashPath, args: ["-lc", c], scope: "app", workingDirectory })
     }
 
     function execFishOrBashOneLiner(fishCmd: string, bashCmd: string): void {
         const f = String(fishCmd ?? "").trim()
         const b = String(bashCmd ?? "").trim()
+        const useFish = supportsFish()
+        const cmd = useFish ? f : b
+        if (cmd.length === 0) return
 
-        if (supportsFish()) {
-            if (f.length === 0) return
-            root.execDetachedArgs([root.fishPath, "-c", f])
-            return
-        }
-
-        if (b.length === 0) return
-        root.execDetachedArgs([root.bashPath, "-lc", b])
+        root.launch({
+            program: useFish ? root.fishPath : root.bashPath,
+            args: [useFish ? "-c" : "-lc", cmd],
+            scope: "app"
+        })
     }
 
     function launchDesktopEntry(desktopId: string, description = ""): bool {
         const id = String(desktopId ?? "").trim().replace(/\.desktop$/, "")
         if (id.length === 0) return false
-        root.execDetachedArgs([root.gtkLaunchPath, id], description.length > 0 ? description : `Launch ${id}`)
+        root.launch({ program: root.gtkLaunchPath, args: [id], scope: "app", description: description.length > 0 ? description : `Launch ${id}` })
         return true
     }
 

--- a/modules/ii/overlay/recorder/Recorder.qml
+++ b/modules/ii/overlay/recorder/Recorder.qml
@@ -234,7 +234,12 @@ StyledOverlayWidget {
                     Behavior on scale { enabled: Appearance.animationsEnabled; NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Appearance.animation.elementMoveFast.type; easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve } }
                     onClicked: {
                         GlobalStates.overlayOpen = false;
-                        Quickshell.execDetached([Directories.recordScriptPath, "--fullscreen", "--sound"]);
+                        ShellExec.launch({
+                            program: Directories.recordScriptPath,
+                            args: ["--fullscreen", "--sound"],
+                            scope: "record",
+                            description: "Screen recorder"
+                        });
                         RecorderStatus.scheduleQuickCheck();
                     }
                 }
@@ -250,7 +255,12 @@ StyledOverlayWidget {
                     Behavior on opacity { enabled: Appearance.animationsEnabled; NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Appearance.animation.elementMoveFast.type; easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve } }
                     Behavior on scale { enabled: Appearance.animationsEnabled; NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Appearance.animation.elementMoveFast.type; easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve } }
                     onClicked: {
-                        Quickshell.execDetached([Directories.recordScriptPath, "--stop"]);
+                        ShellExec.launch({
+                            program: Directories.recordScriptPath,
+                            args: ["--stop"],
+                            scope: "record",
+                            description: "Stop screen recorder"
+                        });
                         RecorderStatus.scheduleQuickCheck();
                     }
                 }

--- a/modules/lock/Lock.qml
+++ b/modules/lock/Lock.qml
@@ -33,11 +33,7 @@ Scope {
         }
     }
     function unlockKeyring() {
-        // Note: unlock.sh is a bash script, so we run it directly
         unlockKeyringProc.exec({
-            environment: ({
-                "UNLOCK_PASSWORD": lockContext.currentText
-            }),
             command: ["/usr/bin/bash", Quickshell.shellPath("scripts/keyring/unlock.sh")]
         })
     }
@@ -47,15 +43,18 @@ Scope {
     // Fallback lock screen when QS lock fails
     function useFallbackLock(): void {
         console.warn("[Lock] Activating fallback lock screen")
-        // Release QS lock first
         GlobalStates.screenLocked = false
-        // Try swaylock first (works on both Niri and Hyprland), then hyprlock
-        // Using shell to check existence and run
-        Quickshell.execDetached(["/usr/bin/bash", "-c", 
-            "command -v swaylock && exec swaylock -f -c 1a1a2e || " +
-            "command -v hyprlock && exec hyprlock || " +
-            "notify-send -u critical 'Lock Failed' 'Install swaylock or hyprlock as fallback'"
-        ])
+        ShellExec.launch({
+            program: ShellExec.bashPath,
+            args: ["-c",
+                "pidof swaylock >/dev/null && exit 0; pidof hyprlock >/dev/null && exit 0; " +
+                "command -v swaylock >/dev/null && exec swaylock -f -c 1a1a2e; " +
+                "command -v hyprlock >/dev/null && exec hyprlock; " +
+                "notify-send -u critical 'Lock Failed' 'Install swaylock or hyprlock as fallback'"
+            ],
+            scope: "lock",
+            description: "Fallback lock screen"
+        })
     }
     
     function saveWindowPositionAndTile() {
@@ -300,7 +299,7 @@ Scope {
 
         function activate(): void {
             if (Config.options?.lock?.useHyprlock ?? false) {
-                Quickshell.execDetached(["/usr/bin/bash", "-lc", "/usr/bin/pidof hyprlock || /usr/bin/hyprlock"]);
+                ShellExec.launch({ program: ShellExec.bashPath, args: ["-lc", "/usr/bin/pidof hyprlock || /usr/bin/hyprlock"], scope: "lock", description: "Lock screen (hyprlock)" });
                 return;
             }
             if (GlobalStates.screenLocked || root._lockActivating)
@@ -339,7 +338,7 @@ Scope {
 
                 onPressed: {
                     if (Config.options?.lock?.useHyprlock ?? false) {
-                        Quickshell.execDetached(["/usr/bin/bash", "-lc", "/usr/bin/pidof hyprlock || /usr/bin/hyprlock"]);
+                        ShellExec.launch({ program: ShellExec.bashPath, args: ["-lc", "/usr/bin/pidof hyprlock || /usr/bin/hyprlock"], scope: "lock", description: "Lock screen (hyprlock)" });
                         return;
                     }
                     if (!GlobalStates.screenLocked && !root._lockActivating)
@@ -359,14 +358,16 @@ Scope {
     }
 
     function initIfReady() {
-        if (!Config.ready || !Persistent.ready) return;
-        if ((Config.options?.lock?.launchOnStartup ?? false) && Persistent.isNewHyprlandInstance) {
-            // Launch lock screen on startup
-            if (CompositorService.isHyprland) {
-                Hyprland.dispatch("global quickshell:lock")
-            } else {
-                if (!GlobalStates.screenLocked && !root._lockActivating)
-                    lockActivateDelay.restart();
+        if (!Config.ready || !Persistent.ready || GlobalStates.startupLockDone)
+            return;
+
+        GlobalStates.startupLockDone = true;
+
+        if (Config.options?.lock?.launchOnStartup ?? false) {
+            if (Config.options?.lock?.useHyprlock ?? false) {
+                ShellExec.launch({ program: ShellExec.bashPath, args: ["-lc", "/usr/bin/pidof hyprlock || /usr/bin/hyprlock"], scope: "lock", description: "Lock screen (hyprlock)" });
+            } else if (!GlobalStates.screenLocked && !root._lockActivating) {
+                lockActivateDelay.restart();
             }
         } else {
             KeyringStorage.fetchKeyringData();

--- a/modules/pill/PillRecorder.qml
+++ b/modules/pill/PillRecorder.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import qs.services
 import qs.modules.common
+import qs.modules.common.functions
 
 /**
  * Recorder surface: start/stop screen recording from the pill. Upstream's
@@ -41,12 +42,12 @@ PillSurface {
     }
 
     function start(fullscreen) {
-        const args = ["/usr/bin/bash", Directories.recordScriptPath];
+        const args = [Directories.recordScriptPath];
         if (fullscreen)
             args.push("--fullscreen");
         if (root.withSound)
             args.push("--sound");
-        Quickshell.execDetached(args);
+        ShellExec.launch({ program: ShellExec.bashPath, args, scope: "record", description: "Record " + (fullscreen ? "screen" : "region") });
         RecorderStatus.scheduleQuickCheck();
         // Region capture hands the screen to slurp; the pill must get out of
         // the way either way.
@@ -54,7 +55,7 @@ PillSurface {
     }
 
     function stop() {
-        Quickshell.execDetached(["/usr/bin/bash", Directories.recordScriptPath, "--stop"]);
+        ShellExec.launch({ program: ShellExec.bashPath, args: [Directories.recordScriptPath, "--stop"], scope: "record", description: "Stop recording" });
         RecorderStatus.scheduleQuickCheck();
     }
 

--- a/modules/regionSelector/RegionSelection.qml
+++ b/modules/regionSelector/RegionSelection.qml
@@ -387,11 +387,13 @@ PanelWindow {
                 snipProc.command = ["/usr/bin/bash", "-c", `${cropInPlace} && /usr/bin/tesseract '${StringUtils.shellSingleQuoteEscape(root.screenshotPath)}' stdout -l $(/usr/bin/tesseract --list-langs | /usr/bin/awk 'NR>1{print $1}' | /usr/bin/tr '\\n' '+' | /usr/bin/sed 's/\\+$/\\n/') | tee >(/usr/bin/wl-copy --primary) | /usr/bin/wl-copy && ${cleanup} && /usr/bin/notify-send "Text recognized" "OCR text copied to clipboard" -a "OCR" -i edit-find -t 3000`]
                 break;
             case RegionSelection.SnipAction.Record:
-                snipProc.command = ["/usr/bin/bash", "-c", `${Directories.recordScriptPath} --region '${slurpRegion}'`]
-                break;
+                ShellExec.launch({ program: ShellExec.bashPath, args: [Directories.recordScriptPath, "--region", slurpRegion], scope: "record", description: "Record region" });
+                root.dismiss();
+                return;
             case RegionSelection.SnipAction.RecordWithSound:
-                snipProc.command = ["/usr/bin/bash", "-c", `${Directories.recordScriptPath} --region '${slurpRegion}' --sound`]
-                break;
+                ShellExec.launch({ program: ShellExec.bashPath, args: [Directories.recordScriptPath, "--region", slurpRegion, "--sound"], scope: "record", description: "Record region with sound" });
+                root.dismiss();
+                return;
             default:
                 root.dismiss();
                 return;

--- a/modules/waffle/startMenu/SearchResults.qml
+++ b/modules/waffle/startMenu/SearchResults.qml
@@ -192,7 +192,7 @@ RowLayout {
                             iconName: isAppEntry ? "open_in_new" : "keyboard_return",
                             iconType: LauncherSearchResult.IconType.Material,
                             execute: () => {
-                                resultPreview.entry?.execute();
+                                AppSearch.launchEntry(resultPreview.entry);
                             }
                         }),
                         ...(isAppEntry ? [
@@ -218,7 +218,14 @@ RowLayout {
                     implicitHeight: 32
                     icon.name: modelData.iconName
                     text: modelData.name
-                    onClicked: modelData.execute();
+                    onClicked: {
+                        const actionCommand = Array.from(modelData.command ?? []).filter(arg => String(arg ?? "").length > 0)
+                        if (actionCommand.length > 0) {
+                            AppSearch.launchDesktopAction(modelData)
+                        } else {
+                            modelData.execute();
+                        }
+                    }
 
                     contentItem: RowLayout {
                         spacing: 8

--- a/modules/waffle/startMenu/WSearchResultButton.qml
+++ b/modules/waffle/startMenu/WSearchResultButton.qml
@@ -27,7 +27,7 @@ WChoiceButton {
 
     function execute() {
         GlobalStates.searchOpen = false;
-        root.entry?.execute?.();
+        AppSearch.launchEntry(root.entry);
     }
 
     contentItem: RowLayout {

--- a/scripts/inir
+++ b/scripts/inir
@@ -11,7 +11,7 @@ max_polls="${INIR_RESTART_MAX_POLLS:-60}"
 max_rapid_restarts="${INIR_MAX_RAPID_RESTARTS:-5}"
 restart_window="${INIR_RESTART_WINDOW:-60}"
 systemd_user_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 launcher_root="$(cd -- "$script_dir/.." 2>/dev/null && pwd || printf '%s' "$script_dir")"
 
 source_config_path_helper() {
@@ -37,6 +37,28 @@ source_config_path_helper() {
 }
 
 source_config_path_helper
+
+source_exec_scoped_helper() {
+    local helper_candidates=(
+        "$script_dir/lib/exec-scoped.sh"
+        "$launcher_root/share/quickshell/inir/scripts/lib/exec-scoped.sh"
+        "$user_config_dir/scripts/lib/exec-scoped.sh"
+        "$system_config_dir/scripts/lib/exec-scoped.sh"
+        "$fallback_system_config_dir/scripts/lib/exec-scoped.sh"
+    )
+
+    local helper_path
+    for helper_path in "${helper_candidates[@]}"; do
+        if [[ -f "$helper_path" ]]; then
+            # shellcheck source=/dev/null
+            source "$helper_path"
+            return
+        fi
+    done
+
+    echo "Unable to locate exec-scoped helper (scripts/lib/exec-scoped.sh)." >&2
+    exit 1
+}
 
 _ipc_registry_loaded=false
 
@@ -102,7 +124,7 @@ EOF
 
     cat <<'EOF'
 Runtime:
-  start, stop, run, restart, kill, terminal, browser, close-window, colorpicker
+  start, stop, run, restart, kill, terminal, browser, files, close-window, colorpicker
 
 Maintenance (delegates to setup):
   install, reinstall, update, doctor, status, migrate, rollback, my-changes, uninstall
@@ -3475,36 +3497,51 @@ EOF
 }
 
 launch_configured_browser() {
-    local config_file
-    config_file="$(inir_config_file)"
-    local browser=""
-
-    if [[ -f "$config_file" ]]; then
-        if command -v jq >/dev/null 2>&1; then
-            browser="$(jq -r '.apps.browser // empty' "$config_file" 2>/dev/null || true)"
-        else
-            browser="$(sed -n 's/.*"browser"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$config_file" | head -1)"
-        fi
-    fi
-
+    local browser
+    browser="$(_read_apps_slot browser)"
     browser="${browser:-xdg-open}"
 
     if command -v "$browser" >/dev/null 2>&1; then
-        if [[ $# -gt 0 ]]; then
-            exec "$browser" "$@"
-        fi
-        exec "$browser"
+        exec_scoped "$browser" "$@"
     fi
 
     if command -v xdg-open >/dev/null 2>&1; then
-        if [[ $# -gt 0 ]]; then
-            exec xdg-open "$@"
-        fi
-        exec xdg-open "https://"
+        exec_scoped xdg-open "${@:-https://}"
     fi
 
     echo "No browser launcher found" >&2
     exit 1
+}
+
+launch_configured_files() {
+    local fm
+    fm="$(_read_apps_slot files)"
+    fm="${fm:-nautilus}"
+
+    if command -v "$fm" >/dev/null 2>&1; then
+        exec_scoped "$fm" "$@"
+    fi
+
+    local fallback
+    for fallback in nautilus dolphin thunar nemo pcmanfm; do
+        if command -v "$fallback" >/dev/null 2>&1; then
+            exec_scoped "$fallback" "$@"
+        fi
+    done
+
+    echo "No file manager found" >&2
+    exit 1
+}
+
+# Exec command inside transient user scope
+exec_scoped() {
+    if ! declare -F inir_exec_scoped >/dev/null 2>&1; then
+        source_exec_scoped_helper
+    fi
+    local bin_name unit_prefix
+    bin_name="$(basename "$1")"
+    unit_prefix="inir-${bin_name//[^a-zA-Z0-9_:.-]/-}"
+    inir_exec_scoped "$unit_prefix" "$@"
 }
 
 parse_config_flag() {
@@ -3762,6 +3799,28 @@ case "$command_name" in
         done
         launch_configured_browser "$@"
         ;;
+    files)
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -c|--config)
+                    parse_config_flag "$@"
+                    shift 2
+                    ;;
+                --)
+                    shift
+                    break
+                    ;;
+                -h|--help)
+                    echo "Usage: inir files [-c PATH] [path]" >&2
+                    exit 0
+                    ;;
+                *)
+                    break
+                    ;;
+            esac
+        done
+        launch_configured_files "$@"
+        ;;
     close-window)
         while [[ $# -gt 0 ]]; do
             case "$1" in
@@ -3817,13 +3876,16 @@ case "$command_name" in
                     usage
                     exit 0
                     ;;
+                call)
+                    shift
+                    ;;
                 *)
                     break
                     ;;
             esac
         done
         if [[ $# -lt 2 ]]; then
-            echo "Usage: inir ipc <target> <function> [args...]" >&2
+            echo "Usage: inir ipc [call] <target> <function> [args...]" >&2
             exit 1
         fi
         resolve_config_dir

--- a/scripts/keyring/unlock.sh
+++ b/scripts/keyring/unlock.sh
@@ -1,23 +1,30 @@
 #!/usr/bin/env bash
-# Based on https://unix.stackexchange.com/a/602935
+# Unlock login keyring via native prompt
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Skip if already unlocked
-if "${SCRIPT_DIR}/is_unlocked.sh"; then
+if "${SCRIPT_DIR}/is_unlocked.sh" 2>/dev/null; then
+    exit 0
+fi
+
+if ! command -v secret-tool >/dev/null 2>&1; then
     exit 1
 fi
 
-# Prompt for password if not provided
-if [[ -z "${UNLOCK_PASSWORD}" ]]; then
-    echo -n 'Login password: ' >&2
-    read -s UNLOCK_PASSWORD || return
-fi
+pkill -u "$(whoami)" -x gnome-keyring-d 2>/dev/null || true
+systemctl --user start gnome-keyring-daemon.socket gnome-keyring-daemon.service 2>/dev/null || true
+sleep 1
 
-# Unlock
-killall -q -u "$(whoami)" gnome-keyring-daemon
-eval $(echo -n "${UNLOCK_PASSWORD}" \
-           | gnome-keyring-daemon --daemonize --login \
-           | sed -e 's/^/export /')
-unset UNLOCK_PASSWORD
-echo '' >&2
+secret-tool search --unlock --all application inir-keyring-unlock >/dev/null 2>&1
+
+if "${SCRIPT_DIR}/is_unlocked.sh" 2>/dev/null; then
+    exit 0
+fi
+for _ in $(seq 1 5); do  # 10s grace, 2s cadence
+    if "${SCRIPT_DIR}/is_unlocked.sh" 2>/dev/null; then
+        exit 0
+    fi
+    sleep 2
+done
+echo 'Keyring unlock failed: no native prompt available or prompt dismissed' >&2
+exit 1

--- a/scripts/launch-terminal.sh
+++ b/scripts/launch-terminal.sh
@@ -5,6 +5,8 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/config-path.sh
 source "$SCRIPT_DIR/lib/config-path.sh"
+# shellcheck source=scripts/lib/exec-scoped.sh
+source "$SCRIPT_DIR/lib/exec-scoped.sh"
 
 CONFIG_FILE="$(inir_config_file)"
 
@@ -16,14 +18,41 @@ fi
 
 TERMINAL="${TERMINAL:-kitty}"
 
+exec_terminal_scoped() {
+    inir_exec_scoped "inir-terminal" "$@"
+}
+
+launch_term() {
+    local term="$1"
+    shift
+    if [[ $# -eq 0 ]]; then
+        exec_terminal_scoped "$term"
+    fi
+
+    case "$1" in
+        -e|start|--|-x)
+            exec_terminal_scoped "$term" "$@"
+            ;;
+    esac
+
+    case "$term" in
+        wezterm)
+            exec_terminal_scoped "$term" start --always-new-process -- "$@"
+            ;;
+        *)
+            exec_terminal_scoped "$term" -e "$@"
+            ;;
+    esac
+}
+
 if command -v "$TERMINAL" &>/dev/null; then
-    exec "$TERMINAL" "$@"
+    launch_term "$TERMINAL" "$@"
 fi
 
 # Fallback chain: project default first, then popular alternatives
 for fallback in kitty foot ghostty alacritty wezterm konsole xterm; do
     if command -v "$fallback" &>/dev/null; then
-        exec "$fallback" "$@"
+        launch_term "$fallback" "$@"
     fi
 done
 

--- a/scripts/lib/check-launch-policy.py
+++ b/scripts/lib/check-launch-policy.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Enforce the process-launch policy: no long-running process may bypass ShellExec.
+
+Scans QML for raw Quickshell.execDetached() calls that reference binaries or
+identifiers the shell must only launch through ShellExec.launch()/launchDaemon()
+(transient systemd scopes/services so they survive shell death/restart).
+
+Usage:
+    python3 scripts/lib/check-launch-policy.py            # scan
+    python3 scripts/lib/check-launch-policy.py --check    # accepted alias (same scan)
+
+Exit codes: 0 = pass, 1 = policy violations, 2 = error (bad args / IO).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+QML_DIRS = [
+    REPO_ROOT / "modules",
+    REPO_ROOT / "services",
+    REPO_ROOT / "GlobalStates.qml",
+    REPO_ROOT / "shell.qml",
+    REPO_ROOT / "ShellIiPanels.qml",
+    REPO_ROOT / "ShellWafflePanels.qml",
+]
+SKIP_FILES = {REPO_ROOT / "modules" / "common" / "functions" / "ShellExec.qml"}
+
+_RE_EXECDETACHED = re.compile(r"Quickshell\.execDetached\s*\(")
+
+SIGNATURES = {
+    "swaylock": "lock screen must go through ShellExec.launch (scope \"lock\")",
+    "hyprlock": "lock screen must go through ShellExec.launch (scope \"lock\")",
+    "wlsunset": "night light daemon must go through ShellExec.launchDaemon (scope \"wlsunset\")",
+    "hyprsunset": "night light daemon must go through ShellExec.launchDaemon (scope \"hyprsunset\")",
+    "awww-daemon": "wallpaper daemon must go through ShellExec.launchDaemon (scope \"awww-daemon\")",
+    "awww": "wallpaper backend must go through ShellExec.launchDaemon (scope \"awww-daemon\")",
+    "easyeffects": "audio daemon must go through ShellExec.launchDaemon (scope \"easyeffects\")",
+    "com.github.wwmm.easyeffects": "flatpak audio daemon must go through ShellExec.launchDaemon (scope \"easyeffects\")",
+    "record.sh": "screen recording must go through ShellExec.launch (scope \"record\")",
+    "recordScriptPath": "screen recording must go through ShellExec.launch (scope \"record\")",
+    "wf-recorder": "screen recording must go through ShellExec.launch (scope \"record\")",
+    "gnome-keyring-daemon": "keyring daemon is owned by scripts/keyring/unlock.sh, never QML",
+}
+
+def _is_qs_p_call(tokens: set[str]) -> bool:
+    has_qs = any(tok == "qs" or tok.endswith("/qs") for tok in tokens)
+    return has_qs and "-p" in tokens
+
+_STOP_FLAGS = ("--stop",)
+
+_RE_PROCESS_REGION_REC = re.compile(
+    r"command\s*:\s*\[[^\]]*recordScriptPath[^\]]*--region", re.S
+)
+
+_RE_UPDATE_PAYLOAD = re.compile(r'["\']-c["\']', re.S)
+
+_ALLOW_MARKER_RE = re.compile(r"//\s*launch-policy:\s*allow\b")
+
+_RE_LAUNCHDAEMON_DEF = re.compile(r"function\s+launchDaemon\s*\(")
+_RE_DAEMON_UNIT_NAME = re.compile(r"inir-")
+_RE_DAEMON_PID_SUFFIX = re.compile(r"-\\\$\\\$|-\\$\\$|-\$\$")
+
+
+def iter_qml_files():
+    """Yield every QML file under the scanned dirs, in deterministic order."""
+    paths = []
+    for entry in QML_DIRS:
+        if entry.is_file():
+            paths.append(entry)
+        elif entry.is_dir():
+            paths.extend(sorted(entry.rglob("*.qml")))
+    return sorted(set(paths))
+
+
+def extract_call_args(text: str, start: int) -> str:
+    """Return the argument text of the execDetached call at `start`."""
+    depth = 1
+    in_string = None
+    i = start
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == in_string:
+                in_string = None
+        else:
+            if ch in ('"', "'", "`"):
+                in_string = ch
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return text[start:i]
+        i += 1
+    return ""
+
+
+def call_tokens(args: str) -> list[str]:
+    """Extract string literals and bare identifiers from call args."""
+    tokens = []
+    for m in re.finditer(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'', args):
+        lit = m.group(1) if m.group(1) is not None else m.group(2)
+        tokens.append(lit)
+        if "/" in lit:
+            tokens.append(lit.rsplit("/", 1)[-1])
+    tokens += re.findall(r"\b[a-zA-Z_][a-zA-Z0-9_]*\b", args)
+    return tokens
+
+
+def line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return [(line, reason)] violations for one QML file."""
+    text = path.read_text(errors="replace")
+    lines = text.splitlines()
+    violations: list[tuple[int, str]] = []
+
+    for m in _RE_EXECDETACHED.finditer(text):
+        call_line = line_of(text, m.start())
+        call_idx = call_line - 1  # 0-based
+        if call_idx >= 0 and _ALLOW_MARKER_RE.search(lines[call_idx]):
+            continue
+        if call_idx - 1 >= 0 and _ALLOW_MARKER_RE.search(lines[call_idx - 1]):
+            continue
+
+        args = extract_call_args(text, m.end())
+        if not args:
+            continue
+
+        tokens = set(call_tokens(args))
+        reasons = []
+        for sig, reason in SIGNATURES.items():
+            if sig in tokens:
+                reasons.append(reason)
+        if _is_qs_p_call(tokens):
+            reasons.append("qs -p panel must go through ShellExec.launch (scope \"killdialog\")")
+        stop_call = any(flag in tokens for flag in _STOP_FLAGS)
+        if "recordScriptPath" in tokens and stop_call:
+            reasons = [r for r in reasons if "recording must go through" not in r]
+        if _RE_UPDATE_PAYLOAD.search(args) and any("updat" in tok.lower() for tok in tokens):
+            reasons.append("update payload must go through ShellExec.launch (scope \"update\")")
+
+        for reason in reasons:
+            violations.append((call_line, reason))
+
+    for m in _RE_PROCESS_REGION_REC.finditer(text):
+        violations.append((line_of(text, m.start()),
+                           "region recording must go through ShellExec.launch (scope \"record\")"))
+
+    return violations
+
+
+def check_naming(shell_exec: Path) -> list[str]:
+    """LS-2: ShellExec.launchDaemon must exist with stable inir- naming."""
+    if not shell_exec.is_file():
+        return [f"FAIL: {shell_exec.relative_to(REPO_ROOT)} not found"]
+    text = shell_exec.read_text(errors="replace")
+    m = _RE_LAUNCHDAEMON_DEF.search(text)
+    if not m:
+        return ["ShellExec.qml lacks `function launchDaemon` (LS-2)"]
+    daemon_body = text[m.start():]
+    problems = []
+    if not _RE_DAEMON_UNIT_NAME.search(daemon_body):
+        problems.append("launchDaemon body lacks stable `inir-` unit prefix (LS-2)")
+    if _RE_DAEMON_PID_SUFFIX.search(daemon_body):
+        problems.append("launchDaemon body must NOT use a `-$$` PID suffix (LS-2)")
+    return problems
+
+
+def main():
+    check_mode = "--check" in sys.argv
+    unknown = [a for a in sys.argv[1:] if a != "--check"]
+    if unknown:
+        print(f"usage: {Path(sys.argv[0]).name} [--check]", file=sys.stderr)
+        return 2
+
+    violations: list[tuple[str, int, str]] = []
+    for path in iter_qml_files():
+        if path in SKIP_FILES:
+            continue
+        for line, reason in scan_file(path):
+            violations.append((str(path.relative_to(REPO_ROOT)), line, reason))
+
+    naming = check_naming(REPO_ROOT / "modules" / "common" / "functions" / "ShellExec.qml")
+
+    if violations or naming:
+        for rel, line, reason in sorted(violations):
+            print(f"{rel}:{line}: {reason} — route via ShellExec.launch()/launchDaemon() or add '// launch-policy: allow <reason>'")
+        for problem in naming:
+            print(f"ShellExec.qml: {problem}")
+        return 1
+
+    if check_mode:
+        print(f"OK: launch policy clean ({len(list(iter_qml_files()))} files scanned)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/config-path.sh
+++ b/scripts/lib/config-path.sh
@@ -44,6 +44,20 @@ inir_config_file() {
     printf '%s/config.json\n' "$(inir_config_dir)"
 }
 
+_read_apps_slot() {
+    local slot="${1:-}"
+    local config_file value=""
+    config_file="$(inir_config_file)"
+    if [[ -n "$slot" && -f "$config_file" ]]; then
+        if command -v jq >/dev/null 2>&1; then
+            value="$(jq -r --arg slot "$slot" '.apps[$slot] // empty' "$config_file" 2>/dev/null || true)"
+        else
+            value="$(sed -n "s/.*\"${slot}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$config_file" | head -1)"
+        fi
+    fi
+    printf '%s\n' "$value"
+}
+
 inir_version_file() {
     printf '%s/version.json\n' "$(inir_config_dir)"
 }

--- a/scripts/lib/exec-scoped.sh
+++ b/scripts/lib/exec-scoped.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Library file: intended to be sourced by other scripts.
+# Do not set shell options here; callers own execution mode.
+
+inir_exec_scoped() {
+    local prefix="${1:-inir-app}"
+    shift
+    if [[ -n "${INVOCATION_ID:-}" ]]; then
+        exec "$@"
+    fi
+    if command -v systemd-run >/dev/null 2>&1 && [[ -S "${XDG_RUNTIME_DIR:-}/systemd/private" ]]; then
+        exec systemd-run --user --quiet --collect --same-dir --scope \
+            --unit="${prefix}-$$" --description="$prefix" -- "$@"
+    fi
+    exec "$@"
+}

--- a/scripts/lib/extract-launch-daemon.py
+++ b/scripts/lib/extract-launch-daemon.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Extract the launchDaemon bash wrapper from ShellExec.qml."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_ENV_RE = re.compile(r"readonly property string _envRestoreScript:\s*`([^`]+)`")
+_DAEMON_RE = re.compile(
+    r"function launchDaemon\(opts:\s*var\):\s*void\s*\{.*?const script = root\._envRestoreScript \+\s*`([^`]+)`",
+    re.DOTALL,
+)
+
+
+def extract_launch_daemon_script(qml_path: str | Path) -> str:
+    path = Path(qml_path)
+    content = path.read_text(encoding="utf-8")
+    env_match = _ENV_RE.search(content)
+    if not env_match:
+        raise ValueError(f"_envRestoreScript not found in {path}")
+    daemon_match = _DAEMON_RE.search(content)
+    if not daemon_match:
+        raise ValueError(f"launchDaemon script not found in {path}")
+    full_script = env_match.group(1) + "\n" + daemon_match.group(1)
+    return re.sub(r"\\(\$|`)", r"\1", full_script)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("qml_path", type=Path, help="Path to ShellExec.qml")
+    args = parser.parse_args(argv)
+    try:
+        sys.stdout.write(extract_launch_daemon_script(args.qml_path))
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/ipc-registry.sh
+++ b/scripts/lib/ipc-registry.sh
@@ -2,8 +2,8 @@
 # Auto-generated from QML IpcHandler declarations + docs/IPC.md metadata.
 # Do not edit manually.
 # Regenerate: python3 scripts/lib/generate-ipc-registry.py
-# IPC.md hash: 9a5215708831bdca
-# Targets: 60
+# IPC.md hash: b3a5df40331701a0
+# Targets: 62
 
 declare -gA IPC_TARGET_DESC=(
   [ai]="Shared multi-provider AI service. It supports Gemini, OpenAI-compatible chat and Responses APIs, Mistral and Anthropic; live provider catalogs are normalized into capability-aware model records. Catalog visibility is separate from execution readiness, so public model lists remain browseable without pretending an API key exists. OpenCode Zen and Go resolve their current model lists and per-model API routes dynamically. Normal shell tools use typed actions and approval cards, while arbitrary commands are isolated in Advanced mode."
@@ -14,6 +14,7 @@ declare -gA IPC_TARGET_DESC=(
   [background]="Desktop background and widget controls."
   [bar]="Top bar visibility."
   [brightness]="Display brightness control."
+  [browser]="Launch the configured browser. Launches are routed through the shell so long-running processes are raised by \`ShellExec.launch\` inside a transient systemd scope."
   [cheatsheet]="Keyboard shortcuts reference. For when you forget what you just configured five minutes ago."
   [clipboard]="Clipboard history panel. Because Ctrl+V only remembers one thing, and that's not enough for power users."
   [cliphistService]="Clipboard history service. The backend that makes clipboard panel work. You probably don't need to call this directly."
@@ -23,6 +24,7 @@ declare -gA IPC_TARGET_DESC=(
   [customWidgets]="Custom widget management. Create, list, reload, and remove user-installed widgets from \`~/.config/inir/widgets/\`."
   [dashboard]="Centered welcome hub panel (ii family): greeting, clock, notifications, media, weather, calendar, todo, system usage and GitHub activity."
   [dev]="Development navigation for loading lazy surfaces and internal views without automating pointer or keyboard input. Destination identifiers are stable and returned as JSON by \`list\`."
+  [files]="Launch the configured file manager. Launches are routed through the shell so long-running processes are raised by \`ShellExec.launch\` inside a transient systemd scope."
   [gamemode]="Performance mode for gaming. Auto-detects fullscreen apps and disables animations/effects. Can also be toggled manually for those stubborn games that don't go fullscreen properly."
   [globalActions]="Command palette / action registry. Search and execute shell actions from scripts or keybinds."
   [keyboard]="Keyboard layout switching (Niri only). Cycles through configured keyboard layouts and queries layout info."
@@ -77,6 +79,7 @@ declare -gA IPC_TARGET_FAMILY=(
   [background]="shared"
   [bar]="shared"
   [brightness]="shared"
+  [browser]="shared"
   [cheatsheet]="shared"
   [clipboard]="shared"
   [cliphistService]="shared"
@@ -86,6 +89,7 @@ declare -gA IPC_TARGET_FAMILY=(
   [customWidgets]="waffle"
   [dashboard]="shared"
   [dev]="shared"
+  [files]="shared"
   [gamemode]="shared"
   [globalActions]="shared"
   [keyboard]="shared"
@@ -140,6 +144,7 @@ declare -gA IPC_TARGET_FUNCTIONS=(
   [background]="toggleEditMode setEditMode editState desktopItemsState focusWidget promoteWidget resetLayerOrder setWidgetEnabled clockDebugState clockDebugSetMode clockDebugSetRegion clockDebugSetLayout clockDebugRestore"
   [bar]="toggle close open"
   [brightness]="increment decrement"
+  [browser]="open openUrl"
   [cheatsheet]="toggle close open"
   [clipboard]="open close toggle"
   [cliphistService]="update"
@@ -149,6 +154,7 @@ declare -gA IPC_TARGET_FUNCTIONS=(
   [customWidgets]="reload list create remove"
   [dashboard]="toggle close open"
   [dev]="list open close current"
+  [files]="open"
   [gamemode]="toggle activate deactivate status"
   [globalActions]="run runWithArgs list search open"
   [keyboard]="switchLayout switchLayoutPrevious getCurrentLayout getLayouts"
@@ -239,6 +245,8 @@ declare -gA IPC_FUNCTION_DESC=(
   ["bar:open"]="Show bar"
   ["brightness:increment"]="Increase brightness"
   ["brightness:decrement"]="Decrease brightness"
+  ["browser:open"]="Open the configured browser (\`apps.browser\`)"
+  ["browser:openUrl"]="Open the configured browser with a URL"
   ["cheatsheet:toggle"]="Open/close cheatsheet"
   ["cheatsheet:close"]="Hide cheatsheet overlay"
   ["cheatsheet:open"]="Show cheatsheet overlay"
@@ -266,6 +274,7 @@ declare -gA IPC_FUNCTION_DESC=(
   ["dev:open"]="Open a destination by semantic identifier"
   ["dev:close"]="Close development-opened surfaces and clear the request"
   ["dev:current"]="Return the current destination or \`closed\`"
+  ["files:open"]="Open the configured file manager (\`apps.files\`), or \`nautilus\` if none is set"
   ["gamemode:toggle"]="Toggle gamemode on/off"
   ["gamemode:activate"]="Force enable gamemode"
   ["gamemode:deactivate"]="Force disable gamemode"
@@ -465,6 +474,7 @@ declare -gA IPC_FUNCTION_ARGS=(
   ["background:clockDebugSetMode"]="<style> <adaptToWallpaper>"
   ["background:clockDebugSetRegion"]="<color> <brightness> <spread>"
   ["background:clockDebugSetLayout"]="<x> <y> <quickControlsOpen>"
+  ["browser:openUrl"]="<url>"
   ["closeConfirm:triggerWindow"]="<windowId> <appId>"
   ["customWidgets:create"]="<name>"
   ["customWidgets:remove"]="<widgetId>"
@@ -502,9 +512,11 @@ declare -gA IPC_TARGET_EXAMPLE=(
   [altSwitcher]='bind "Alt+Tab" { spawn "inir" "altSwitcher" "next"; }
 bind "Alt+Shift+Tab" { spawn "inir" "altSwitcher" "previous"; }'
   [background]='bind "Super+W" { spawn "inir" "background" "toggleEditMode"; }'
+  [browser]='bind "Super+W" { spawn "inir" "browser"; }'
   [cheatsheet]='bind "Super+Slash" { spawn "inir" "cheatsheet" "toggle"; }'
   [clipboard]='bind "Super+V" repeat=false { spawn "inir" "clipboard" "toggle"; }'
   [closeConfirm]='bind "Mod+Q" repeat=false { spawn "inir" "close-window"; }'
+  [files]='bind "Super+E" { spawn "inir" "files"; }'
   [gamemode]='bind "Super+F12" { spawn "inir" "gamemode" "toggle"; }'
   [globalActions]='bind "Super+Slash" { spawn "inir" "globalActions" "open"; }
 bind "Super+M" { spawn "inir" "globalActions" "run" "toggle-mute"; }'
@@ -531,8 +543,8 @@ bind "Ctrl+Alt+A" { spawn "inir" "wallpaperSelector" "openLauncher" "animated"; 
   [ytmusic]='bind "Mod+M+Space" { spawn "inir" "ytmusic" "playPause"; }'
 )
 
-IPC_ALL_TARGETS=(ai altSwitcher appCatalog audio autostart background bar brightness cheatsheet clipboard cliphistService closeConfirm controlPanel coverflowSelector customWidgets dashboard dev gamemode globalActions keyboard lock mascot mascotMood mediaControls memory minimize mpris notifications osd osdVolume osk overlay overview packageSearch panelFamily pill recordingOsd region search session settings settingsNav shellLayout shellUpdate sidebarLeft sidebarRight taskview tiling voiceSearch wactionCenter waffleAltSwitcher wallpaperLauncher wallpaperSelector wbar widgetpower wnotificationCenter workspaceStrip wwidgets ytmusic zoom)
-IPC_SHARED_TARGETS=(ai altSwitcher appCatalog audio background bar brightness cheatsheet clipboard cliphistService closeConfirm controlPanel coverflowSelector dashboard dev gamemode globalActions keyboard lock mascot mascotMood mediaControls memory minimize mpris notifications osdVolume osk overlay overview packageSearch panelFamily pill region session settings settingsNav shellLayout shellUpdate sidebarLeft sidebarRight tiling voiceSearch wallpaperLauncher wallpaperSelector workspaceStrip ytmusic zoom)
+IPC_ALL_TARGETS=(ai altSwitcher appCatalog audio autostart background bar brightness browser cheatsheet clipboard cliphistService closeConfirm controlPanel coverflowSelector customWidgets dashboard dev files gamemode globalActions keyboard lock mascot mascotMood mediaControls memory minimize mpris notifications osd osdVolume osk overlay overview packageSearch panelFamily pill recordingOsd region search session settings settingsNav shellLayout shellUpdate sidebarLeft sidebarRight taskview tiling voiceSearch wactionCenter waffleAltSwitcher wallpaperLauncher wallpaperSelector wbar widgetpower wnotificationCenter workspaceStrip wwidgets ytmusic zoom)
+IPC_SHARED_TARGETS=(ai altSwitcher appCatalog audio background bar brightness browser cheatsheet clipboard cliphistService closeConfirm controlPanel coverflowSelector dashboard dev files gamemode globalActions keyboard lock mascot mascotMood mediaControls memory minimize mpris notifications osdVolume osk overlay overview packageSearch panelFamily pill region session settings settingsNav shellLayout shellUpdate sidebarLeft sidebarRight tiling voiceSearch wallpaperLauncher wallpaperSelector workspaceStrip ytmusic zoom)
 IPC_II_TARGETS=()
 IPC_WAFFLE_TARGETS=(autostart customWidgets osd recordingOsd search taskview wactionCenter waffleAltSwitcher wbar widgetpower wnotificationCenter wwidgets)
 

--- a/scripts/lib/privileged-gui-argv.py
+++ b/scripts/lib/privileged-gui-argv.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Table-driven privileged GUI argv adapter.
+
+Adding a privileged GUI is adding a table row. QML ShellExec.privilegedGuiArgv
+mirrors this table.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+PRIVILEGED_GUI = (
+    {"basename": "gparted", "wrap": True, "inject_qt5": False, "prefix": False},
+    {"basename": "ventoygui", "wrap": True, "inject_qt5": True, "prefix": True},
+)
+
+_FRONTEND_RE = re.compile(r"^--(gtk[234]|qt[456])$")
+
+
+def privileged_gui_argv(command: Sequence[str], wrapper_script: str) -> list[str]:
+    argv = [str(arg) for arg in (command or []) if str(arg)]
+    if not argv:
+        return []
+    base = argv[0].rsplit("/", 1)[-1].lower()
+    match = None
+    for row in PRIVILEGED_GUI:
+        name = row["basename"]
+        if base == name or (row.get("prefix") and base.startswith(f"{name}.")):
+            match = row
+            break
+    if not match or not match.get("wrap"):
+        return argv
+    graphical = list(argv)
+    if match.get("inject_qt5"):
+        has_frontend = any(_FRONTEND_RE.match(arg.lower()) for arg in graphical[1:])
+        if not has_frontend:
+            graphical = [graphical[0], "--qt5", *graphical[1:]]
+    return [wrapper_script, *graphical]

--- a/scripts/test-local-distribution.sh
+++ b/scripts/test-local-distribution.sh
@@ -79,7 +79,7 @@ schema_checks = {
     "schema dock not hover-only": "property bool hoverToReveal: false" in schema,
     "schema right sidebar full height": "property bool collapseEmptyNotifications: false" in schema,
     "schema left sidebar full height": "property bool collapseWidgetsTab: false" in schema,
-    "schema wallhaven tab": "property JsonObject wallhaven: JsonObject {\n                    // Enable/disable the Wallhaven tab in the left sidebar\n                    property bool enable: true" in schema,
+    "schema wallhaven tab": "property JsonObject wallhaven: JsonObject {\n                    // Enable/disable the Wallpapers tab in the left sidebar\n                    property bool enable: true" in schema,
     "schema news tab": "property JsonObject news: JsonObject {\n                    property bool enable: true" in schema,
     "wizard applies initial profile": "root.applyProfile(root.selectedProfile)" in wizard,
     "wizard dock pinned": '"dock.pinnedOnStartup": true' in wizard,
@@ -218,6 +218,17 @@ if command -v python3 &>/dev/null && [[ -f "$runtime_root/scripts/lib/generate-i
     python3 "$runtime_root/scripts/lib/generate-ipc-registry.py" --check
 fi
 
+if command -v python3 &>/dev/null && [[ -f "$runtime_root/scripts/lib/check-launch-policy.py" ]]; then
+    step "launch policy scan"
+    # set -euo pipefail at the top makes a scanner violation fatal.
+    python3 "$runtime_root/scripts/lib/check-launch-policy.py"
+fi
+
+if [[ -f "$runtime_root/scripts/tests/test-launch-daemon.sh" ]]; then
+    step "launch daemon contract suite"
+    bash "$runtime_root/scripts/tests/test-launch-daemon.sh"
+fi
+
 if [[ "$run_runtime" == true ]]; then
     step "runtime restart"
     bash "$runtime_root/scripts/inir" kill >/dev/null 2>&1 || true
@@ -292,7 +303,7 @@ done
 # Maintainer and development tooling must be stripped by both install paths.
 dev_tooling_files=(release.sh wiki-sync.sh verify-docs.sh qml-check.fish
     test-local-distribution.sh test-mascot-pack-flow.sh)
-dev_tooling_dirs=(agents tools l10n)
+dev_tooling_dirs=(agents tools l10n tests)
 for tool in "${dev_tooling_files[@]}" "${dev_tooling_dirs[@]}"; do
     pattern="--exclude='/$tool'"
     [[ " ${dev_tooling_dirs[*]} " == *" $tool "* ]] && pattern="--exclude='/$tool/'"

--- a/scripts/tests/benchmark-launch-daemon.sh
+++ b/scripts/tests/benchmark-launch-daemon.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+ITERATIONS="${1:-100}"
+UNIT="inir-bench-test"
+
+cleanup() {
+    systemctl --user stop "${UNIT}.service" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Ensure clean slate
+cleanup
+
+# Start active dummy service
+if ! systemd-run --user --quiet --unit="$UNIT" --description="Benchmark Unit" sleep 3600; then
+    echo "Failed to launch benchmark test unit" >&2
+    exit 1
+fi
+
+# Wait until unit is confirmed active
+for _ in $(seq 1 20); do
+    if systemctl --user is-active --quiet "$UNIT" 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+if ! systemctl --user is-active --quiet "$UNIT" 2>/dev/null; then
+    echo "Benchmark unit failed to transition to active state" >&2
+    exit 1
+fi
+
+python3 - "$REPO_ROOT" "$UNIT" "$ITERATIONS" <<'PY'
+import importlib.util
+import sys
+import time
+import statistics
+import subprocess
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+unit = sys.argv[2]
+iterations = int(sys.argv[3])
+
+extractor_path = repo_root / "scripts" / "lib" / "extract-launch-daemon.py"
+spec = importlib.util.spec_from_file_location("extract_launch_daemon", extractor_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+qml_file = repo_root / "modules/common/functions/ShellExec.qml"
+try:
+    script = module.extract_launch_daemon_script(qml_file)
+except (OSError, ValueError) as exc:
+    print(f"Error: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"Running {iterations} iterations on active unit '{unit}'...")
+latencies = []
+for i in range(iterations):
+    t0 = time.perf_counter()
+    res = subprocess.run(
+        ["/usr/bin/bash", "-c", script, "inir-daemon", "/usr/bin/systemd-run", "Benchmark Unit", unit, "", "reuse", "true"],
+        capture_output=True
+    )
+    t1 = time.perf_counter()
+    if res.returncode != 0:
+        print(f"Iteration {i+1} failed with code {res.returncode}: {res.stderr.decode()}", file=sys.stderr)
+        sys.exit(res.returncode)
+    latencies.append((t1 - t0) * 1000.0)
+
+latencies.sort()
+mean_val = statistics.mean(latencies)
+stdev_val = statistics.stdev(latencies) if len(latencies) > 1 else 0.0
+p95_val = latencies[int(len(latencies) * 0.95)]
+p50_val = statistics.median(latencies)
+min_val = min(latencies)
+max_val = max(latencies)
+total_val = sum(latencies)
+
+print("\n--- Latency Benchmark Results ---")
+print(f"Iterations: {len(latencies)}")
+print(f"Total time: {total_val:.2f} ms")
+print(f"Mean:       {mean_val:.2f} ms")
+print(f"Median:     {p50_val:.2f} ms")
+print(f"Min:        {min_val:.2f} ms")
+print(f"Max:        {max_val:.2f} ms")
+print(f"p95:        {p95_val:.2f} ms")
+print(f"StdDev:     {stdev_val:.2f} ms")
+print("---------------------------------")
+PY

--- a/scripts/tests/test-check-launch-policy.py
+++ b/scripts/tests/test-check-launch-policy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""TDD: launch-policy scanner signatures and check_naming return-early."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "lib" / "check-launch-policy.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_launch_policy", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CheckLaunchPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_module()
+
+    def test_signatures_include_hyprsunset_and_awww_daemon(self):
+        names = set(self.mod.SIGNATURES)
+        self.assertIn("hyprsunset", names)
+        self.assertIn("awww-daemon", names)
+
+    def test_check_naming_missing_function_returns_only_that(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ShellExec.qml"
+            path.write_text("pragma Singleton\nSingleton { id: root }\n", encoding="utf-8")
+            problems = self.mod.check_naming(path)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("launchDaemon", problems[0])
+        joined = " ".join(problems).lower()
+        self.assertNotIn("inir-", joined)
+        self.assertNotIn("unit prefix", joined)
+
+
+if __name__ == "__main__":
+    result = unittest.main(verbosity=2, exit=False).result
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/scripts/tests/test-ensure-awww-daemon.sh
+++ b/scripts/tests/test-ensure-awww-daemon.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Contract test: AwwwBackend._ensureDaemonScript waits for the daemon, then starts it.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+qml_file="$repo_root/services/AwwwBackend.qml"
+
+log_pass() { printf '[test-ensure-awww-daemon] PASS: %s\n' "$1"; }
+log_fail() { printf '[test-ensure-awww-daemon] FAIL: %s\n' "$1" >&2; exit 1; }
+
+if [[ ! -f "$qml_file" ]]; then
+    log_fail "AwwwBackend.qml not found at $qml_file"
+fi
+
+ensure_script="$(python3 - "$qml_file" <<'PY'
+import re, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+content = path.read_text(encoding="utf-8")
+match = re.search(r'readonly property string _ensureDaemonScript:\s*`([^`]+)`', content)
+if not match:
+    sys.exit("Error: _ensureDaemonScript not found")
+print(re.sub(r'\\(\$|`)', r'\1', match.group(1)))
+PY
+)"
+
+if [[ -z "$ensure_script" ]]; then
+    log_fail "Failed to extract _ensureDaemonScript"
+fi
+
+if [[ "$ensure_script" != *"inir-awww-daemon"* ]]; then
+    log_fail "Script does not wait/start inir-awww-daemon"
+fi
+if [[ "$ensure_script" != *"query"* ]]; then
+    log_fail "Script does not poll awww query"
+fi
+if [[ "$ensure_script" != *"systemctl --user start"* && "$ensure_script" != *"systemctl --user start inir-awww-daemon"* ]]; then
+    log_fail "Script does not start inir-awww-daemon after wait"
+fi
+
+log_pass "extracted script gates on inir-awww-daemon and awww query"
+
+tmp_dir="$(mktemp -d /tmp/inir-test-ensure-awww.XXXXXX)"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT INT TERM
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+log_file="$tmp_dir/sys.log"
+query_count_file="$tmp_dir/query.count"
+printf '0' > "$query_count_file"
+
+cat > "$stub_bin/awww" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" != "query" ]]; then
+    echo "unexpected awww args: \$*" >&2
+    exit 2
+fi
+count=\$(cat "$query_count_file")
+count=\$((count + 1))
+printf '%s' "\$count" > "$query_count_file"
+if [[ -f "$tmp_dir/query.ok" ]]; then
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$stub_bin/awww"
+
+cat > "$stub_bin/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$log_file"
+if [[ "\$1" == "--user" && "\$2" == "is-active" ]]; then
+    if [[ -f "$tmp_dir/unit.active" ]]; then
+        exit 0
+    fi
+    exit 3
+fi
+if [[ "\$1" == "--user" && "\$2" == "start" ]]; then
+    touch "$tmp_dir/started"
+    touch "$tmp_dir/query.ok"
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$stub_bin/systemctl"
+
+# sleep stays real so the 0.1s budget can elapse
+export PATH="$stub_bin:/usr/bin:/bin"
+
+set +e
+output="$(bash -c "$ensure_script" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "ensure script exited $ec. Output: $output"
+fi
+
+if [[ ! -f "$tmp_dir/started" ]]; then
+    log_fail "expected systemctl --user start when query never succeeded during wait"
+fi
+
+if ! grep -q 'is-active' "$log_file"; then
+    log_fail "expected systemctl --user is-active inir-awww-daemon during wait"
+fi
+
+if ! grep -q 'start' "$log_file"; then
+    log_fail "systemctl start was not recorded"
+fi
+
+query_count="$(cat "$query_count_file")"
+if [[ "$query_count" -lt 5 ]]; then
+    log_fail "expected multiple awww query polls, got $query_count"
+fi
+
+log_pass "wait then systemctl start when daemon is down (queries=$query_count)"
+
+# Query already succeeding: must not start
+rm -f "$tmp_dir/started" "$log_file"
+touch "$tmp_dir/query.ok"
+printf '0' > "$query_count_file"
+
+set +e
+output="$(bash -c "$ensure_script" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "ready-daemon ensure script exited $ec. Output: $output"
+fi
+if [[ -f "$tmp_dir/started" ]]; then
+    log_fail "must not systemctl start when awww query already succeeds"
+fi
+
+log_pass "no start when awww query already succeeds"
+printf '[test-ensure-awww-daemon] All scenarios passed\n'

--- a/scripts/tests/test-exec-scoped.sh
+++ b/scripts/tests/test-exec-scoped.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Contract test: inir_exec_scoped skips nested systemd-run when already in a unit.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+helper="$repo_root/scripts/lib/exec-scoped.sh"
+inir_script="$repo_root/scripts/inir"
+term_script="$repo_root/scripts/launch-terminal.sh"
+
+log_pass() { printf '[test-exec-scoped] PASS: %s\n' "$1"; }
+log_fail() { printf '[test-exec-scoped] FAIL: %s\n' "$1" >&2; exit 1; }
+
+if [[ ! -f "$helper" ]]; then
+    log_fail "scripts/lib/exec-scoped.sh not found"
+fi
+
+# shellcheck source=/dev/null
+source "$helper"
+if ! declare -F inir_exec_scoped >/dev/null 2>&1; then
+    log_fail "inir_exec_scoped is not defined"
+fi
+
+tmp_dir="$(mktemp -d /tmp/inir-test-exec-scoped.XXXXXX)"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT INT TERM
+
+marker="$tmp_dir/ran"
+systemd_log="$tmp_dir/systemd-run.log"
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin" "$tmp_dir/runtime/systemd"
+
+cat > "$stub_bin/payload" <<EOF
+#!/usr/bin/env bash
+printf 'payload:%s\n' "\$*" > "$marker"
+EOF
+chmod +x "$stub_bin/payload"
+
+cat > "$stub_bin/systemd-run" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > "$systemd_log"
+while [[ \$# -gt 0 ]]; do
+    if [[ "\$1" == "--" ]]; then
+        shift
+        exec "\$@"
+    fi
+    shift
+done
+exit 1
+EOF
+chmod +x "$stub_bin/systemd-run"
+
+export PATH="$stub_bin:/usr/bin:/bin"
+export XDG_RUNTIME_DIR="$tmp_dir/runtime"
+
+run_scoped() {
+    # inir_exec_scoped execs, so run in a subshell
+    (inir_exec_scoped "$@")
+}
+
+# Already inside a unit: never wrap.
+rm -f "$marker" "$systemd_log"
+INVOCATION_ID="test-unit" run_scoped "inir-app" payload /tmp/x
+if [[ ! -f "$marker" ]]; then
+    log_fail "INVOCATION_ID path did not exec payload"
+fi
+if [[ -f "$systemd_log" ]]; then
+    log_fail "INVOCATION_ID path must not call systemd-run"
+fi
+log_pass "INVOCATION_ID skips systemd-run"
+
+# No private socket: exec directly.
+unset INVOCATION_ID
+rm -f "$marker" "$systemd_log"
+run_scoped "inir-app" payload /tmp/y
+if [[ ! -f "$marker" ]]; then
+    log_fail "no-socket path did not exec payload"
+fi
+if [[ -f "$systemd_log" ]]; then
+    log_fail "no-socket path must not call systemd-run"
+fi
+log_pass "missing systemd private socket execs directly"
+
+# Socket + systemd-run: wrap with expected flags.
+rm -f "$marker" "$systemd_log" "$tmp_dir/runtime/systemd/private"
+python3 - "$tmp_dir/runtime/systemd/private" <<'PY'
+import os, socket, sys
+path = sys.argv[1]
+if os.path.exists(path):
+    os.remove(path)
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.bind(path)
+sock.close()
+PY
+if [[ ! -S "$tmp_dir/runtime/systemd/private" ]]; then
+    log_fail "failed to create fake systemd private socket"
+fi
+run_scoped "inir-terminal" payload /tmp/z
+if [[ ! -f "$marker" ]]; then
+    log_fail "wrap path did not exec payload"
+fi
+if [[ ! -f "$systemd_log" ]]; then
+    log_fail "wrap path did not call systemd-run"
+fi
+flags="$(cat "$systemd_log")"
+for needed in --user --quiet --collect --same-dir --scope --unit=inir-terminal-; do
+    if [[ "$flags" != *"$needed"* ]]; then
+        log_fail "systemd-run flags missing '$needed': $flags"
+    fi
+done
+if [[ "$flags" != *"-- payload /tmp/z"* && "$flags" != *" -- payload /tmp/z" ]]; then
+    # allow either spacing; require payload after --
+    if [[ "$flags" != *" -- "* || "$flags" != *"payload /tmp/z"* ]]; then
+        log_fail "systemd-run did not exec payload after --: $flags"
+    fi
+fi
+log_pass "systemd-run wraps with --user --quiet --collect --same-dir --scope --unit=<prefix>-PID"
+
+if ! grep -q 'exec-scoped.sh' "$inir_script" && ! grep -q 'inir_exec_scoped' "$inir_script"; then
+    log_fail "scripts/inir does not use inir_exec_scoped"
+fi
+if ! grep -q 'exec-scoped.sh' "$term_script" && ! grep -q 'inir_exec_scoped' "$term_script"; then
+    log_fail "scripts/launch-terminal.sh does not use inir_exec_scoped"
+fi
+log_pass "inir and launch-terminal.sh share inir_exec_scoped"
+
+# systemd ExecStart uses ~/.local/bin/inir → repo script. dirname(BASH_SOURCE)
+# is the symlink directory, which has no lib/exec-scoped.sh. help/run must
+# still work; the helper is only required when exec_scoped runs.
+link_bin="$tmp_dir/link-bin"
+mkdir -p "$link_bin"
+ln -s "$inir_script" "$link_bin/inir"
+set +e
+help_out="$("$link_bin/inir" help 2>&1)"
+help_ec=$?
+set -e
+if [[ "$help_out" == *"Unable to locate exec-scoped helper"* ]]; then
+    log_fail "symlink inir help must not require exec-scoped.sh at parse time. Output: $help_out"
+fi
+if [[ $help_ec -ne 0 ]]; then
+    log_fail "symlink inir help exited $help_ec. Output: $help_out"
+fi
+log_pass "symlink inir help does not require exec-scoped.sh at parse time"
+
+# Payload copy without the new helper (stale ~/.config/quickshell/inir).
+orphan_dir="$tmp_dir/orphan-scripts"
+mkdir -p "$orphan_dir"
+cp "$inir_script" "$orphan_dir/inir"
+chmod +x "$orphan_dir/inir"
+set +e
+orphan_out="$("$orphan_dir/inir" help 2>&1)"
+orphan_ec=$?
+set -e
+if [[ "$orphan_out" == *"Unable to locate exec-scoped helper"* ]]; then
+    log_fail "inir help must work when exec-scoped.sh is absent. Output: $orphan_out"
+fi
+if [[ $orphan_ec -ne 0 ]]; then
+    log_fail "orphan inir help exited $orphan_ec. Output: $orphan_out"
+fi
+log_pass "inir help works when exec-scoped.sh is not installed"
+printf '[test-exec-scoped] All scenarios passed\n'

--- a/scripts/tests/test-inir-configured-app.sh
+++ b/scripts/tests/test-inir-configured-app.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Contract test: app slot reader uses inir_config_file, not payload config.json.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+config_path_helper="$repo_root/scripts/lib/config-path.sh"
+inir_script="$repo_root/scripts/inir"
+
+log_pass() { printf '[test-inir-configured-app] PASS: %s\n' "$1"; }
+log_fail() { printf '[test-inir-configured-app] FAIL: %s\n' "$1" >&2; exit 1; }
+
+if [[ ! -f "$config_path_helper" ]]; then
+    log_fail "config-path.sh not found"
+fi
+if [[ ! -f "$inir_script" ]]; then
+    log_fail "scripts/inir not found"
+fi
+
+tmp_dir="$(mktemp -d /tmp/inir-test-configured-app.XXXXXX)"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT INT TERM
+
+export HOME="$tmp_dir/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+unset XDG_RUNTIME_DIR
+export XDG_RUNTIME_DIR="$tmp_dir/runtime"
+mkdir -p "$XDG_CONFIG_HOME/inir" "$XDG_RUNTIME_DIR" "$HOME"
+
+user_config="$XDG_CONFIG_HOME/inir/config.json"
+cat > "$user_config" <<'EOF'
+{
+  "apps": {
+    "files": "inir-test-fm-xyz",
+    "browser": "inir-test-browser-xyz"
+  }
+}
+EOF
+
+# Decoy payload-next-to-shell.qml config.json must be ignored for app slots.
+payload_dir="$tmp_dir/payload"
+mkdir -p "$payload_dir"
+touch "$payload_dir/shell.qml"
+cat > "$payload_dir/config.json" <<'EOF'
+{
+  "apps": {
+    "files": "wrong-fm",
+    "browser": "wrong-browser"
+  }
+}
+EOF
+export INIR_RUNTIME_DIR="$payload_dir"
+
+# shellcheck source=/dev/null
+source "$config_path_helper"
+
+if ! declare -F _read_apps_slot >/dev/null 2>&1; then
+    log_fail "_read_apps_slot is not defined after sourcing config-path.sh"
+fi
+
+files_slot="$(_read_apps_slot files)"
+if [[ "$files_slot" != "inir-test-fm-xyz" ]]; then
+    log_fail "_read_apps_slot files expected inir-test-fm-xyz, got '$files_slot'"
+fi
+browser_slot="$(_read_apps_slot browser)"
+if [[ "$browser_slot" != "inir-test-browser-xyz" ]]; then
+    log_fail "_read_apps_slot browser expected inir-test-browser-xyz, got '$browser_slot'"
+fi
+log_pass "_read_apps_slot uses inir_config_file (user config.json)"
+
+if ! grep -q '_read_apps_slot files' "$inir_script"; then
+    log_fail "launch_configured_files does not call _read_apps_slot"
+fi
+if ! grep -q '_read_apps_slot browser' "$inir_script"; then
+    log_fail "launch_configured_browser does not call _read_apps_slot"
+fi
+if awk '/^launch_configured_files\(\)/,/^}/ { print }' "$inir_script" | grep -q 'resolve_config_dir'; then
+    log_fail "launch_configured_files still calls resolve_config_dir"
+fi
+log_pass "both launchers share _read_apps_slot"
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+call_log="$tmp_dir/call.log"
+
+cat > "$stub_bin/inir-test-fm-xyz" <<EOF
+#!/usr/bin/env bash
+printf 'FM:%s\n' "\$*" > "$call_log"
+EOF
+chmod +x "$stub_bin/inir-test-fm-xyz"
+
+export PATH="$stub_bin:/usr/bin:/bin"
+rm -f "$call_log"
+set +e
+output="$("$inir_script" files /tmp/some-folder 2>&1)"
+ec=$?
+set -e
+if [[ $ec -ne 0 ]]; then
+    log_fail "inir files exited $ec. Output: $output"
+fi
+if [[ ! -f "$call_log" ]]; then
+    log_fail "inir files did not exec the configured file manager. Output: $output"
+fi
+if ! grep -q 'FM:/tmp/some-folder' "$call_log"; then
+    log_fail "configured file manager argv mismatch: $(cat "$call_log")"
+fi
+log_pass "inir files execs user-configured command, ignores payload config.json"
+printf '[test-inir-configured-app] All scenarios passed\n'

--- a/scripts/tests/test-keyring-unlock.sh
+++ b/scripts/tests/test-keyring-unlock.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Contract test: unlock.sh must not pkill before secret-tool / already-unlocked guards.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+src_unlock="$repo_root/scripts/keyring/unlock.sh"
+
+log_pass() { printf '[test-keyring-unlock] PASS: %s\n' "$1"; }
+log_fail() { printf '[test-keyring-unlock] FAIL: %s\n' "$1" >&2; exit 1; }
+
+if [[ ! -f "$src_unlock" ]]; then
+    log_fail "unlock.sh not found"
+fi
+
+tmp_dir="$(mktemp -d /tmp/inir-test-keyring-unlock.XXXXXX)"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT INT TERM
+
+cp "$src_unlock" "$tmp_dir/unlock.sh"
+chmod +x "$tmp_dir/unlock.sh"
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+pkill_log="$tmp_dir/pkill.log"
+
+cat > "$stub_bin/pkill" <<EOF
+#!/usr/bin/env bash
+printf 'pkill:%s\n' "\$*" >> "$pkill_log"
+exit 0
+EOF
+chmod +x "$stub_bin/pkill"
+
+cat > "$stub_bin/systemctl" <<EOF
+#!/usr/bin/env bash
+printf 'systemctl:%s\n' "\$*" >> "$tmp_dir/systemctl.log"
+exit 0
+EOF
+chmod +x "$stub_bin/systemctl"
+
+cat > "$stub_bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$stub_bin/sleep"
+
+for needed in bash sh env cat printf whoami seq dirname pwd rm mkdir; do
+    resolved="$(command -v "$needed" 2>/dev/null || true)"
+    if [[ -n "$resolved" && -x "$resolved" ]]; then
+        ln -sf "$resolved" "$stub_bin/$needed"
+    fi
+done
+isolated_path="$stub_bin"
+
+# Case 1: already unlocked — never pkill
+cat > "$tmp_dir/is_unlocked.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$tmp_dir/is_unlocked.sh"
+rm -f "$pkill_log"
+set +e
+output="$(PATH="$isolated_path" "$tmp_dir/unlock.sh" 2>&1)"
+ec=$?
+set -e
+if [[ $ec -ne 0 ]]; then
+    log_fail "already unlocked should exit 0, got $ec. Output: $output"
+fi
+if [[ -f "$pkill_log" ]]; then
+    log_fail "already unlocked must never pkill: $(cat "$pkill_log")"
+fi
+log_pass "already unlocked exits 0 without pkill"
+
+# Case 2: locked + missing secret-tool — exit 1, never pkill
+cat > "$tmp_dir/is_unlocked.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$tmp_dir/is_unlocked.sh"
+rm -f "$pkill_log"
+set +e
+output="$(PATH="$isolated_path" "$tmp_dir/unlock.sh" 2>&1)"
+ec=$?
+set -e
+if [[ $ec -ne 1 ]]; then
+    log_fail "missing secret-tool should exit 1, got $ec. Output: $output"
+fi
+if [[ -f "$pkill_log" ]]; then
+    log_fail "missing secret-tool must never pkill: $(cat "$pkill_log")"
+fi
+log_pass "missing secret-tool exits 1 without pkill"
+printf '[test-keyring-unlock] All scenarios passed\n'

--- a/scripts/tests/test-launch-daemon.sh
+++ b/scripts/tests/test-launch-daemon.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# Contract test suite for ShellExec.launchDaemon
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+qml_file="$repo_root/modules/common/functions/ShellExec.qml"
+
+# Temporary directory for mocks and test logs
+tmp_dir="$(mktemp -d /tmp/inir-test-launch-daemon.XXXXXX)"
+
+test_units=(
+    "inir-test-dummy"
+    "inir-test-rel"
+    "inir-test-notfound"
+    "inir-test-fail"
+    "inir-test-crash"
+)
+
+cleanup() {
+    local exit_code=$?
+    # Ensure all test units are stopped and reset in systemd user manager
+    for unit in "${test_units[@]}"; do
+        systemctl --user stop "${unit}.service" >/dev/null 2>&1 || true
+        systemctl --user reset-failed "${unit}.service" >/dev/null 2>&1 || true
+    done
+    if [[ -d "$tmp_dir" ]]; then
+        rm -rf "$tmp_dir"
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+log_step() {
+    printf '\n[test-launch-daemon] == %s ==\n' "$1"
+}
+
+log_pass() {
+    printf '[test-launch-daemon] PASS: %s\n' "$1"
+}
+
+log_fail() {
+    printf '[test-launch-daemon] FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+# Preflight checks
+if ! command -v systemctl >/dev/null 2>&1 || ! command -v systemd-run >/dev/null 2>&1; then
+    log_fail "systemctl or systemd-run not found in PATH"
+fi
+
+if ! systemctl --user is-system-running >/dev/null 2>&1 && ! systemctl --user status >/dev/null 2>&1; then
+    log_fail "systemd --user manager is not running or not accessible"
+fi
+
+if [[ ! -f "$qml_file" ]]; then
+    log_fail "ShellExec.qml not found at $qml_file"
+fi
+
+# Clean initial state
+for unit in "${test_units[@]}"; do
+    systemctl --user stop "${unit}.service" >/dev/null 2>&1 || true
+    systemctl --user reset-failed "${unit}.service" >/dev/null 2>&1 || true
+done
+
+# Extract the runtime launcher wrapper script from ShellExec.qml
+log_step "Extracting launchDaemon script from ShellExec.qml"
+extractor="$repo_root/scripts/lib/extract-launch-daemon.py"
+if [[ ! -f "$extractor" ]]; then
+    log_fail "Extractor not found at $extractor"
+fi
+launcher_script="$(python3 "$extractor" "$qml_file")"
+
+if [[ -z "$launcher_script" ]]; then
+    log_fail "Failed to extract launcher script from ShellExec.qml"
+fi
+
+# Helper to invoke the extracted launchDaemon script with identical contract signature
+# argv: $0 inir-daemon, $1 systemd_run, $2 desc, $3 unit, $4 restart, $5 if_active, $6 program, then args
+invoke_launch_daemon() {
+    local scope="$1"
+    local program="$2"
+    local restart="${3:-}"
+    local desc="${4:-$scope}"
+    local custom_systemd_run="${5:-/usr/bin/systemd-run}"
+    local if_active="${6:-replace}"
+    shift 6 || true
+    local extra_args=("$@")
+
+    local unit="inir-${scope}"
+
+    bash -c "$launcher_script" "inir-daemon" "$custom_systemd_run" "$desc" "$unit" "$restart" "$if_active" "$program" "${extra_args[@]}"
+}
+
+# Scenario 1: STARTED (Normal launch creates transient systemd service)
+log_step "Scenario 1: STARTED"
+systemctl --user stop "inir-test-dummy.service" >/dev/null 2>&1 || true
+systemctl --user reset-failed "inir-test-dummy.service" >/dev/null 2>&1 || true
+
+set +e
+output="$(invoke_launch_daemon "test-dummy" "sleep" "" "Test Dummy Daemon" "/usr/bin/systemd-run" "replace" "60" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "Scenario 1: Expected exit code 0, got $ec. Output: $output"
+fi
+
+if ! systemctl --user is-active --quiet "inir-test-dummy.service"; then
+    log_fail "Scenario 1: Unit inir-test-dummy.service is not active in systemd"
+fi
+
+dummy_pid="$(systemctl --user show -p MainPID --value inir-test-dummy.service)"
+if [[ -z "$dummy_pid" || "$dummy_pid" -le 0 ]]; then
+    log_fail "Scenario 1: Unit inir-test-dummy.service has invalid MainPID: $dummy_pid"
+fi
+
+log_pass "Scenario 1 (STARTED): Unit inir-test-dummy.service active with PID $dummy_pid"
+
+# Scenario 2: REPLACE (default relaunch stops the unit and starts a new MainPID)
+log_step "Scenario 2: REPLACE"
+pid_before="$(systemctl --user show -p MainPID --value inir-test-dummy.service)"
+
+set +e
+output="$(invoke_launch_daemon "test-dummy" "sleep" "" "Test Dummy Daemon" "/usr/bin/systemd-run" "replace" "60" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "Scenario 2: Expected exit code 0 for replace relaunch, got $ec. Output: $output"
+fi
+
+if ! systemctl --user is-active --quiet "inir-test-dummy.service"; then
+    log_fail "Scenario 2: Unit inir-test-dummy.service is not active after replace"
+fi
+
+pid_after="$(systemctl --user show -p MainPID --value inir-test-dummy.service)"
+if [[ -z "$pid_after" || "$pid_after" -le 0 ]]; then
+    log_fail "Scenario 2: Unit has invalid MainPID after replace: $pid_after"
+fi
+if [[ "$pid_before" == "$pid_after" ]]; then
+    log_fail "Scenario 2: MainPID was preserved ($pid_before); replace must change MainPID"
+fi
+
+log_pass "Scenario 2 (REPLACE): Relaunch changed MainPID $pid_before -> $pid_after"
+
+# Scenario 2b: REUSE (explicit if_active=reuse preserves MainPID)
+log_step "Scenario 2b: REUSE"
+pid_before="$(systemctl --user show -p MainPID --value inir-test-dummy.service)"
+
+set +e
+output="$(invoke_launch_daemon "test-dummy" "sleep" "" "Test Dummy Daemon" "/usr/bin/systemd-run" "reuse" "60" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "Scenario 2b: Expected exit code 0 for reuse relaunch, got $ec. Output: $output"
+fi
+
+if ! systemctl --user is-active --quiet "inir-test-dummy.service"; then
+    log_fail "Scenario 2b: Unit inir-test-dummy.service is not active after reuse"
+fi
+
+pid_after="$(systemctl --user show -p MainPID --value inir-test-dummy.service)"
+if [[ "$pid_before" != "$pid_after" ]]; then
+    log_fail "Scenario 2b: MainPID changed from $pid_before to $pid_after; reuse must preserve MainPID"
+fi
+
+log_pass "Scenario 2b (REUSE): Idempotency verified, PID preserved ($pid_after)"
+
+# Scenario 3: PATH_RESOLUTION (Relative binary resolved in restored $PATH)
+log_step "Scenario 3: PATH_RESOLUTION"
+systemctl --user stop "inir-test-rel.service" >/dev/null 2>&1 || true
+systemctl --user reset-failed "inir-test-rel.service" >/dev/null 2>&1 || true
+
+set +e
+output="$(invoke_launch_daemon "test-rel" "sleep" "" "Test Rel Daemon" "/usr/bin/systemd-run" "replace" "60" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "Scenario 3: Expected exit code 0, got $ec. Output: $output"
+fi
+
+if ! systemctl --user is-active --quiet "inir-test-rel.service"; then
+    log_fail "Scenario 3: Unit inir-test-rel.service is not active"
+fi
+
+exec_start="$(systemctl --user show -p ExecStart --value inir-test-rel.service)"
+if [[ "$exec_start" != *"path=/usr/bin/sleep"* && "$exec_start" != *"sleep"* ]]; then
+    log_fail "Scenario 3: ExecStart does not contain resolved path: $exec_start"
+fi
+
+log_pass "Scenario 3 (PATH_RESOLUTION): Relative binary resolved and started as inir-test-rel.service"
+
+# Scenario 4: NOT_FOUND (Non-existent binary aborts with 127)
+log_step "Scenario 4: NOT_FOUND"
+set +e
+err_out="$(invoke_launch_daemon "test-notfound" "nonexistent_bin_xyz_999" "" "Test Not Found" "/usr/bin/systemd-run" "replace" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 127 ]]; then
+    log_fail "Scenario 4: Expected exit code 127 for missing binary, got $ec. Output: $err_out"
+fi
+
+if [[ "$err_out" != *"not found or not executable"* && "$err_out" != *"[launcher]"* ]]; then
+    log_fail "Scenario 4: Stderr missing expected error message. Got: $err_out"
+fi
+
+if systemctl --user is-active --quiet "inir-test-notfound.service" 2>/dev/null; then
+    log_fail "Scenario 4: inir-test-notfound.service should not have been created"
+fi
+
+log_pass "Scenario 4 (NOT_FOUND): Non-existent binary exited with 127 and reported error"
+
+# Scenario 5: FAILED (Supervisor failure exits with 1, no orphan exec)
+log_step "Scenario 5: FAILED"
+mock_systemd_run="$tmp_dir/mock-systemd-run-fail"
+cat <<'EOF' > "$mock_systemd_run"
+#!/usr/bin/env bash
+echo "Failed to start transient service: unit configuration invalid" >&2
+exit 1
+EOF
+chmod +x "$mock_systemd_run"
+
+# Record sleep processes before test
+sleep_count_before=$(pgrep -f "sleep 59" | wc -l || true)
+
+set +e
+err_out="$(invoke_launch_daemon "test-fail" "sleep" "" "Test Fail Daemon" "$mock_systemd_run" "replace" "59" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 1 ]]; then
+    log_fail "Scenario 5: Expected exit code 1 on systemd-run failure, got $ec. Output: $err_out"
+fi
+
+if [[ "$err_out" != *"systemd-run failed to start service"* && "$err_out" != *"[launcher]"* ]]; then
+    log_fail "Scenario 5: Stderr missing expected failure message. Got: $err_out"
+fi
+
+sleep_count_after=$(pgrep -f "sleep 59" | wc -l || true)
+if [[ "$sleep_count_after" -ne "$sleep_count_before" ]]; then
+    log_fail "Scenario 5: Orphan process was executed in shell cgroup! sleep count before=$sleep_count_before, after=$sleep_count_after"
+fi
+
+log_pass "Scenario 5 (FAILED): Supervisor failure cleanly returned 1 without falling back to plain exec"
+
+# Scenario 6: RESTART_CRASH_STATE (Supervisor custody and failed is-active check)
+log_step "Scenario 6: RESTART_CRASH_STATE"
+systemctl --user stop "inir-test-crash.service" >/dev/null 2>&1 || true
+systemctl --user reset-failed "inir-test-crash.service" >/dev/null 2>&1 || true
+
+set +e
+output="$(invoke_launch_daemon "test-crash" "false" "on-failure" "Test Crash Daemon" "/usr/bin/systemd-run" "replace" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "Scenario 6: Initial launch delegation to systemd failed with exit code $ec. Output: $output"
+fi
+
+# Poll for crash transition (unit should enter failed or inactive state)
+crashed=false
+for _ in $(seq 1 40); do
+    state="$(systemctl --user show -p ActiveState --value "inir-test-crash.service" 2>/dev/null || true)"
+    if [[ "$state" == "failed" || "$state" == "inactive" ]]; then
+        crashed=true
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ "$crashed" != true ]]; then
+    log_fail "Scenario 6: Failing process did not transition to failed/inactive state"
+fi
+
+# Verify is-active returns non-zero
+set +e
+systemctl --user is-active --quiet "inir-test-crash.service"
+is_active_ec=$?
+set -e
+
+if [[ $is_active_ec -eq 0 ]]; then
+    log_fail "Scenario 6: is-active returned 0 for crashed unit inir-test-crash.service"
+fi
+
+unit_state="$(systemctl --user is-active "inir-test-crash.service" 2>&1 || true)"
+log_pass "Scenario 6 (RESTART_CRASH_STATE): Custody delegated, crashed unit state is '$unit_state' (is-active exit code: $is_active_ec)"
+
+# Scenario 7: NO_SYSTEMD (Degraded mode fallback executes directly and propagates exit code)
+log_step "Scenario 7: NO_SYSTEMD (Degraded Mode)"
+
+# Create a mock isolated bin directory without systemctl or systemd-run
+no_systemd_bin_dir="$tmp_dir/no-systemd-bin"
+mkdir -p "$no_systemd_bin_dir"
+# Link essential binaries needed for shell execution (bash, coreutils, sed, etc.)
+for b in bash sh cat cut sed tr date mkdir rm printf uname chmod env true false id stat type; do
+    p="$(command -v "$b" 2>/dev/null || true)"
+    if [[ -n "$p" && -x "$p" ]]; then
+        ln -sf "$p" "$no_systemd_bin_dir/$b"
+    fi
+done
+
+# Test 7.1: Degraded mode succeeds on successful child (true -> exit 0)
+set +e
+output="$(PATH="$no_systemd_bin_dir" invoke_launch_daemon "test-nosystemd-success" "true" "" "Test No Systemd Success" "/nonexistent/systemd-run" "replace" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 0 ]]; then
+    log_fail "Scenario 7.1: Expected exit code 0 for degraded mode with true, got $ec. Output: $output"
+fi
+
+# Test 7.2: Degraded mode propagates non-zero exit code of child (sh -c 'exit 42' -> exit 42)
+set +e
+output="$(PATH="$no_systemd_bin_dir" invoke_launch_daemon "test-nosystemd-fail" "sh" "" "Test No Systemd Fail" "/nonexistent/systemd-run" "replace" "-c" "exit 42" 2>&1)"
+ec=$?
+set -e
+
+if [[ $ec -ne 42 ]]; then
+    log_fail "Scenario 7.2: Expected propagated child exit code 42 in degraded mode, got $ec. Output: $output"
+fi
+
+log_pass "Scenario 7 (NO_SYSTEMD): Degraded fallback executed child via exec and cleanly propagated exit codes (0 and 42)"
+
+# Final cleanup and success
+log_step "All contract scenarios passed successfully"
+

--- a/scripts/tests/test-privileged-gui-argv.py
+++ b/scripts/tests/test-privileged-gui-argv.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""TDD: privileged GUI argv adapter + browser openUrl argv launch."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "scripts" / "lib" / "privileged-gui-argv.py"
+SHELL_EXEC = REPO_ROOT / "modules" / "common" / "functions" / "ShellExec.qml"
+APP_SEARCH = REPO_ROOT / "services" / "AppSearch.qml"
+APP_LAUNCHER = REPO_ROOT / "services" / "AppLauncher.qml"
+GLOBAL_ACTIONS = REPO_ROOT / "services" / "GlobalActions.qml"
+WRAPPER = "/tmp/inir/scripts/launch-privileged-gui.sh"
+
+
+def load_helper():
+    spec = importlib.util.spec_from_file_location("privileged_gui_argv", HELPER)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(HELPER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PrivilegedGuiArgvTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not HELPER.is_file():
+            raise unittest.SkipTest(f"missing {HELPER}")
+        cls.mod = load_helper()
+
+    def test_gparted_is_wrapped(self):
+        out = self.mod.privileged_gui_argv(["/usr/sbin/gparted"], WRAPPER)
+        self.assertEqual(out, [WRAPPER, "/usr/sbin/gparted"])
+
+    def test_plain_app_passthrough(self):
+        out = self.mod.privileged_gui_argv(["firefox", "https://example"], WRAPPER)
+        self.assertEqual(out, ["firefox", "https://example"])
+
+    def test_ventoygui_injects_qt5_and_wraps(self):
+        out = self.mod.privileged_gui_argv(["ventoygui"], WRAPPER)
+        self.assertEqual(out, [WRAPPER, "ventoygui", "--qt5"])
+
+    def test_ventoygui_prefix_match(self):
+        out = self.mod.privileged_gui_argv(["/opt/ventoygui.gtk3"], WRAPPER)
+        self.assertEqual(out, [WRAPPER, "/opt/ventoygui.gtk3", "--qt5"])
+
+    def test_ventoygui_keeps_existing_frontend(self):
+        out = self.mod.privileged_gui_argv(["ventoygui", "--gtk3"], WRAPPER)
+        self.assertEqual(out, [WRAPPER, "ventoygui", "--gtk3"])
+
+    def test_empty_command(self):
+        self.assertEqual(self.mod.privileged_gui_argv([], WRAPPER), [])
+
+
+class QmlWiringTests(unittest.TestCase):
+    def test_shellexec_defines_privileged_gui_argv_table(self):
+        text = SHELL_EXEC.read_text(encoding="utf-8")
+        self.assertIn("function privilegedGuiArgv", text)
+        self.assertIn("gparted", text)
+        self.assertIn("ventoygui", text)
+        self.assertIn("launch-privileged-gui.sh", text)
+
+    def test_appsearch_uses_adapter(self):
+        text = APP_SEARCH.read_text(encoding="utf-8")
+        self.assertIn("privilegedGuiArgv", text)
+        self.assertGreaterEqual(text.count("privilegedGuiArgv"), 2)
+
+    def test_app_launcher_has_extra_args_or_launch_url(self):
+        text = APP_LAUNCHER.read_text(encoding="utf-8")
+        has_launch_url = "function launchUrl" in text
+        has_extra = "extraArgs" in text and "function launch(" in text
+        self.assertTrue(has_launch_url or has_extra, "need launchUrl or launch(slotId, extraArgs)")
+
+    def test_open_url_does_not_interpolate_execcmd(self):
+        text = GLOBAL_ACTIONS.read_text(encoding="utf-8")
+        start = text.find("function openUrl")
+        self.assertGreaterEqual(start, 0)
+        end = text.find("function open(", start + 1)
+        if end < 0:
+            end = text.find("IpcHandler", start + 1)
+        chunk = text[start:end if end > start else start + 400]
+        self.assertNotIn("execCmd", chunk)
+        self.assertNotIn('commandFor("browser")', chunk)
+        self.assertTrue("launchUrl" in chunk or "AppLauncher.launch(" in chunk)
+
+
+if __name__ == "__main__":
+    failures = 0
+    if not HELPER.is_file():
+        print(f"FAIL: missing helper {HELPER}", file=sys.stderr)
+        sys.exit(1)
+    result = unittest.main(verbosity=2, exit=False).result
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/sdata/lib/functions.sh
+++ b/sdata/lib/functions.sh
@@ -180,7 +180,7 @@ RUNTIME_EXCLUDES=(
   # Maintainer and development tooling. Anchored with a leading slash so these
   # common names only ever match at the top of a payload directory, never a
   # future modules/…/tools/ that has every right to ship.
-  --exclude='/agents/' --exclude='/tools/' --exclude='/l10n/'
+  --exclude='/agents/' --exclude='/tools/' --exclude='/l10n/' --exclude='/tests/'
   --exclude='/release.sh' --exclude='/wiki-sync.sh' --exclude='/verify-docs.sh'
   --exclude='/qml-check.fish' --exclude='/test-local-distribution.sh'
   --exclude='/test-mascot-pack-flow.sh'

--- a/services/AppLauncher.qml
+++ b/services/AppLauncher.qml
@@ -50,6 +50,20 @@ Singleton {
             ]
         },
         {
+            id: "files",
+            label: Translation.tr("File manager"),
+            description: Translation.tr("Used by file manager shortcuts and app launch tiles."),
+            defaultCommand: "nautilus",
+            placeholder: "nautilus",
+            presets: [
+                { id: "nautilus", label: "GNOME Files", command: "nautilus" },
+                { id: "dolphin", label: "Dolphin", command: "dolphin" },
+                { id: "thunar", label: "Thunar", command: "thunar" },
+                { id: "nemo", label: "Nemo", command: "nemo" },
+                { id: "pcmanfm", label: "PCManFM", command: "pcmanfm" }
+            ]
+        },
+        {
             id: "manageUser",
             label: Translation.tr("Manage my account"),
             description: Translation.tr("Used by the profile menu and start menu account shortcuts."),
@@ -205,7 +219,8 @@ Singleton {
         Config.setNestedValue(`apps.${slotId}`, String(command ?? "").trim())
     }
 
-    function launch(slotId: string): void {
+    function launch(slotId: string, extraArgs): void {
+        const extras = Array.from(extraArgs ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
         const command = root.commandFor(slotId)
         if (command.length === 0)
             return
@@ -216,12 +231,39 @@ Singleton {
         if (!command.includes(" ") && !command.includes("/")) {
             const entry = DesktopEntries.heuristicLookup(command)
             if (entry) {
-                AppSearch.launchEntry(entry)
+                if (extras.length === 0) {
+                    AppSearch.launchEntry(entry)
+                    return
+                }
+                const cmd = AppSearch._sanitizeDesktopArgs(entry.command)
+                AppSearch.launchEntry({
+                    originalEntry: entry.originalEntry ?? entry,
+                    id: entry.id,
+                    name: entry.name,
+                    command: cmd.concat(extras),
+                    workingDirectory: entry.workingDirectory,
+                    runInTerminal: entry.runInTerminal
+                })
                 return
             }
         }
 
-        ShellExec.execCmd(command)
+        if (extras.length === 0) {
+            ShellExec.execCmd(command)
+            return
+        }
+
+        const words = command.split(/\s+/).filter(word => word.length > 0)
+        ShellExec.execDetachedArgs(words.concat(extras))
+    }
+
+    function launchUrl(slotId: string, url: string): void {
+        const raw = String(url ?? "").trim()
+        if (raw.length === 0) {
+            root.launch(slotId)
+            return
+        }
+        root.launch(slotId, [raw])
     }
 
     function launchNetworkSettings(useEthernet: bool): void {

--- a/services/AppSearch.qml
+++ b/services/AppSearch.qml
@@ -341,6 +341,21 @@ Singleton {
         }
     }
 
+    function _sanitizeDesktopArgs(rawArgs): var {
+        const cleaned = Array.from(rawArgs ?? [])
+            .map(arg => String(arg ?? "").trim())
+            .filter(arg => {
+                if (arg.length === 0) return false
+                if (/^%[a-zA-Z]$/.test(arg)) return false
+                if (/^--[a-zA-Z0-9_-]+=(%[a-zA-Z])?$/.test(arg)) return false
+                return true
+            })
+        if (cleaned.length > 1 && cleaned[cleaned.length - 1] === "--") {
+            cleaned.pop()
+        }
+        return cleaned
+    }
+
     function launchEntry(entry): bool {
         if (!entry) return false
 
@@ -351,20 +366,17 @@ Singleton {
 
         // Prefer the parsed desktop command so every shell surface shares the
         // same launch environment, transient-scope lifetime and Path= handling.
-        const command = Array.from(entry.command ?? rawEntry?.command ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
+        const command = root._sanitizeDesktopArgs(entry.command ?? rawEntry?.command)
         if (command.length > 0) {
             if (entry.runInTerminal ?? rawEntry?.runInTerminal ?? false) {
-                const terminal = String(Config.options?.apps?.terminal ?? "kitty").trim() || "kitty"
-                const quotedCommand = command.map(arg => `'${StringUtils.shellSingleQuoteEscape(arg)}'`).join(" ")
-                if (terminal === "wezterm") {
-                    ShellExec.execCmd(`${terminal} start --always-new-process -- ${quotedCommand}`, workingDirectory)
-                } else {
-                    ShellExec.execCmd(`${terminal} -e ${quotedCommand}`, workingDirectory)
-                }
+                const terminalScript = `${Directories.scriptsPath}/launch-terminal.sh`
+                ShellExec.execDetachedArgs([terminalScript, ...command],
+                    displayName.length > 0 ? `Launch ${displayName}` : "",
+                    workingDirectory)
                 return true
             }
 
-            ShellExec.execDetachedArgs(command,
+            ShellExec.execDetachedArgs(ShellExec.privilegedGuiArgv(command),
                 displayName.length > 0 ? `Launch ${displayName}` : "",
                 workingDirectory)
             return true
@@ -378,7 +390,7 @@ Singleton {
                 displayName.length > 0 ? `Launch ${displayName}` : "")
         }
 
-        // Non-desktop search providers can still expose their own callback.
+        // launch-policy: allow provider-managed actions
         if (typeof entry.execute === "function") {
             entry.execute()
             return true
@@ -387,20 +399,26 @@ Singleton {
         return false
     }
 
+    // Launch a desktop entry action
     function launchDesktopAction(entry, action): bool {
-        if (!entry || !action) return false
-
-        const command = Array.from(action.command ?? []).map(arg => String(arg ?? "")).filter(arg => arg.length > 0)
-        if (command.length > 0) {
-            const actionName = String(action.name ?? entry.name ?? "").trim()
-            const workingDirectory = String(entry.workingDirectory ?? "").trim()
-            ShellExec.execDetachedArgs(command,
-                actionName.length > 0 ? `Launch ${actionName}` : "",
-                workingDirectory)
-            return true
+        if (action === undefined) {
+            action = entry
+            entry = null
         }
+        if (!action) return false
 
-        return false
+        const raw = (Array.isArray(action.command) && action.command.length > 0)
+            ? action.command
+            : (String(action.execString ?? "").trim().length > 0 ? [action.execString] : [])
+        const command = root._sanitizeDesktopArgs(raw)
+        if (command.length === 0) return false
+
+        const actionName = String(action.name ?? entry?.name ?? "app action").trim()
+        const workingDirectory = String(entry?.workingDirectory ?? "").trim()
+        ShellExec.execDetachedArgs(ShellExec.privilegedGuiArgv(command),
+            actionName.length > 0 ? `Launch ${actionName}` : "",
+            workingDirectory)
+        return true
     }
 
     function iconExists(iconName) {

--- a/services/AwwwBackend.qml
+++ b/services/AwwwBackend.qml
@@ -97,6 +97,8 @@ Singleton {
         if (root.previewActive && signature === root._previewSignature)
             return
 
+        root.ensureDaemon()
+
         // Preview uses the user's configured transition, exactly like an apply.
         // Hardcoding one here made every browse step look identical and unlike
         // the wallpaper change it is previewing.
@@ -298,20 +300,38 @@ Singleton {
         probeProc.running = true
     }
 
+    function ensureDaemon(): void {
+        if (!available)
+            return
+        ShellExec.launchDaemon({
+            program: "awww-daemon",
+            scope: "awww-daemon",
+            description: "iNiR wallpaper daemon",
+            ifActive: "reuse"
+        })
+    }
+
     // Applying a video wallpaper stops the daemon (awww cannot display video),
     // so any later awww command must be able to bring it back up first.
     readonly property string _ensureDaemonScript: `
                 awww_bin=$(command -v awww 2>/dev/null || true)
-                daemon_bin=$(command -v awww-daemon 2>/dev/null || true)
-                if [ -n "$awww_bin" ] && [ -n "$daemon_bin" ] && ! "$awww_bin" query >/dev/null 2>&1; then
-                    if command -v systemd-run >/dev/null 2>&1; then
-                        if ! systemd-run --user --quiet --collect --property=Description="iNiR wallpaper daemon" --setenv="WAYLAND_DISPLAY=$WAYLAND_DISPLAY" --setenv="XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" -- "$daemon_bin" >/dev/null 2>&1; then
-                            nohup "$daemon_bin" >/dev/null 2>&1 &
-                        fi
-                    else
-                        nohup "$daemon_bin" >/dev/null 2>&1 &
+                if [ -n "$awww_bin" ] && ! "$awww_bin" query >/dev/null 2>&1; then
+                    _i=0
+                    while [ "$_i" -lt 30 ]; do
+                        "$awww_bin" query >/dev/null 2>&1 && break
+                        systemctl --user is-active --quiet inir-awww-daemon 2>/dev/null || true
+                        sleep 0.1
+                        _i=$((_i + 1))
+                    done
+                    if ! "$awww_bin" query >/dev/null 2>&1; then
+                        systemctl --user start inir-awww-daemon.service >/dev/null 2>&1 || true
+                        _i=0
+                        while [ "$_i" -lt 30 ]; do
+                            "$awww_bin" query >/dev/null 2>&1 && break
+                            sleep 0.1
+                            _i=$((_i + 1))
+                        done
                     fi
-                    for _ in 1 2 3 4 5 6 7 8 9 10; do "$awww_bin" query >/dev/null 2>&1 && break; sleep 0.1; done
                 fi
             `
 
@@ -379,6 +399,8 @@ Singleton {
         // kill the in-progress transition just to restart the same one.
         if (applyProc.running && applyProc._pendingSignature === signature)
             return
+
+        root.ensureDaemon()
 
         const lines = [root._ensureDaemonScript]
 

--- a/services/ConflictKiller.qml
+++ b/services/ConflictKiller.qml
@@ -59,7 +59,7 @@ Singleton {
             else Quickshell.execDetached(["/usr/bin/killall", "mako", "dunst"])
         }
         if (openDialog) {
-            Quickshell.execDetached(["/usr/bin/qs", "-p", root.killDialogQmlPath])
+            ShellExec.launch({ program: "/usr/bin/qs", args: ["-p", root.killDialogQmlPath], scope: "killdialog", description: "Conflict resolution dialog" })
         }
     }
 

--- a/services/GlobalActions.qml
+++ b/services/GlobalActions.qml
@@ -121,6 +121,41 @@ Singleton {
         }
     }
 
+    IpcHandler {
+        target: "browser"
+
+        function open(): string {
+            console.debug("[ipc] request=browser open source=keybind")
+            AppLauncher.launch("browser")
+            return "ok"
+        }
+
+        function openUrl(url: string): string {
+            const rawUrl = String(url ?? "").trim()
+            if (rawUrl.length === 0) {
+                AppLauncher.launch("browser")
+                return "ok"
+            }
+            console.debug("[ipc] request=browser openUrl source=keybind")
+            AppLauncher.launchUrl("browser", rawUrl)
+            return "ok"
+        }
+    }
+
+    IpcHandler {
+        target: "files"
+
+        function open(): string {
+            console.debug("[ipc] request=files open source=keybind")
+            if (AppLauncher.slotDefinition("files")) {
+                AppLauncher.launch("files")
+            } else {
+                ShellExec.execCmd("nautilus")
+            }
+            return "ok"
+        }
+    }
+
     // ── Built-in Providers ──────────────────────────────────────────────
 
     // SYSTEM: WiFi, Bluetooth, Night Light, Game Mode, DND, Lock, Session
@@ -410,12 +445,12 @@ Singleton {
             category: "tools",
             keywords: ["record", "screen", "video", "capture", "wf-recorder", "audio", "microphone", "mic"],
             execute: () => {
-                const args = ["/usr/bin/bash", Directories.recordScriptPath]
+                const args = [Directories.recordScriptPath]
                 if (RecorderStatus.isRecording)
                     args.push("--stop")
                 else
                     args.push("--fullscreen", "--sound")
-                Quickshell.execDetached(args)
+                ShellExec.launch({ program: ShellExec.bashPath, args, scope: "record", description: "Toggle screen recording" })
                 RecorderStatus.scheduleQuickCheck()
             }
         },
@@ -892,7 +927,7 @@ Singleton {
         ShellExec.execDetachedArgs(term === "wezterm"
             ? [term, "start", "--always-new-process", "--", "/usr/bin/bash", path]
             : [term, "-e", "/usr/bin/bash", path], `Setup ${target.name}`)
-        Quickshell.execDetached(["/usr/bin/notify-send",
+        ShellExec.execDetachedArgs(["/usr/bin/notify-send",
             "-a", "Setup", "-i", target.icon || "download",
             "-h", `string:x-canonical-private-synchronous:setup-${target.slug}`,
             "--", target.name, Translation.tr("Starting setup in terminal…")])

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -2,6 +2,7 @@ pragma Singleton
 
 import QtQuick
 import qs.modules.common
+import qs.modules.common.functions
 import Quickshell
 import Quickshell.Io
 import Quickshell.Hyprland
@@ -101,12 +102,9 @@ Singleton {
 
     function _doEnable() {
         if (CompositorService.isNiri) {
-            // wlsunset: -T high temp (day), -t low temp (night)
-            // Force "always night" mode: sunset at 00:00, sunrise at 23:59
-            // Must use execDetached so wlsunset keeps running after Process ends
-            Quickshell.execDetached(["/usr/bin/wlsunset", "-T", "6500", "-t", root.colorTemperature.toString(), "-s", "00:00", "-S", "23:59"]);
+            ShellExec.launchDaemon({ program: "/usr/bin/wlsunset", args: ["-T", "6500", "-t", root.colorTemperature.toString(), "-s", "00:00", "-S", "23:59"], scope: "wlsunset", description: "Night light (wlsunset)" });
         } else {
-            hyprsunsetStartProc.running = true;
+            ShellExec.launchDaemon({ program: "/usr/bin/hyprsunset", args: ["--temperature", root.colorTemperature.toString()], scope: "hyprsunset", description: "Night light (hyprsunset)" });
         }
     }
 
@@ -139,11 +137,6 @@ Singleton {
 
     // === Hyprland processes ===
     Process {
-        id: hyprsunsetStartProc
-        command: ["/usr/bin/bash", "-c", `pidof hyprsunset || /usr/bin/hyprsunset --temperature ${root.colorTemperature}`]
-    }
-
-    Process {
         id: hyprsunsetKillProc
         command: ["/usr/bin/pkill", "-x", "hyprsunset"]
     }
@@ -175,9 +168,6 @@ Singleton {
             }
         }
     }
-
-    // wlsunsetStartProc removed - using Quickshell.execDetached instead
-    // because Process terminates the child when it's destroyed/restarted
 
     Process {
         id: niriFetchProc
@@ -218,6 +208,7 @@ Singleton {
                 root._pendingRestart = true;
                 restartDebounce.restart();
             } else {
+                // launch-policy: allow hyprctl temperature IPC, not daemon launch
                 Quickshell.execDetached(["/usr/bin/hyprctl", "hyprsunset", "temperature", `${temp}`]);
             }
         }

--- a/services/ShellUpdates.qml
+++ b/services/ShellUpdates.qml
@@ -250,7 +250,7 @@ Singleton {
             print("[ShellUpdates] Update launched in terminal (" + termBin + ") from: " + repoDir)
         } else {
             // Detached background — same path as before the terminal toggle existed.
-            Quickshell.execDetached(["/usr/bin/bash", "-c", bashCmd])
+            ShellExec.launch({ program: ShellExec.bashPath, args: ["-c", bashCmd], scope: "update", description: "Update iNiR" })
             print("[ShellUpdates] Update launched (detached) from: " + repoDir)
         }
         print("[ShellUpdates] Log: " + logPath + " | Status: " + statusPath)

--- a/services/TrayService.qml
+++ b/services/TrayService.qml
@@ -251,6 +251,7 @@ Singleton {
         }
     }
 
+    // launch-policy: allow bridge lifecycle bound to shell
     Process {
         id: xembedProxyStartProc
         stdout: SplitParser {

--- a/services/deferred/EasyEffects.qml
+++ b/services/deferred/EasyEffects.qml
@@ -2,6 +2,7 @@ pragma Singleton
 pragma ComponentBehavior: Bound
 
 import qs.modules.common
+import qs.modules.common.functions
 import QtQuick
 import Quickshell
 import Quickshell.Io
@@ -48,9 +49,9 @@ Singleton {
         if (!root.available) return
         root.active = true
         if (root.nativeInstalled) {
-            Quickshell.execDetached(["/usr/bin/easyeffects", "--service-mode"])
+            ShellExec.launchDaemon({ program: "/usr/bin/easyeffects", args: ["--service-mode"], scope: "easyeffects", description: "EasyEffects service mode", ifActive: "reuse" })
         } else {
-            Quickshell.execDetached(["/usr/bin/flatpak", "run", "com.github.wwmm.easyeffects", "--service-mode"])
+            ShellExec.launchDaemon({ program: "/usr/bin/flatpak", args: ["run", "com.github.wwmm.easyeffects", "--service-mode"], scope: "easyeffects", description: "EasyEffects service mode (flatpak)", ifActive: "reuse" })
         }
         refreshStateTimer.restart()
     }


### PR DESCRIPTION
## Summary

Centralize process launches behind `ShellExec.launch` (transient user scopes) and `ShellExec.launchDaemon` (transient systemd user services), so interactive apps and session daemons share one lifecycle policy.

Why: ad-hoc `execDetached` / `Process` children died with the shell or raced systemd. Night-light temperature updates, wallpaper daemon bring-up, Super+E, privileged GUIs, and keyring unlock all go through that policy.

**BREAKING CHANGE:** `launchDaemon` replaces a live unit unless the caller passes `ifActive: "reuse"`. `inir files` no longer reads `config.json` next to `shell.qml`.

## Testing

- [x] `inir restart && inir logs`: no new errors
- [x] Exercised the exact flow that changed (`inir files` / `files open`, launchDaemon contract tests, policy scanner)
- [x] Both panel families checked (shared ShellExec/AppSearch/GlobalActions; ii recorder; waffle start menu)

## Notes

Closes #