### PR TITLE
feat(systemd): wrap terminal and browser launching in transient systemd scopes

### DIFF
--- a/scripts/inir
+++ b/scripts/inir
@@ -3490,17 +3490,31 @@ launch_configured_browser() {
     browser="${browser:-xdg-open}"
 
     if command -v "$browser" >/dev/null 2>&1; then
-        if [[ $# -gt 0 ]]; then
-            exec "$browser" "$@"
+        if command -v systemd-run >/dev/null 2>&1; then
+            if [[ $# -gt 0 ]]; then
+                exec systemd-run --user --scope --quiet --collect --property="Description=iNiR Browser" -- "$browser" "$@"
+            fi
+            exec systemd-run --user --scope --quiet --collect --property="Description=iNiR Browser" -- "$browser"
+        else
+            if [[ $# -gt 0 ]]; then
+                exec "$browser" "$@"
+            fi
+            exec "$browser"
         fi
-        exec "$browser"
     fi
 
     if command -v xdg-open >/dev/null 2>&1; then
-        if [[ $# -gt 0 ]]; then
-            exec xdg-open "$@"
+        if command -v systemd-run >/dev/null 2>&1; then
+            if [[ $# -gt 0 ]]; then
+                exec systemd-run --user --scope --quiet --collect --property="Description=XDG Open" -- xdg-open "$@"
+            fi
+            exec systemd-run --user --scope --quiet --collect --property="Description=XDG Open" -- xdg-open "https://"
+        else
+            if [[ $# -gt 0 ]]; then
+                exec xdg-open "$@"
+            fi
+            exec xdg-open "https://"
         fi
-        exec xdg-open "https://"
     fi
 
     echo "No browser launcher found" >&2

--- a/scripts/launch-terminal.sh
+++ b/scripts/launch-terminal.sh
@@ -17,13 +17,21 @@ fi
 TERMINAL="${TERMINAL:-kitty}"
 
 if command -v "$TERMINAL" &>/dev/null; then
-    exec "$TERMINAL" "$@"
+    if command -v systemd-run &>/dev/null; then
+        exec systemd-run --user --scope --quiet --collect --property="Description=iNiR Terminal" -- "$TERMINAL" "$@"
+    else
+        exec "$TERMINAL" "$@"
+    fi
 fi
 
 # Fallback chain: project default first, then popular alternatives
 for fallback in kitty foot ghostty alacritty wezterm konsole xterm; do
     if command -v "$fallback" &>/dev/null; then
-        exec "$fallback" "$@"
+        if command -v systemd-run &>/dev/null; then
+            exec systemd-run --user --scope --quiet --collect --property="Description=iNiR Terminal" -- "$fallback" "$@"
+        else
+            exec "$fallback" "$@"
+        fi
     fi
 done
 


### PR DESCRIPTION
### Summary
Wraps spawned terminal and browser processes in transient  units when systemd is available.

### Why this is needed
When the iNiR shell service restarts, updates, or crashes, child processes launched directly by the shell can be terminated with the cgroup. Wrapping application launches in transient user scopes isolates running applications (e.g. terminals, browsers, coding sessions) so they stay alive across shell lifecycle events.
