### PR TITLE
feat(search): add development environment actions

### DIFF
--- a/defaults/dev-environments.json
+++ b/defaults/dev-environments.json
@@ -3,7 +3,7 @@
     "id": "rails",
     "name": "Ruby on Rails",
     "group": "Ruby",
-    "description": "Install Ruby on Rails with mise and Bundler defaults",
+    "description": "Ruby on Rails language and framework with Bundler defaults",
     "icon": "code",
     "tags": ["ruby", "rails", "gem", "framework"]
   },
@@ -11,7 +11,7 @@
     "id": "node",
     "name": "Node.js",
     "group": "JavaScript",
-    "description": "Install the Node.js JavaScript runtime",
+    "description": "Node.js JavaScript runtime and package ecosystem",
     "icon": "javascript",
     "tags": ["javascript", "node", "npm", "runtime"]
   },
@@ -19,7 +19,7 @@
     "id": "bun",
     "name": "Bun",
     "group": "JavaScript",
-    "description": "Install the Bun JavaScript runtime and package manager",
+    "description": "Bun JavaScript runtime and package manager",
     "icon": "javascript",
     "tags": ["javascript", "bun", "runtime", "package manager"]
   },
@@ -27,7 +27,7 @@
     "id": "deno",
     "name": "Deno",
     "group": "JavaScript",
-    "description": "Install the Deno JavaScript and TypeScript runtime",
+    "description": "Deno JavaScript and TypeScript runtime",
     "icon": "javascript",
     "tags": ["javascript", "typescript", "deno", "runtime"]
   },
@@ -35,7 +35,7 @@
     "id": "go",
     "name": "Go",
     "group": "Languages",
-    "description": "Install the Go programming language",
+    "description": "Go programming language and toolchain",
     "icon": "code",
     "tags": ["golang", "language", "compiler"]
   },
@@ -43,7 +43,7 @@
     "id": "php",
     "name": "PHP",
     "group": "PHP",
-    "description": "Install PHP, Composer, SQLite, and Xdebug",
+    "description": "PHP, Composer, SQLite, and Xdebug development tools",
     "icon": "code",
     "tags": ["php", "composer", "xdebug", "web"]
   },
@@ -51,7 +51,7 @@
     "id": "laravel",
     "name": "Laravel",
     "group": "PHP",
-    "description": "Install PHP, Node.js, and the Laravel installer",
+    "description": "PHP, Node.js, and the Laravel application installer",
     "icon": "code",
     "tags": ["php", "laravel", "composer", "framework"]
   },
@@ -59,7 +59,7 @@
     "id": "symfony",
     "name": "Symfony",
     "group": "PHP",
-    "description": "Install PHP and the Symfony CLI",
+    "description": "PHP and the Symfony application CLI",
     "icon": "code",
     "tags": ["php", "symfony", "framework", "web"]
   },
@@ -67,7 +67,7 @@
     "id": "python",
     "name": "Python",
     "group": "Languages",
-    "description": "Install Python with the uv package manager",
+    "description": "Python language with the uv package manager",
     "icon": "code",
     "tags": ["python", "uv", "language", "pip"]
   },
@@ -75,7 +75,7 @@
     "id": "elixir",
     "name": "Elixir",
     "group": "Elixir",
-    "description": "Install Erlang, Elixir, and Hex",
+    "description": "Erlang, Elixir, and Hex development tools",
     "icon": "code",
     "tags": ["elixir", "erlang", "hex", "language"]
   },
@@ -83,7 +83,7 @@
     "id": "phoenix",
     "name": "Phoenix",
     "group": "Elixir",
-    "description": "Install Elixir, Erlang, Hex, Rebar, and Phoenix",
+    "description": "Elixir, Erlang, Hex, Rebar, and Phoenix framework tools",
     "icon": "code",
     "tags": ["elixir", "erlang", "phoenix", "framework"]
   },
@@ -91,7 +91,7 @@
     "id": "rust",
     "name": "Rust",
     "group": "Languages",
-    "description": "Install Rust with rustup",
+    "description": "Rust language and rustup toolchain",
     "icon": "code",
     "tags": ["rust", "cargo", "rustup", "language"]
   },
@@ -99,7 +99,7 @@
     "id": "java",
     "name": "Java",
     "group": "Languages",
-    "description": "Install the Java runtime and development environment",
+    "description": "Java runtime and development toolchain",
     "icon": "code",
     "tags": ["java", "jdk", "language"]
   },
@@ -107,7 +107,7 @@
     "id": "zig",
     "name": "Zig",
     "group": "Languages",
-    "description": "Install Zig and the ZLS language server",
+    "description": "Zig compiler and ZLS language server",
     "icon": "code",
     "tags": ["zig", "zls", "language", "compiler"]
   },
@@ -115,7 +115,7 @@
     "id": "dotnet",
     "name": ".NET",
     "group": "Languages",
-    "description": "Install the .NET SDK",
+    "description": ".NET SDK and development toolchain",
     "icon": "code",
     "tags": ["dotnet", "csharp", "c#", "language"]
   },
@@ -123,7 +123,7 @@
     "id": "ocaml",
     "name": "OCaml",
     "group": "Languages",
-    "description": "Install OCaml, opam, LSP, odoc, and formatting tools",
+    "description": "OCaml, opam, LSP, documentation, and formatting tools",
     "icon": "code",
     "tags": ["ocaml", "opam", "language", "lsp"]
   },
@@ -131,7 +131,7 @@
     "id": "clojure",
     "name": "Clojure",
     "group": "Languages",
-    "description": "Install Clojure with rlwrap",
+    "description": "Clojure language with rlwrap",
     "icon": "code",
     "tags": ["clojure", "jvm", "language", "lisp"]
   },
@@ -139,7 +139,7 @@
     "id": "scala",
     "name": "Scala",
     "group": "Languages",
-    "description": "Install Java, Scala, and Scala CLI",
+    "description": "Java, Scala, and Scala CLI development tools",
     "icon": "code",
     "tags": ["scala", "java", "jvm", "language"]
   },
@@ -147,7 +147,7 @@
     "id": "docker-dbs",
     "name": "Docker Databases",
     "group": "Docker",
-    "description": "Install MySQL, PostgreSQL, Redis, MongoDB, MariaDB, or MSSQL containers",
+    "description": "MySQL, PostgreSQL, Redis, MongoDB, MariaDB, or MSSQL containers",
     "icon": "deployed_code",
     "tags": ["docker", "database", "mysql", "postgres", "redis", "mongodb"]
   }

