### PR TITLE
feat(bluetooth): add connected device name/battery hover tooltip and pending feedback

### DIFF
--- a/modules/bar/BarContent.qml
+++ b/modules/bar/BarContent.qml
@@ -1539,6 +1539,25 @@ Item { // Bar content region
                         text: BluetoothStatus.activeIcon
                         iconSize: Appearance.font.pixelSize.larger
                         color: rightSidebarButton.colText
+
+                        HoverHandler {
+                            id: btHover
+                        }
+
+                        StyledToolTip {
+                            extraVisibleCondition: btHover.hovered
+                            text: {
+                                if (!BluetoothStatus.enabled) return Translation.tr("Bluetooth is disabled");
+                                if (!BluetoothStatus.connected) return Translation.tr("Bluetooth disconnected");
+                                let device = BluetoothStatus.firstActiveDevice;
+                                if (!device) return Translation.tr("Bluetooth connected");
+                                let devInfo = device.name || Translation.tr("Unknown device");
+                                if (device.batteryAvailable) {
+                                    devInfo += " (" + Math.round(device.battery * 100) + "%)";
+                                }
+                                return devInfo;
+                            }
+                        }
                     }
                 }
             }

--- a/modules/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
+++ b/modules/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
@@ -101,15 +101,38 @@ DialogListItem {
 
                 Item { Layout.fillWidth: true }
                 ActionButton {
-                    buttonText: root.device?.connected ? Translation.tr("Disconnect") : Translation.tr("Connect")
+                    id: connectBtn
+                    property bool operationPending: false
+                    buttonText: {
+                        if (operationPending) {
+                            return root.device?.connected ? Translation.tr("Disconnecting…") : Translation.tr("Connecting…");
+                        }
+                        return root.device?.connected ? Translation.tr("Disconnect") : Translation.tr("Connect")
+                    }
 
                     onClicked: {
+                        operationPending = true;
+                        pendingTimeout.start();
                         if (root.device?.connected) {
                             root.device.disconnect();
                         } else {
                             root.device.trusted = true;
                             root.device.connect();
                         }
+                    }
+
+                    Connections {
+                        target: root.device
+                        function onConnectedChanged() {
+                            connectBtn.operationPending = false;
+                            pendingTimeout.stop();
+                        }
+                    }
+
+                    Timer {
+                        id: pendingTimeout
+                        interval: 15000
+                        onTriggered: connectBtn.operationPending = false
                     }
                 }
                 Revealer {


### PR DESCRIPTION
### Summary
Adds a clean hover tooltip to the Bluetooth status icon in the top bar to show the connected device name and battery percentage (if available), along with visual pending feedback (Connecting… / Disconnecting…) in the Bluetooth device item.

### Changes
- : Shows connected device name + battery percentage when hovering over the Bluetooth icon.
- : Displays pending action states during connection/disconnection.
