### PR TITLE
fix(wifi): auto-refresh network details on Wi-Fi icon hover and add detailed tooltip

### DIFF
--- a/modules/bar/BarContent.qml
+++ b/modules/bar/BarContent.qml
@@ -1531,6 +1531,39 @@ Item { // Bar content region
                     iconSize: Appearance.font.pixelSize.larger
                     color: rightSidebarButton.colText
                     Layout.rightMargin: BluetoothStatus.available ? indicatorsRowLayout.realSpacing : 0
+
+                    HoverHandler {
+                        id: wifiHover
+                        onHoveredChanged: {
+                            if (hovered) {
+                                Network.refreshActiveNetworkDetails();
+                            }
+                        }
+                    }
+
+                    StyledToolTip {
+                        extraVisibleCondition: wifiHover.hovered
+                        text: {
+                            if (!Network.wifiEnabled) return Translation.tr("Wi-Fi is disabled");
+                            if (Network.ethernet) return Translation.tr("Ethernet connected");
+                            if (!Network.networkName) return Translation.tr("Not connected");
+                            let lines = [Translation.tr("Connected to %1").arg(Network.networkName)];
+                            if (Network.active) {
+                                lines.push(Network.networkStrength + "%");
+                                if (Network.active.frequency) {
+                                    let ghz = Network.active.frequency > 5900 ? "6 GHz" : (Network.active.frequency > 4000 ? "5 GHz" : "2.4 GHz");
+                                    lines.push(ghz + " (" + Network.active.frequency + " MHz)");
+                                }
+                                if (Network.active.rate) {
+                                    lines.push(Network.active.rate);
+                                }
+                                if (Network.active.bssid) {
+                                    lines.push(Network.active.bssid);
+                                }
+                            }
+                            return lines.join(" | ");
+                        }
+                    }
                 }
                 Revealer {
                     reveal: BluetoothStatus.available

--- a/services/Network.qml
+++ b/services/Network.qml
@@ -81,6 +81,12 @@ Singleton {
         if (active) disconnectProc.exec(["nmcli", "connection", "down", active.ssid]);
     }
 
+    function refreshActiveNetworkDetails(): void {
+        if (!getNetworks.running) {
+            getNetworks.running = true;
+        }
+    }
+
     function openPublicWifiPortal() {
         ShellExec.execDetachedArgs(["xdg-open", "https://nmcheck.gnome.org/"], "Open network check") // From some StackExchange thread, seems to work
     }


### PR DESCRIPTION
### Summary
Adds a targeted hover tooltip directly to the Wi-Fi icon in the top bar with connection metrics (SSID, signal %, frequency band, link rate, BSSID) and triggers an auto-refresh of active network details on hover to prevent stale or blank network states.

### Changes
- : Restricts hover tooltip to the Wi-Fi icon with live connection parameters.
- : Exposes  to refresh network metadata on icon hover.
