### PR TITLE
docs(nix): update NixOS guide for prerelease, recorder deps, and keybinds

### DIFF
--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -4,19 +4,24 @@
 
 iNiR provides a flake with:
 
-| Output | Purpose |
-|---|---|
-| `packages.<system>.default` | Packaged iNiR runtime and `inir` launcher |
-| `nixosModules.inir` | NixOS module for system package + user service |
-| `homeModules.inir` | Home Manager module for user package + user service |
+| Output                      | Purpose                                             |
+| --------------------------- | --------------------------------------------------- |
+| `packages.<system>.default` | Packaged iNiR runtime and `inir` launcher           |
+| `nixosModules.inir`         | NixOS module for system package + user service      |
+| `homeModules.inir`          | Home Manager module for user package + user service |
 
-The module does not run `./setup install` or `./setup update`. Nix owns the installed files, and iNiR runs from the package store path.
+The module does not run `./setup install` or `./setup update`. Nix owns the
+installed files, and iNiR runs from the package store path.
 
-The package and modules are ordinary Nix expressions under `nix/`. Flakes are only one entrypoint, so traditional Nix configurations can import them directly. Both entrypoints use the same `package.nix`, NixOS module, and Home Manager module rather than maintaining separate implementations.
+The package and modules are ordinary Nix expressions under `nix/`. Flakes are
+only one entrypoint, so traditional Nix configurations can import them directly.
+Both entrypoints use the same `package.nix`, NixOS module, and Home Manager
+module rather than maintaining separate implementations.
 
 ## Without flakes
 
-Point `inirSrc` at a local checkout or a source pinned with your preferred Nix fetcher:
+Point `inirSrc` at a local checkout or a source pinned with your preferred Nix
+fetcher:
 
 ```nix
 { pkgs, ... }:
@@ -36,9 +41,17 @@ in
 }
 ```
 
-For Home Manager, import `nix/home-module.nix` instead. The package expression accepts the consumer's `pkgs` set explicitly, so traditional configurations can choose or pin nixpkgs without converting the project to a flake. Both modules use that same package expression by default unless `programs.inir.package` is overridden.
+For Home Manager, import `nix/home-module.nix` instead. The package expression
+accepts the consumer's `pkgs` set explicitly, so traditional configurations can
+choose or pin nixpkgs without converting the project to a flake. Both modules
+use that same package expression by default unless `programs.inir.package` is
+overridden.
 
 ## With niri-flake
+
+> [!TIP]
+> For the latest updates use the **prerelease** branch of iNiR. It's where new
+> features land and it's the recommended flavor for daily use.
 
 Add both flakes:
 
@@ -46,8 +59,7 @@ Add both flakes:
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    niri.url = "github:sodiboo/niri-flake";
-    inir.url = "github:snowarch/inir";
+    inir.url = "github:snowarch/inir/prerelease";
   };
 }
 ```
@@ -55,9 +67,8 @@ Add both flakes:
 Then import both modules in your NixOS configuration:
 
 ```nix