--- a/defaults/dev-environments.json
+++ b/defaults/dev-environments.json
@@ -1,0 +1,154 @@
+[
+  {
+    "id": "rails",
+    "name": "Ruby on Rails",
+    "group": "Ruby",
+    "description": "Install Ruby on Rails with mise and Bundler defaults",
+    "icon": "code",
+    "tags": ["ruby", "rails", "gem", "framework"]
+  },
+  {
+    "id": "node",
+    "name": "Node.js",
+    "group": "JavaScript",
+    "description": "Install the Node.js JavaScript runtime",
+    "icon": "javascript",
+    "tags": ["javascript", "node", "npm", "runtime"]
+  },
+  {
+    "id": "bun",
+    "name": "Bun",
+    "group": "JavaScript",
+    "description": "Install the Bun JavaScript runtime and package manager",
+    "icon": "javascript",
+    "tags": ["javascript", "bun", "runtime", "package manager"]
+  },
+  {
+    "id": "deno",
+    "name": "Deno",
+    "group": "JavaScript",
+    "description": "Install the Deno JavaScript and TypeScript runtime",
+    "icon": "javascript",
+    "tags": ["javascript", "typescript", "deno", "runtime"]
+  },
+  {
+    "id": "go",
+    "name": "Go",
+    "group": "Languages",
+    "description": "Install the Go programming language",
+    "icon": "code",
+    "tags": ["golang", "language", "compiler"]
+  },
+  {
+    "id": "php",
+    "name": "PHP",
+    "group": "PHP",
+    "description": "Install PHP, Composer, SQLite, and Xdebug",
+    "icon": "code",
+    "tags": ["php", "composer", "xdebug", "web"]
+  },
+  {
+    "id": "laravel",
+    "name": "Laravel",
+    "group": "PHP",
+    "description": "Install PHP, Node.js, and the Laravel installer",
+    "icon": "code",
+    "tags": ["php", "laravel", "composer", "framework"]
+  },
+  {
+    "id": "symfony",
+    "name": "Symfony",
+    "group": "PHP",
+    "description": "Install PHP and the Symfony CLI",
+    "icon": "code",
+    "tags": ["php", "symfony", "framework", "web"]
+  },
+  {
+    "id": "python",
+    "name": "Python",
+    "group": "Languages",
+    "description": "Install Python with the uv package manager",
+    "icon": "code",
+    "tags": ["python", "uv", "language", "pip"]
+  },
+  {
+    "id": "elixir",
+    "name": "Elixir",
+    "group": "Elixir",
+    "description": "Install Erlang, Elixir, and Hex",
+    "icon": "code",
+    "tags": ["elixir", "erlang", "hex", "language"]
+  },
+  {
+    "id": "phoenix",
+    "name": "Phoenix",
+    "group": "Elixir",
+    "description": "Install Elixir, Erlang, Hex, Rebar, and Phoenix",
+    "icon": "code",
+    "tags": ["elixir", "erlang", "phoenix", "framework"]
+  },
+  {
+    "id": "rust",
+    "name": "Rust",
+    "group": "Languages",
+    "description": "Install Rust with rustup",
+    "icon": "code",
+    "tags": ["rust", "cargo", "rustup", "language"]
+  },
+  {
+    "id": "java",
+    "name": "Java",
+    "group": "Languages",
+    "description": "Install the Java runtime and development environment",
+    "icon": "code",
+    "tags": ["java", "jdk", "language"]
+  },
+  {
+    "id": "zig",
+    "name": "Zig",
+    "group": "Languages",
+    "description": "Install Zig and the ZLS language server",
+    "icon": "code",
+    "tags": ["zig", "zls", "language", "compiler"]
+  },
+  {
+    "id": "dotnet",
+    "name": ".NET",
+    "group": "Languages",
+    "description": "Install the .NET SDK",
+    "icon": "code",
+    "tags": ["dotnet", "csharp", "c#", "language"]
+  },
+  {
+    "id": "ocaml",
+    "name": "OCaml",
+    "group": "Languages",
+    "description": "Install OCaml, opam, LSP, odoc, and formatting tools",
+    "icon": "code",
+    "tags": ["ocaml", "opam", "language", "lsp"]
+  },
+  {
+    "id": "clojure",
+    "name": "Clojure",
+    "group": "Languages",
+    "description": "Install Clojure with rlwrap",
+    "icon": "code",
+    "tags": ["clojure", "jvm", "language", "lisp"]
+  },
+  {
+    "id": "scala",
+    "name": "Scala",
+    "group": "Languages",
+    "description": "Install Java, Scala, and Scala CLI",
+    "icon": "code",
+    "tags": ["scala", "java", "jvm", "language"]
+  },
+  {
+    "id": "docker-dbs",
+    "name": "Docker Databases",
+    "group": "Docker",
+    "description": "Install MySQL, PostgreSQL, Redis, MongoDB, MariaDB, or MSSQL containers",
+    "icon": "deployed_code",
+    "tags": ["docker", "database", "mysql", "postgres", "redis", "mongodb"]
+  }
+]

--- a/docs/GLOBAL_ACTIONS.md
+++ b/docs/GLOBAL_ACTIONS.md
@@ -62,6 +62,16 @@ The action id (`/setup-<slug>`), display name, icon, keywords, terminal launchin
 
 You can disable the whole category by setting `search.globalActions.enableSetup` to `false` in your config.
 
