### PR TITLE
fix(nix): ship mascot sprites in the default package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Mascot sprites in the Nix package**: the default package now embeds the mascot art pack, so the sprite GIF/PNG poses load instead of only the manifest. Previously only `manifest.json` was shipped and every pose failed with "Error Reading Animated Image File", leaving the mascot invisible.
+
 ## [2.29.3] - 2026-08-25
 
 A polish release for Pill controls and surfaces, settings navigation, TUI app themes, and several runtime fixes including privileged graphical apps and audio feedback stability.

--- a/nix/mascot-pack.nix
+++ b/nix/mascot-pack.nix
@@ -1,0 +1,11 @@
+{ pkgs }:
+# Shared source for the iNiR mascot art pack (poses & animations), published
+# from the snowarch/inir-mascot repo. Reused by the default iNiR package
+# (which embeds the sprites so it ships the mascot) and by the standalone
+# inir-mascot companion package.
+{
+  src = pkgs.fetchurl {
+    url = "https://github.com/snowarch/inir-mascot/releases/download/v3/inir-mascot-pack.tar.gz";
+    hash = "sha256-DCkWHOVa/7N9FlGD+XdVBuyXRnlWf+3Kv3Lp9f9aw5s=";
+  };
+}

--- a/nix/mascot-package.nix
+++ b/nix/mascot-package.nix
@@ -4,10 +4,7 @@ pkgs.stdenvNoCC.mkDerivation {
   pname = "inir-mascot";
   version = "3";
 
-  src = pkgs.fetchurl {
-    url = "https://github.com/snowarch/inir-mascot/releases/download/v3/inir-mascot-pack.tar.gz";
-    hash = "sha256-DCkWHOVa/7N9FlGD+XdVBuyXRnlWf+3Kv3Lp9f9aw5s=";
-  };
+  src = (import ./mascot-pack.nix { inherit pkgs; }).src;
 
   dontUnpack = true;
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,6 +3,8 @@
 let
   lib = pkgs.lib;
 
+  mascotPack = import ./mascot-pack.nix { inherit pkgs; };
+
   optionalTop = name:
     lib.optional (builtins.hasAttr name pkgs) (builtins.getAttr name pkgs);
 
@@ -155,6 +157,11 @@ pkgs.stdenvNoCC.mkDerivation {
       [ -n "$dir" ] || continue
       cp -R "$dir" "$runtime/$dir"
     done < sdata/runtime-payload-dirs.txt
+
+    # Embed the mascot art pack so the default package ships the sprite
+    # GIF/PNG poses the MascotCompanion loads, instead of only the manifest.
+    mkdir -p "$runtime/assets/images/mascot"
+    tar xf ${mascotPack.src} -C "$runtime/assets/images/mascot/"
 
     # Copy root-level QML entry points (shell.qml, settings.qml, etc.)
     # which aren't listed in runtime-root-files.txt.


### PR DESCRIPTION
## Problem

The default iNiR Nix package shipped only the mascot `manifest.json` (the pose/line description), but **none of the actual sprite files** (`.gif`/`.png`) that `MascotCompanion.qml` loads. As a result every pose failed with:

```
QML AnimatedImage: Error Reading Animated Image File
.../assets/images/mascot/inir-mascot-headphone-groove-full-loop.gif
```

and the mascot never rendered. The art pack was only available through the separate `inir-mascot` package, which consumers had to merge manually via `symlinkJoin`.

## Change

- **`nix/mascot-pack.nix` (new)**: shared source for the mascot art pack (single place for the fetchurl + hash, deduped from `mascot-package.nix`).
- **`nix/package.nix`**: unpack the art pack into `assets/images/mascot/` during `installPhase`, so the **default** package ships the sprites and is self-contained. The mascot now works out of the box.
- **`nix/mascot-package.nix`**: reuse the shared source (no duplicate URL/hash).
- **`CHANGELOG.md`**: entry under `[Unreleased]`.

## Verification

Built locally (`nix build .#default`); the result now contains 24 GIFs + 330 PNGs including the previously-missing `inir-mascot-headphone-groove-full-loop.gif`, plus the unchanged `manifest.json`.