-{ config, inputs, ... }: {
+{ config, inputs, pkgs, ... }: {
   imports = [
-    inputs.niri.nixosModules.niri
     inputs.inir.nixosModules.inir
   ];
 
@@ -66,45 +77,66 @@ Then import both modules in your NixOS configuration:
   programs.inir = {
     enable = true;
     service.compositor = "niri";
-    extraPackages = [ config.programs.niri.package ];
+    extraPackages = [
+      config.programs.niri.package
+      pkgs.wf-recorder
+      pkgs.slurp
+      pkgs.file
+      pkgs.xdg-utils
+      pkgs.xdg-user-dirs
+      pkgs.pulseaudio
+    ];
   };
 }
 ```
 
-`programs.inir.service.compositor = "niri"` creates the user unit wiring under `niri.service.wants/inir.service`. It does not wire iNiR to `graphical-session.target`, so it will not auto-start under KDE, GNOME, or other desktop sessions.
+`programs.inir.service.compositor = "niri"` creates the user unit wiring under
+`niri.service.wants/inir.service`. It does not wire iNiR to
+`graphical-session.target`, so it will not auto-start under KDE, GNOME, or other
+desktop sessions.
 
-`extraPackages = [ config.programs.niri.package ];` puts the same `niri` client binary used by your compositor on iNiR's runtime `PATH`, so features that call `niri msg` use the matching package.
+`extraPackages = [ config.programs.niri.package ];` puts the same `niri` client
+binary used by your compositor on iNiR's runtime `PATH`, so features that call
+`niri msg` use the matching package.
 
-For useful default shortcuts, merge iNiR actions into `programs.niri.settings.binds`:
+**Recorder dependencies.** For the screen recorder to work, put these on iNiR's
+runtime `PATH` via `extraPackages`:
+
+| Package         | Why it's needed                               |
+| --------------- | --------------------------------------------- |
+| `wf-recorder`   | The actual screen recording engine            |
+| `slurp`         | Region selection for recording/screenshots    |
+| `file`          | Detect the recorded file type                 |
+| `xdg-utils`     | `xdg-open` / mime helpers for opening results |
+| `xdg-user-dirs` | Resolve the user's Pictures/Videos folders    |
+| `pulseaudio`    | Audio capture while recording                 |
+
+For useful keybinds, merge iNiR actions into `programs.niri.settings.binds` —
+the same binds you'd put in `config.kdl`:
 
 ```nix
 {
   programs.niri.settings.binds = {
+    "Ctrl+Shift+L".action.spawn = [ "inir" "clipboard" "toggle" ];
+    "Mod+D".action.spawn = [ "inir" "dashboard" "toggle" ];
+    "Mod+Comma".action.spawn = [ "inir" "settings" ];
+    "Mod+Slash".action.spawn = [ "inir" "cheatsheet" "toggle" ];
+
     "Mod+Space" = {
       repeat = false;
       action.spawn = [ "inir" "overview" "toggle" ];
     };
 
-    "Mod+V".action.spawn = [ "inir" "clipboard" "toggle" ];
-    "Mod+Comma".action.spawn = [ "inir" "settings" ];
-    "Mod+Slash".action.spawn = [ "inir" "cheatsheet" "toggle" ];
-    "Mod+Shift+W".action.spawn = [ "inir" "panelFamily" "cycle" ];
-
-    "Mod+Alt+L" = {
-      allow-when-locked = true;
-      action.spawn = [ "inir" "lock" "activate" ];
-    };
-
-    "Mod+Shift+S".action.spawn = [ "inir" "region" "screenshot" ];
-    "Mod+Shift+X".action.spawn = [ "inir" "region" "ocr" ];
-    "Mod+Shift+A".action.spawn = [ "inir" "region" "search" ];
+    "Mod+R".action.spawn = [ "inir" "overlay" "toggle" ];
+    "Mod+Shift+P".action.spawn = [ "inir" "session" "toggle" ];
   };
 }
 ```
 
 ## Home Manager
 
-If you manage your user session with Home Manager, import the Home Manager module instead:
+If you manage your user session with Home Manager, import the Home Manager
+module instead:
 
 ```nix
 { inputs, ... }: {
@@ -125,7 +157,9 @@ The Home Manager module can also expose the packaged runtime at:
 ~/.config/quickshell/inir
 ```
 
-That symlink keeps tools that expect the traditional config path working, but it is opt-in because it will conflict with an existing repo checkout at the same path. Enable it with:
+That symlink keeps tools that expect the traditional config path working, but it
+is opt-in because it will conflict with an existing repo checkout at the same
+path. Enable it with:
 
 ```nix
 programs.inir.configSymlink.enable = true;
@@ -159,5 +193,7 @@ systemctl --user start inir.service
 
 - Use `inir logs --full` for runtime errors.
 - The packaged `inir` launcher wraps Quickshell and runtime tools in `PATH`.
-- User preferences still live in iNiR's normal config/state files; the packaged QML source itself is immutable.
-- `inir update` is not the right update path for a Nix install. Update through your flake inputs and rebuild.
+- User preferences still live in iNiR's normal config/state files; the packaged
+  QML source itself is immutable.
+- `inir update` is not the right update path for a Nix install. Update through
+  your flake inputs and rebuild.


### PR DESCRIPTION
Updates `docs/NIXOS.md`:

- **Prerelease**: recommends the `prerelease` branch of the flake (latest updates, incl. recorder) and updates the example input.
- **Recorder dependencies**: adds `wf-recorder`, `slurp`, `file`, `xdg-utils`, `xdg-user-dirs`, `pulseaudio` to the `extraPackages` example, with a table describing each.
- **Keybinds**: updates the `programs.niri.settings.binds` example to the current iNiR keybinds used in `config.kdl`.

This branch (`add-nixos-docs`) contains only this doc change.