### PR TITLE
feat(network): support 6 GHz frequency band calculations and active network details

### DIFF
--- a/modules/common/models/quickToggles/NetworkToggle.qml
+++ b/modules/common/models/quickToggles/NetworkToggle.qml
@@ -8,7 +8,21 @@ import qs.modules.common.widgets
 QuickToggleModel {
     name: Translation.tr("Internet")
     statusText: Network.networkName
-    tooltipText: Translation.tr("%1 | Right-click to configure").arg(Network.networkName)
+    tooltipText: {
+        if (!Network.wifiEnabled) return Translation.tr("Wi-Fi is disabled");
+        if (Network.ethernet) return Translation.tr("Ethernet connected");
+        if (!Network.networkName) return Translation.tr("Not connected");
+        let info = Network.networkName;
+        if (Network.active) {
+            info += " (" + Network.networkStrength + "%)";
+            if (Network.active.rate) info += " | " + Network.active.rate;
+            if (Network.active.frequency) {
+                let ghz = Network.active.frequency > 5900 ? "6 GHz" : (Network.active.frequency > 4000 ? "5 GHz" : "2.4 GHz");
+                info += " | " + ghz;
+            }
+        }
+        return Translation.tr("%1 | Right-click to configure").arg(info);
+    }
     icon: Network.materialSymbol
 
     toggled: Network.wifiStatus !== "disabled"

--- a/modules/sidebarRight/quickToggles/androidStyle/AndroidNetworkToggle.qml
+++ b/modules/sidebarRight/quickToggles/androidStyle/AndroidNetworkToggle.qml
@@ -15,7 +15,21 @@ AndroidQuickToggleButton {
     mainAction: () => Network.toggleWifi()
     altAction: () => root.openMenu()
     StyledToolTip {
-        text: Translation.tr("%1 | Right-click to configure").arg(Network.networkName)
+        text: {
+            if (!Network.wifiEnabled) return Translation.tr("Wi-Fi is disabled");
+            if (Network.ethernet) return Translation.tr("Ethernet connected");
+            if (!Network.networkName) return Translation.tr("Not connected");
+            let info = Network.networkName;
+            if (Network.active) {
+                info += " (" + Network.networkStrength + "%)";
+                if (Network.active.rate) info += " | " + Network.active.rate;
+                if (Network.active.frequency) {
+                    let ghz = Network.active.frequency > 5900 ? "6 GHz" : (Network.active.frequency > 4000 ? "5 GHz" : "2.4 GHz");
+                    info += " | " + ghz;
+                }
+            }
+            return Translation.tr("%1 | Right-click to configure").arg(info);
+        }
     }
 }
 

--- a/modules/sidebarRight/quickToggles/classicStyle/NetworkToggle.qml
+++ b/modules/sidebarRight/quickToggles/classicStyle/NetworkToggle.qml
@@ -15,6 +15,20 @@ QuickToggleButton {
     onClicked: Network.toggleWifi()
     // altAction is set by parent (ClassicQuickPanel opens dialog, others may open external app)
     StyledToolTip {
-        text: Translation.tr("%1 | Right-click to configure").arg(Network.networkName)
+        text: {
+            if (!Network.wifiEnabled) return Translation.tr("Wi-Fi is disabled");
+            if (Network.ethernet) return Translation.tr("Ethernet connected");
+            if (!Network.networkName) return Translation.tr("Not connected");
+            let info = Network.networkName;
+            if (Network.active) {
+                info += " (" + Network.networkStrength + "%)";
+                if (Network.active.rate) info += " | " + Network.active.rate;
+                if (Network.active.frequency) {
+                    let ghz = Network.active.frequency > 5900 ? "6 GHz" : (Network.active.frequency > 4000 ? "5 GHz" : "2.4 GHz");
+                    info += " | " + ghz;
+                }
+            }
+            return Translation.tr("%1 | Right-click to configure").arg(info);
+        }
     }
 }

--- a/modules/sidebarRight/wifiNetworks/WifiNetworkItem.qml
+++ b/modules/sidebarRight/wifiNetworks/WifiNetworkItem.qml
@@ -35,11 +35,42 @@ DialogListItem {
                 text: strength > 80 ? "signal_wifi_4_bar" : strength > 60 ? "network_wifi_3_bar" : strength > 40 ? "network_wifi_2_bar" : strength > 20 ? "network_wifi_1_bar" : "signal_wifi_0_bar"
                 color: Appearance.inirEverywhere ? Appearance.inir.colTextSecondary : Appearance.colors.colOnSurfaceVariant
             }
-            StyledText {
+            ColumnLayout {
                 Layout.fillWidth: true
-                color: Appearance.inirEverywhere ? Appearance.inir.colText : Appearance.colors.colOnSurfaceVariant
-                elide: Text.ElideRight
-                text: root.wifiNetwork?.ssid ?? Translation.tr("Unknown")
+                spacing: 2
+                StyledText {
+                    Layout.fillWidth: true
+                    color: Appearance.inirEverywhere ? Appearance.inir.colText : Appearance.colors.colOnSurfaceVariant
+                    elide: Text.ElideRight
+                    text: root.wifiNetwork?.ssid ?? Translation.tr("Unknown")
+                }
+                Revealer {
+                    vertical: true
+                    reveal: root.wifiNetwork?.active ?? false
+                    Layout.fillWidth: true
+                    StyledText {
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.inirEverywhere ? Appearance.inir.colTextSecondary : Appearance.colors.colSubtext
+                        elide: Text.ElideRight
+                        text: {
+                            if (!root.wifiNetwork || !root.wifiNetwork.active) return "";
+                            let details = [];
+                            details.push(Translation.tr("Connected"));
+                            details.push(root.wifiNetwork.strength + "%");
+                            if (root.wifiNetwork.frequency) {
+                                let ghz = root.wifiNetwork.frequency > 5900 ? "6 GHz" : (root.wifiNetwork.frequency > 4000 ? "5 GHz" : "2.4 GHz");
+                                details.push(ghz + " (" + root.wifiNetwork.frequency + " MHz)");
+                            }
+                            if (root.wifiNetwork.rate) {
+                                details.push(root.wifiNetwork.rate);
+                            }
+                            if (root.wifiNetwork.bssid) {
+                                details.push(root.wifiNetwork.bssid);
+                            }
+                            return details.join(" • ");
+                        }
+                    }
+                }
             }
             MaterialSymbol {
                 visible: (root.wifiNetwork?.isSecure || root.wifiNetwork?.active) ?? false


### PR DESCRIPTION
### Summary
Adds frequency band detection for frequencies >5900 MHz to properly identify and display **6 GHz (Wi-Fi 6E / Wi-Fi 7)** networks across network toggles and the Wi-Fi network list.

### Changes
- : Shows connected frequency (2.4 GHz / 5 GHz / 6 GHz), link rate, and signal strength for active networks.
-  & Quick Toggle buttons: Include 6 GHz band calculation and link rate in tooltip status.