+## Development environments
+
+Search for a language, runtime, framework, or database by name in an unprefixed search. Results show the current state and open a terminal action to install or remove the selected environment.
+
+Supported entries include Ruby/Rails, Node.js, Bun, Deno, Go, PHP, Laravel, Symfony, Python, Elixir, Phoenix, Rust, Java, Zig, .NET, OCaml, Clojure, Scala, and Docker databases. The setup backend currently targets Arch-based systems and keeps the package/runtime recipes in `scripts/setup/development.sh`.
+
+The metadata is maintained in [`defaults/dev-environments.json`](https://github.com/snowarch/inir/blob/main/defaults/dev-environments.json). Prefix searches remain routed to their existing providers.
+
+For Bun and Deno, Remove also handles an exact Arch package (`bun`, `bun-bin`, or `deno`) when the command resolves to `/usr/bin`; unrelated system packages are not removed.
+
 ## Custom actions
 
 You can add your own actions by creating scripts in:

--- a/docs/GLOBAL_ACTIONS.md
+++ b/docs/GLOBAL_ACTIONS.md
@@ -64,11 +64,11 @@ You can disable the whole category by setting `search.globalActions.enableSetup`
 
 ## Development environments
 
-Search for a language, runtime, framework, or database by name in an unprefixed search. Results show the current state and open a terminal action to install or remove the selected environment.
+Search for a language, runtime, framework, or database by name in an unprefixed search. Results remain available as discovery entries everywhere; install and remove actions are shown only where the current platform supports them.
 
-Supported entries include Ruby/Rails, Node.js, Bun, Deno, Go, PHP, Laravel, Symfony, Python, Elixir, Phoenix, Rust, Java, Zig, .NET, OCaml, Clojure, Scala, and Docker databases. The setup backend currently targets Arch-based systems and keeps the package/runtime recipes in `scripts/setup/development.sh`.
+Supported entries include Ruby/Rails, Node.js, Bun, Deno, Go, PHP, Laravel, Symfony, Python, Elixir, Phoenix, Rust, Java, Zig, .NET, OCaml, Clojure, Scala, and Docker databases. The search metadata is maintained in `defaults/dev-environments.json`; the private mutation helper is `scripts/setup/_development.sh`.
 
-The metadata is maintained in [`defaults/dev-environments.json`](https://github.com/snowarch/inir/blob/main/defaults/dev-environments.json). Prefix searches remain routed to their existing providers.
+Prefix searches remain routed to their existing providers. Unsupported systems still receive the discovery result, but no broken install/remove callback is attached.
 
 For Bun and Deno, Remove also handles an exact Arch package (`bun`, `bun-bin`, or `deno`) when the command resolves to `/usr/bin`; unrelated system packages are not removed.
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -90,6 +90,7 @@
 | **AppLauncher** | Default app slot manager (terminal, browser, file manager, etc.). |
 | **AppSearch** | Desktop entry fuzzy search with icon substitution mappings. |
 | **AppCatalog** | Curated software catalog with multi-distro install support. IPC target: `appCatalog`. |
+| **DevelopmentEnvironments** | Shared search provider for development environment status and install/remove actions. |
 | **LauncherSearch** | Overview search with prefix routing (apps, actions, calculator, packages). |
 | **TaskbarApps** | Dock/taskbar app list (merged pinned + open windows). |
 | **MinimizedWindows** | Niri window minimization via hidden workspace. IPC target: `minimize`. |

--- a/modules/overview/SearchItem.qml
+++ b/modules/overview/SearchItem.qml
@@ -27,6 +27,7 @@ RippleButton {
     property bool blurImage: entry?.blurImage ?? false
     property string blurImageText: entry?.blurImageText ?? "Image hidden"
     property bool compactClipboardPreview: entry?.compactClipboardPreview ?? false
+    readonly property bool actionable: typeof root.entry?.execute === "function"
     readonly property string desktopEntryId: String(root.entry?.desktopEntryId ?? "")
     readonly property bool draggableApplication: root.desktopEntryId.length > 0
     property bool suppressClick: false
@@ -165,6 +166,7 @@ RippleButton {
     }
 
     onClicked: {
+        if (!root.actionable) return
         if (root.suppressClick) {
             root.suppressClick = false
             return

--- a/modules/overview/SearchWidget.qml
+++ b/modules/overview/SearchWidget.qml
@@ -232,6 +232,19 @@ Item { // Wrapper
             })
         }
 
+        const hasSearchPrefix = [
+            root.prefixAction,
+            root.prefixApp,
+            root.prefixClipboard,
+            root.prefixEmojis,
+            root.prefixMath,
+            root.prefixShellCommand,
+            root.prefixWebSearch
+        ].some(prefix => text.startsWith(prefix))
+        const developmentResultObjects = hasSearchPrefix
+            ? []
+            : DevelopmentEnvironments.searchResults(text)
+
         const commandResultObject = {
             key: "__run_command__",
             name: StringUtils.cleanPrefix(text, root.prefixShellCommand).replace("file://", ""),
@@ -303,6 +316,7 @@ Item { // Wrapper
         }
 
         result = result.concat(appResultObjects);
+        result = result.concat(developmentResultObjects);
         result = result.concat(launcherActionObjects);
 
         if (root.searchPrefixes.showDefaultActionsWithoutPrefix ?? true) {

--- a/modules/waffle/startMenu/SearchResults.qml
+++ b/modules/waffle/startMenu/SearchResults.qml
@@ -184,9 +184,10 @@ RowLayout {
                 spacing: 1
                 model: {
                     const isAppEntry = resultPreview.entry?.type === Translation.tr("App");
+                    const hasPrimaryAction = typeof resultPreview.entry?.execute === "function";
                     const appId = isAppEntry ? (resultPreview.entry?.id ?? "") : "";
                     const pinned = isAppEntry ? (Config.options.dock?.pinnedApps?.includes(appId) ?? false) : false;
-                    var result = [
+                    var result = hasPrimaryAction ? [
                         ({
                             name: resultPreview.entry?.verb ?? Translation.tr("Open"),
                             iconName: isAppEntry ? "open_in_new" : "keyboard_return",
@@ -205,7 +206,7 @@ RowLayout {
                                 }
                             })
                         ] : [])
-                    ];
+                    ] : [];
                     if (resultPreview.entry?.actions) {
                         result = result.concat(resultPreview.entry.actions);
                     }

--- a/modules/waffle/startMenu/WSearchResultButton.qml
+++ b/modules/waffle/startMenu/WSearchResultButton.qml
@@ -26,8 +26,9 @@ WChoiceButton {
     }
 
     function execute() {
+        if (typeof root.entry?.execute !== "function") return;
         GlobalStates.searchOpen = false;
-        root.entry?.execute?.();
+        root.entry.execute();
     }
 
     contentItem: RowLayout {

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -26,6 +26,10 @@ Files whose basename starts with `_` (e.g. `_lib.sh`, `_template.sh.example`,
 `_scan.sh`) are never registered as actions, so they are safe to use for
 shared helpers.
 
+The private `_development.sh` helper follows the same rule. Development
+environment metadata is searched from `defaults/dev-environments.json`, while
+the helper is invoked directly only for supported install/remove operations.
+
 You can run the scanner by hand to debug what the launcher will see:
 
 ```bash

--- a/scripts/setup/_development.sh
+++ b/scripts/setup/_development.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# scripts/setup/development.sh
-# /setup-development — install or remove development environments.
+# scripts/setup/_development.sh
+# Internal backend for development-environment discovery and mutation.
 #
-# @meta name: Development Environments
-# @meta description: Install or remove languages, runtimes, frameworks, and Docker databases
-# @meta icon: code
-# @meta keywords: development language runtime framework mise ruby node bun deno go php python elixir rust java zig dotnet ocaml clojure scala docker database
+# Search metadata lives in defaults/dev-environments.json. This file is
+# intentionally private so it is not exposed as a generic /setup action.
 
 set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -39,7 +37,8 @@ declare -A ENV_LABELS=(
 )
 
 usage() {
-    printf 'Usage: %s [status|install|remove] [environment]\n' "${BASH_SOURCE[0]}"
+    printf 'Usage: %s status | %s install <environment> | %s remove <environment>\n' \
+        "${BASH_SOURCE[0]}" "${BASH_SOURCE[0]}" "${BASH_SOURCE[0]}"
     printf 'Environments: %s\n' "${ENV_IDS[*]}"
 }
 
@@ -174,50 +173,6 @@ install_php() {
     for ext in "${extensions_to_enable[@]}"; do
         sudo sed -i "s/^;extension=${ext}/extension=${ext}/" "$php_ini_path"
     done
-}
-
-choose_from_ids() {
-    local header="$1"
-    shift
-    local ids=("$@")
-    local i choice
-
-    if have_cmd gum; then
-        local options=()
-        for i in "${ids[@]}"; do
-            options+=("$i|${ENV_LABELS[$i]}")
-        done
-        choice="$(printf '%s\n' "${options[@]}" | gum choose --header "$header" || true)"
-        [[ -n "$choice" ]] || return 1
-        printf '%s\n' "${choice%%|*}"
-        return 0
-    fi
-
-    printf '\n%s\n' "$header" >&2
-    for i in "${!ids[@]}"; do
-        printf '  %d) %s\n' "$((i + 1))" "${ENV_LABELS[${ids[$i]}]}" >&2
-    done
-    printf '  0) Cancel\n' >&2
-    while true; do
-        read -r -p 'Enter choice: ' choice
-        [[ "$choice" == 0 ]] && return 1
-        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#ids[@]} )); then
-            printf '%s\n' "${ids[$((choice - 1))]}"
-            return 0
-        fi
-    done
-}
-
-select_operation_and_environment() {
-    local operation id
-    if have_cmd gum; then
-        operation="$(printf '%s\n' install remove | gum choose --header 'Select development action' || true)"
-    else
-        operation="install"
-    fi
-    [[ -n "$operation" ]] || return 1
-    id="$(choose_from_ids 'Select development environment' "${ENV_IDS[@]}")" || return 1
-    printf '%s\t%s\n' "$operation" "$id"
 }
 
 install_docker_databases() {
@@ -421,12 +376,6 @@ remove_environment() {
 main() {
     local operation="${1:-}"
     local id="${2:-}"
-
-    if [[ -z "$operation" ]]; then
-        local selection
-        selection="$(select_operation_and_environment)" || exit 0
-        IFS=$'\t' read -r operation id <<< "$selection"
-    fi
 
     case "$operation" in
         status)

--- a/scripts/setup/development.sh
+++ b/scripts/setup/development.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# scripts/setup/development.sh
+# /setup-development — install or remove development environments.
+#
+# @meta name: Development Environments
+# @meta description: Install or remove languages, runtimes, frameworks, and Docker databases
+# @meta icon: code
+# @meta keywords: development language runtime framework mise ruby node bun deno go php python elixir rust java zig dotnet ocaml clojure scala docker database
+
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/_lib.sh"
+
+readonly MISE_DATA_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}"
+readonly MISE_CACHE_DIR="${MISE_CACHE_DIR:-$HOME/.cache/mise}"
+readonly ENV_IDS=(rails node bun deno go php laravel symfony python elixir phoenix rust java zig dotnet ocaml clojure scala docker-dbs)
+
+declare -A ENV_LABELS=(
+    [rails]="Ruby on Rails"
+    [node]="Node.js"
+    [bun]="Bun"
+    [deno]="Deno"
+    [go]="Go"
+    [php]="PHP"
+    [laravel]="Laravel"
+    [symfony]="Symfony"
+    [python]="Python"
+    [elixir]="Elixir"
+    [phoenix]="Phoenix"
+    [rust]="Rust"
+    [java]="Java"
+    [zig]="Zig"
+    [dotnet]=".NET"
+    [ocaml]="OCaml"
+    [clojure]="Clojure"
+    [scala]="Scala"
+    [docker-dbs]="Docker Databases"
+)
+
+usage() {
+    printf 'Usage: %s [status|install|remove] [environment]\n' "${BASH_SOURCE[0]}"
+    printf 'Environments: %s\n' "${ENV_IDS[*]}"
+}
+
+valid_environment() {
+    local id="$1"
+    local candidate
+    for candidate in "${ENV_IDS[@]}"; do
+        [[ "$candidate" == "$id" ]] && return 0
+    done
+    return 1
+}
+
+mise_runtime_present() {
+    [[ -n "$(compgen -G "$MISE_DATA_DIR/installs/$1/*" || true)" ]]
+}
+
+remove_mise_runtime() {
+    local tool="$1"
+
+    if have_cmd mise; then
+        # Remove both the global selector and every installed version. The
+        # explicit tree cleanup handles runtimes left behind by older mise
+        # versions or interrupted uninstalls.
+        mise unuse --global "$tool" 2>/dev/null || true
+        mise uninstall --all "$tool" 2>/dev/null || true
+    fi
+    rm -rf -- "$MISE_DATA_DIR/installs/$tool" "$MISE_CACHE_DIR/$tool"
+}
+
+system_runtime_package() {
+    local tool="$1" executable package
+    have_cmd pacman || return 1
+    executable="$(command -v "$tool" 2>/dev/null || true)"
+    [[ "$executable" == /usr/bin/* ]] || return 1
+    package="$(pacman -Qo "$executable" 2>/dev/null | awk '{print $5}')"
+    case "$tool:$package" in
+        deno:deno|bun:bun|bun:bun-bin) printf '%s\n' "$package"; return 0 ;;
+    esac
+    return 1
+}
+
+remove_system_runtime() {
+    local tool="$1" package
+    package="$(system_runtime_package "$tool" || true)"
+    [[ -n "$package" ]] || return 0
+    sudo pacman -Rns --noconfirm "$package"
+}
+
+docker_container_present() {
+    local target="$1"
+    have_cmd docker || return 1
+    local name
+    while IFS= read -r name; do
+        [[ "$name" == "$target" ]] && return 0
+    done < <(docker ps -a --format '{{.Names}}' 2>/dev/null || true)
+    return 1
+}
+
+docker_database_present() {
+    docker_container_present mysql8 || docker_container_present postgres18 \
+        || docker_container_present redis || docker_container_present mongodb \
+        || docker_container_present mariadb11 || docker_container_present mssql
+}
+
+environment_status() {
+    case "$1" in
+        rails) mise_runtime_present ruby ;;
+        node|go|python|elixir|java|zig|dotnet|clojure|scala) mise_runtime_present "$1" ;;
+        bun|deno) mise_runtime_present "$1" || system_runtime_package "$1" >/dev/null ;;
+        php) have_cmd php ;;
+        laravel) [[ -x "$HOME/.config/composer/vendor/bin/laravel" ]] ;;
+        symfony) have_cmd symfony ;;
+        phoenix) compgen -G "$HOME/.mix/archives/phx_new*" >/dev/null ;;
+        rust) [[ -d "$HOME/.rustup" ]] ;;
+        ocaml) [[ -d "${OPAMROOT:-$HOME/.opam}" ]] ;;
+        docker-dbs) docker_database_present ;;
+        *) return 1 ;;
+    esac
+}
+
+status_all() {
+    local id state
+    for id in "${ENV_IDS[@]}"; do
+        if ! is_arch_like; then
+            state="unsupported"
+        elif environment_status "$id"; then
+            state="installed"
+        else
+            state="missing"
+        fi
+        printf '%s\t%s\n' "$id" "$state"
+    done
+}
+
+require_arch() {
+    if ! is_arch_like; then
+        setup_fail "Development environment setup currently supports Arch-based systems only."
+        setup_finish_pause
+        exit 1
+    fi
+}
+
+ensure_mise() {
+    if ! have_cmd mise; then
+        setup_progress 1 2 "Installing mise"
+        install_arch mise
+    fi
+    have_cmd mise || { setup_fail "mise is not available after installation"; return 1; }
+}
+
+install_node() {
+    ensure_mise
+    mise use --global node@latest
+}
+
+install_php() {
+    install_arch php composer php-sqlite xdebug
+
+    local bashrc="$HOME/.bashrc"
+    if [[ ! -f "$bashrc" ]] || ! grep -Fq 'export PATH="$HOME/.config/composer/vendor/bin:$PATH"' "$bashrc"; then
+        printf '\nexport PATH="$HOME/.config/composer/vendor/bin:$PATH"\n' >> "$bashrc"
+    fi
+    export PATH="$HOME/.config/composer/vendor/bin:$PATH"
+
+    local php_ini_path="/etc/php/php.ini"
+    local ext
+    local extensions_to_enable=(bcmath intl iconv openssl pdo_sqlite pdo_mysql)
+    sudo sed -i \
+        -e 's/^;zend_extension=xdebug.so/zend_extension=xdebug.so/' \
+        -e 's/^;xdebug.mode=debug/xdebug.mode=debug/' \
+        /etc/php/conf.d/xdebug.ini
+    for ext in "${extensions_to_enable[@]}"; do
+        sudo sed -i "s/^;extension=${ext}/extension=${ext}/" "$php_ini_path"
+    done
+}
+
+choose_from_ids() {
+    local header="$1"
+    shift
+    local ids=("$@")
+    local i choice
+
+    if have_cmd gum; then
+        local options=()
+        for i in "${ids[@]}"; do
+            options+=("$i|${ENV_LABELS[$i]}")
+        done
+        choice="$(printf '%s\n' "${options[@]}" | gum choose --header "$header" || true)"
+        [[ -n "$choice" ]] || return 1
+        printf '%s\n' "${choice%%|*}"
+        return 0
+    fi
+
+    printf '\n%s\n' "$header" >&2
+    for i in "${!ids[@]}"; do
+        printf '  %d) %s\n' "$((i + 1))" "${ENV_LABELS[${ids[$i]}]}" >&2
+    done
+    printf '  0) Cancel\n' >&2
+    while true; do
+        read -r -p 'Enter choice: ' choice
+        [[ "$choice" == 0 ]] && return 1
+        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#ids[@]} )); then
+            printf '%s\n' "${ids[$((choice - 1))]}"
+            return 0
+        fi
+    done
+}
+
+select_operation_and_environment() {
+    local operation id
+    if have_cmd gum; then
+        operation="$(printf '%s\n' install remove | gum choose --header 'Select development action' || true)"
+    else
+        operation="install"
+    fi
+    [[ -n "$operation" ]] || return 1
+    id="$(choose_from_ids 'Select development environment' "${ENV_IDS[@]}")" || return 1
+    printf '%s\t%s\n' "$operation" "$id"
+}
+
+install_docker_databases() {
+    local options=(MySQL PostgreSQL Redis MongoDB MariaDB MSSQL)
+    local choices
+    if have_cmd gum; then
+        choices="$(printf '%s\n' "${options[@]}" | gum choose --no-limit --header 'Select databases to install' || true)"
+    else
+        choices=""
+        printf 'Install Docker databases with gum for multi-select.\n' >&2
+        read -r -p 'Enter database names separated by spaces (or leave empty to cancel): ' choices
+    fi
+    [[ -n "$choices" ]] || return 0
+
+    local db
+    for db in $choices; do
+        case "$db" in
+            MySQL)
+                docker_container_present mysql8 || sudo docker run -d --restart unless-stopped -p 127.0.0.1:3306:3306 --name=mysql8 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.4
+                ;;
+            PostgreSQL)
+                docker_container_present postgres18 || sudo docker run -d --restart unless-stopped -p 127.0.0.1:5432:5432 --name=postgres18 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:18
+                ;;
+            MariaDB)
+                docker_container_present mariadb11 || sudo docker run -d --restart unless-stopped -p 127.0.0.1:3306:3306 --name=mariadb11 -e MARIADB_ROOT_PASSWORD= -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true mariadb:11.8
+                ;;
+            Redis)
+                docker_container_present redis || sudo docker run -d --restart unless-stopped -p 127.0.0.1:6379:6379 --name=redis redis:7
+                ;;
+            MongoDB)
+                docker_container_present mongodb || sudo docker run -d --restart unless-stopped -p 127.0.0.1:27017:27017 --name=mongodb -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=admin123 mongo:noble
+                ;;
+            MSSQL)
+                docker_container_present mssql || sudo docker run -d --restart unless-stopped -p 127.0.0.1:1433:1433 --name=mssql -e MSSQL_PID=Developer -e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD='@dmin123' mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04
+                ;;
+            *)
+                printf 'Unknown database: %s\n' "$db" >&2
+                return 1
+                ;;
+        esac
+    done
+}
+
+remove_docker_databases() {
+    local known=(mysql8 postgres18 redis mongodb mariadb11 mssql)
+    local existing=()
+    local id
+    for id in "${known[@]}"; do
+        docker_container_present "$id" && existing+=("$id")
+    done
+    ((${#existing[@]})) || { printf 'No managed Docker database containers found.\n'; return 0; }
+
+    local choices
+    if have_cmd gum; then
+        choices="$(printf '%s\n' "${existing[@]}" | gum choose --no-limit --header 'Select databases to remove' || true)"
+    else
+        choices="${existing[*]}"
+        read -r -p "Enter container names separated by spaces [${choices}]: " input
+        [[ -n "$input" ]] && choices="$input"
+    fi
+    [[ -n "$choices" ]] || return 0
+    for id in $choices; do
+        valid=0
+        for known_id in "${known[@]}"; do
+            [[ "$id" == "$known_id" ]] && valid=1
+        done
+        (( valid )) || { printf 'Skipping unmanaged container: %s\n' "$id" >&2; continue; }
+        sudo docker rm -f -- "$id"
+    done
+}
+
+install_environment() {
+    local id="$1"
+    local label="${ENV_LABELS[$id]}"
+    setup_init "development-$id" "Setup $label"
+    require_arch
+    setup_progress 1 2 "Installing $label"
+
+    case "$id" in
+        rails)
+            install_arch libyaml
+            ensure_mise
+            mise settings add ruby.compile false
+            mise settings add idiomatic_version_file_enable_tools ruby
+            mise use --global ruby@latest
+            printf 'gem: --no-document\n' > "$HOME/.gemrc"
+            mise x ruby -- gem install rails --no-document
+            ;;
+        node) install_node ;;
+        bun) ensure_mise; mise use --global bun@latest ;;
+        deno) ensure_mise; mise use --global deno@latest ;;
+        go) ensure_mise; mise use --global go@latest ;;
+        php) install_php ;;
+        laravel) install_php; install_node; composer global require laravel/installer ;;
+        symfony) install_php; install_arch -- symfony-cli ;;
+        python)
+            ensure_mise
+            mise use --global python@latest
+            have_cmd uv || curl -fsSL https://astral.sh/uv/install.sh | sh
+            ;;
+        elixir)
+            ensure_mise
+            mise use --global erlang@latest
+            mise use --global elixir@latest
+            mise x elixir -- mix local.hex --force
+            ;;
+        phoenix)
+            ensure_mise
+            mise use --global erlang@latest
+            mise use --global elixir@latest
+            mise x elixir -- mix local.hex --force
+            mise x elixir -- mix local.rebar --force
+            mise x elixir -- mix archive.install hex phx_new --force
+            ;;
+        rust) have_cmd rustup || bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y ;;
+        java) ensure_mise; mise use --global java@latest ;;
+        zig) ensure_mise; mise use --global zig@latest; mise use --global zls@latest ;;
+        dotnet) ensure_mise; mise use --global dotnet@latest ;;
+        ocaml)
+            if ! have_cmd opam; then
+                bash -c "$(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
+            fi
+            opam init --yes
+            eval "$(opam env)"
+            opam install ocaml-lsp-server odoc ocamlformat utop --yes
+            ;;
+        clojure) install_arch rlwrap; ensure_mise; mise use --global clojure@latest ;;
+        scala) ensure_mise; mise use --global java@latest; mise use --global scala@latest; mise use --global scala-cli@latest ;;
+        docker-dbs)
+            have_cmd docker || install_arch docker
+            install_docker_databases
+            ;;
+        *) setup_fail "Unknown development environment: $id"; setup_finish_pause; exit 1 ;;
+    esac
+
+    setup_progress 2 2 "Verifying $label"
+    if [[ "$id" != docker-dbs ]] && ! environment_status "$id"; then
+        setup_fail "$label setup did not produce the expected installation marker"
+        setup_finish_pause
+        exit 1
+    fi
+    setup_done "$label ready"
+    setup_finish_pause
+}
+
+remove_environment() {
+    local id="$1"
+    local label="${ENV_LABELS[$id]}"
+    setup_init "development-remove-$id" "Remove $label"
+    require_arch
+    setup_progress 1 2 "Removing $label"
+
+    case "$id" in
+        rails) remove_mise_runtime ruby; rm -f "$HOME/.gemrc" ;;
+        node|go|java|dotnet|clojure)
+            remove_mise_runtime "$id"
+            ;;
+        bun|deno)
+            remove_mise_runtime "$id"
+            remove_system_runtime "$id"
+            ;;
+        php) sudo pacman -Rns --noconfirm php composer php-sqlite xdebug 2>/dev/null || true ;;
+        laravel) composer global remove laravel/installer 2>/dev/null || true ;;
+        symfony) sudo pacman -Rns --noconfirm symfony-cli 2>/dev/null || true ;;
+        python)
+            remove_mise_runtime python
+            rm -f "$HOME/.local/bin/uv" "$HOME/.local/bin/uvx" "$HOME/.cargo/bin/uv"
+            ;;
+        elixir|phoenix)
+            remove_mise_runtime elixir
+            remove_mise_runtime erlang
+            ;;
+        rust) rustup self uninstall -y 2>/dev/null || true ;;
+        zig)
+            remove_mise_runtime zig
+            remove_mise_runtime zls
+            ;;
+        ocaml)
+            opam switch remove default -y 2>/dev/null || true
+            rm -rf "${OPAMROOT:-$HOME/.opam}"
+            sudo rm -f /usr/local/bin/opam 2>/dev/null || true
+            ;;
+        scala)
+            remove_mise_runtime scala
+            remove_mise_runtime scala-cli
+            ;;
+        docker-dbs) remove_docker_databases ;;
+        *) setup_fail "Unknown development environment: $id"; setup_finish_pause; exit 1 ;;
+    esac
+
+    setup_progress 2 2 "Verifying removal"
+    if [[ "$id" != docker-dbs ]] && environment_status "$id"; then
+        setup_fail "$label removal left an installed runtime or tool behind"
+        setup_finish_pause
+        exit 1
+    fi
+    setup_done "$label removed"
+    setup_finish_pause
+}
+
+main() {
+    local operation="${1:-}"
+    local id="${2:-}"
+
+    if [[ -z "$operation" ]]; then
+        local selection
+        selection="$(select_operation_and_environment)" || exit 0
+        IFS=$'\t' read -r operation id <<< "$selection"
+    fi
+
+    case "$operation" in
+        status)
+            status_all
+            ;;
+        install|remove)
+            if ! valid_environment "$id"; then
+                usage >&2
+                exit 2
+            fi
+            if [[ "$operation" == install ]]; then
+                install_environment "$id"
+            else
+                remove_environment "$id"
+            fi
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/test-local-distribution.sh
+++ b/scripts/test-local-distribution.sh
@@ -18,7 +18,7 @@ step "shell syntax"
 bash -n \
     "$runtime_root/setup" \
     "$runtime_root/scripts/inir" \
-    "$runtime_root/scripts/setup/development.sh" \
+    "$runtime_root/scripts/setup/_development.sh" \
     "$runtime_root/sdata/lib/"*.sh \
     "$runtime_root/sdata/subcmd-install/"*.sh \
     "$runtime_root/sdata/migrations/"*.sh
@@ -114,6 +114,11 @@ if grep -Fq 'pacman -S $installflags "${depends[@]}"' "$arch_installer"; then
 fi
 
 step "runtime payload manifests"
+if bash "$runtime_root/scripts/setup/_scan.sh" | jq -e '.[] | select(.slug == "development")' >/dev/null; then
+    printf 'FAIL: private development mutation helper is exposed as a setup action\n' >&2
+    exit 1
+fi
+
 python3 - "$runtime_root/defaults/dev-environments.json" <<'PY'
 import json
 import pathlib

--- a/scripts/test-local-distribution.sh
+++ b/scripts/test-local-distribution.sh
@@ -18,6 +18,7 @@ step "shell syntax"
 bash -n \
     "$runtime_root/setup" \
     "$runtime_root/scripts/inir" \
+    "$runtime_root/scripts/setup/development.sh" \
     "$runtime_root/sdata/lib/"*.sh \
     "$runtime_root/sdata/subcmd-install/"*.sh \
     "$runtime_root/sdata/migrations/"*.sh
@@ -113,6 +114,19 @@ if grep -Fq 'pacman -S $installflags "${depends[@]}"' "$arch_installer"; then
 fi
 
 step "runtime payload manifests"
+python3 - "$runtime_root/defaults/dev-environments.json" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+required = {"id", "name", "description", "group", "icon", "tags"}
+if len(manifest) != 19 or any(not required.issubset(entry) for entry in manifest):
+    raise SystemExit("FAIL: development environment manifest is incomplete")
+if len({entry["id"] for entry in manifest}) != len(manifest):
+    raise SystemExit("FAIL: development environment IDs are not unique")
+PY
+
 while IFS= read -r runtime_file; do
     [[ -n "$runtime_file" ]] || continue
     [[ -f "$runtime_root/$runtime_file" ]]

--- a/services/DevelopmentEnvironments.qml
+++ b/services/DevelopmentEnvironments.qml
@@ -1,0 +1,158 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs
+import qs.modules.common
+import qs.modules.common.functions
+import qs.modules.common.models
+
+/**
+ * Searchable development environments backed by scripts/setup/development.sh.
+ *
+ * The search consumers use this service for metadata and callbacks, while the
+ * setup script remains the single source of truth for privileged operations.
+ */
+Singleton {
+    id: root
+
+    property list<var> environments: []
+    property var statuses: ({})
+    property int statusRevision: 0
+    property bool loading: true
+    property bool checking: false
+
+    readonly property string scriptPath: `${Directories.scriptsPath}/setup/development.sh`
+
+    FileView {
+        id: manifestFile
+        path: Qt.resolvedUrl("../defaults/dev-environments.json")
+        onLoadedChanged: {
+            if (!manifestFile.loaded) return
+            try {
+                root.environments = JSON.parse(manifestFile.text())
+                root.loading = false
+                root.refresh()
+            } catch (error) {
+                console.warn("[DevelopmentEnvironments] Failed to parse manifest:", error)
+                root.environments = []
+                root.loading = false
+            }
+        }
+    }
+
+    Process {
+        id: statusProcess
+        stdout: StdioCollector {
+            onStreamFinished: root._applyStatuses(this.text)
+        }
+        onExited: {
+            root.checking = false
+        }
+    }
+
+    Timer {
+        id: refreshTimer
+        interval: 5000
+        onTriggered: root.refresh()
+    }
+
+    Connections {
+        target: GlobalStates
+        function onOverviewOpenChanged(): void {
+            if (GlobalStates.overviewOpen) root.refresh()
+        }
+    }
+
+    function _applyStatuses(raw: string): void {
+        const next = {}
+        const lines = String(raw ?? "").trim().split("\n")
+        for (const line of lines) {
+            const parts = line.trim().split("\t")
+            if (parts.length >= 2 && parts[0].length > 0)
+                next[parts[0]] = parts[1]
+        }
+        root.statuses = next
+        root.statusRevision += 1
+    }
+
+    function refresh(): void {
+        if (root.loading || root.checking || root.environments.length === 0) return
+        statusProcess.command = ["/usr/bin/bash", root.scriptPath, "status"]
+        root.checking = true
+        statusProcess.running = true
+    }
+
+    function _environment(id: string): var {
+        return root.environments.find(environment => environment?.id === id) ?? null
+    }
+
+    function _safeTerminal(): string {
+        const configured = (Config.options?.apps?.terminal ?? "kitty").trim()
+        return /^[A-Za-z0-9._+-]+$/.test(configured) ? configured : "kitty"
+    }
+
+    function _run(operation: string, id: string): void {
+        if (!_environment(id)) return
+
+        const terminal = root._safeTerminal()
+        const command = ["/usr/bin/bash", root.scriptPath, operation, id]
+        if (terminal === "wezterm") {
+            ShellExec.execDetachedArgs([terminal, "start", "--always-new-process", "--", ...command],
+                `${operation} ${id}`)
+        } else {
+            ShellExec.execDetachedArgs([terminal, "-e", ...command], `${operation} ${id}`)
+        }
+        refreshTimer.restart()
+    }
+
+    function install(id: string): void { root._run("install", id) }
+    function remove(id: string): void { root._run("remove", id) }
+
+    function searchResults(query: string): list<var> {
+        const _statusRevision = root.statusRevision
+        const q = String(query ?? "").toLowerCase().trim()
+        if (q.length === 0 || root.loading) return []
+
+        const tokens = q.split(/\s+/).filter(token => token.length > 0)
+        const results = []
+        for (const environment of root.environments) {
+            const searchable = [
+                environment.id,
+                environment.name,
+                environment.group,
+                environment.description,
+                ...(environment.tags ?? []),
+                "development"
+            ].join(" ").toLowerCase()
+            if (!tokens.every(token => searchable.includes(token))) continue
+
+            const installed = root.statuses[environment.id] === "installed"
+            const operation = installed ? "remove" : "install"
+            const verb = installed ? Translation.tr("Remove") : Translation.tr("Install")
+            const actionName = `${verb} ${environment.name}`
+            const id = environment.id
+            results.push({
+                key: `development_${operation}_${id}`,
+                id: id,
+                name: actionName,
+                description: `${environment.group} - ${environment.description}`,
+                comment: `${Translation.tr("Development")} > ${environment.group}`,
+                type: Translation.tr("Development"),
+                icon: environment.icon ?? "code",
+                iconName: environment.icon ?? "code",
+                materialSymbol: environment.icon ?? "code",
+                iconType: LauncherSearchResult.IconType.Material,
+                verb: verb,
+                clickActionName: verb,
+                execute: () => {
+                    if (operation === "remove") root.remove(id)
+                    else root.install(id)
+                }
+            })
+        }
+        return results
+    }
+}

--- a/services/DevelopmentEnvironments.qml
+++ b/services/DevelopmentEnvironments.qml
@@ -10,7 +10,7 @@ import qs.modules.common.functions
 import qs.modules.common.models
 
 /**
- * Searchable development environments backed by scripts/setup/development.sh.
+ * Searchable development environments backed by a private setup helper.
  *
  * The search consumers use this service for metadata and callbacks, while the
  * setup script remains the single source of truth for privileged operations.
@@ -23,8 +23,9 @@ Singleton {
     property int statusRevision: 0
     property bool loading: true
     property bool checking: false
+    property bool statusReady: false
 
-    readonly property string scriptPath: `${Directories.scriptsPath}/setup/development.sh`
+    readonly property string scriptPath: `${Directories.scriptsPath}/setup/_development.sh`
 
     FileView {
         id: manifestFile
@@ -50,6 +51,11 @@ Singleton {
         }
         onExited: {
             root.checking = false
+            if (!root.statusReady) {
+                root.statuses = ({})
+                root.statusRevision += 1
+                root.statusReady = true
+            }
         }
     }
 
@@ -76,11 +82,13 @@ Singleton {
         }
         root.statuses = next
         root.statusRevision += 1
+        root.statusReady = true
     }
 
     function refresh(): void {
         if (root.loading || root.checking || root.environments.length === 0) return
         statusProcess.command = ["/usr/bin/bash", root.scriptPath, "status"]
+        root.statusReady = false
         root.checking = true
         statusProcess.running = true
     }
@@ -129,29 +137,37 @@ Singleton {
             ].join(" ").toLowerCase()
             if (!tokens.every(token => searchable.includes(token))) continue
 
-            const installed = root.statuses[environment.id] === "installed"
+            const state = root.statuses[environment.id] ?? "unknown"
+            const canMutate = root.statusReady && (state === "installed" || state === "missing")
+            const installed = state === "installed"
             const operation = installed ? "remove" : "install"
             const verb = installed ? Translation.tr("Remove") : Translation.tr("Install")
-            const actionName = `${verb} ${environment.name}`
+            const actionName = canMutate ? `${verb} ${environment.name}` : environment.name
+            const stateDescription = state === "unsupported"
+                ? Translation.tr("Install/remove actions are unavailable on this system")
+                : state === "unknown" && root.statusReady
+                    ? Translation.tr("Installation actions are unavailable")
+                    : ""
             const id = environment.id
-            results.push({
-                key: `development_${operation}_${id}`,
+            const result = {
+                key: `development_${canMutate ? operation : "info"}_${id}`,
                 id: id,
                 name: actionName,
-                description: `${environment.group} - ${environment.description}`,
+                description: `${environment.group} - ${environment.description}${stateDescription ? ` - ${stateDescription}` : ""}`,
                 comment: `${Translation.tr("Development")} > ${environment.group}`,
                 type: Translation.tr("Development"),
                 icon: environment.icon ?? "code",
                 iconName: environment.icon ?? "code",
                 materialSymbol: environment.icon ?? "code",
                 iconType: LauncherSearchResult.IconType.Material,
-                verb: verb,
-                clickActionName: verb,
-                execute: () => {
+                verb: canMutate ? verb : "",
+                clickActionName: canMutate ? verb : ""
+            }
+            if (canMutate) result.execute = () => {
                     if (operation === "remove") root.remove(id)
                     else root.install(id)
                 }
-            })
+            results.push(result)
         }
         return results
     }

--- a/services/deferred/LauncherSearch.qml
+++ b/services/deferred/LauncherSearch.qml
@@ -138,6 +138,15 @@ Singleton {
         const startsWithMath = q.startsWith(mathPrefix)
         const startsWithShell = q.startsWith(shellPrefix)
         const startsWithWeb = q.startsWith(webPrefix)
+        const hasSearchPrefix = [
+            actionPrefix,
+            appPrefix,
+            clipboardPrefix,
+            emojisPrefix,
+            mathPrefix,
+            shellPrefix,
+            webPrefix
+        ].some(prefix => q.startsWith(prefix))
 
         // Math result (priority if starts with number or =)
         const mathObj = ({
@@ -225,6 +234,9 @@ Singleton {
             }))
         }
         result = result.concat(appResults)
+
+        if (!hasSearchPrefix)
+            result = result.concat(DevelopmentEnvironments.searchResults(q))
 
         // Actions (built-in + user scripts)
         const actionResults = root.allActions.map(action => {

--- a/services/qmldir
+++ b/services/qmldir
@@ -21,6 +21,7 @@ singleton DateTime 1.0 DateTime.qml
 singleton DesktopItems 1.0 DesktopItems.qml
 singleton DesktopWidgetLayout 1.0 DesktopWidgetLayout.qml
 singleton DevNavigation 1.0 DevNavigation.qml
+singleton DevelopmentEnvironments 1.0 DevelopmentEnvironments.qml
 singleton Events 1.0 Events.qml
 singleton FirstRunExperience 1.0 FirstRunExperience.qml
 singleton FontSyncService 1.0 FontSyncService.qml


### PR DESCRIPTION
## Summary

- Add searchable metadata for 18 development environments and Docker databases.
- Add shared status, install, and remove actions for Overview and Waffle searches.
- Add setup recipe discovery and runtime manifest validation.
- Handle stale managed runtime directories and exact system Bun/Deno packages during removal.

## Validation

- `bash -n scripts/setup/development.sh`
- `qmllint -I . services/DevelopmentEnvironments.qml modules/overview/SearchWidget.qml services/deferred/LauncherSearch.qml`
- JSON manifest validation
- Setup discovery and status checks
- `git diff --check`

The full local distribution test currently stops at an existing Wallhaven schema-comment assertion.