### PR TITLE
feat(connectivity): add split-toggle controls, live status, and background AP caching

### DIFF
--- a/modules/sidebarRight/CompactSidebarRightContent.qml
+++ b/modules/sidebarRight/CompactSidebarRightContent.qml
@@ -567,6 +567,8 @@ Item {
         required property string chipIcon
         required property string chipLabel
         property string value: ""
+        property bool toggled: true
+        property var iconAction: null
 
         signal clicked()
 
@@ -582,6 +584,7 @@ Item {
         readonly property color _colSub: bg.inirEverywhere ? Appearance.inir.colTextSecondary
             : bg.angelEverywhere ? Appearance.angel.colTextSecondary
             : Appearance.colors.colSubtext
+        readonly property color _colAccent: chip.toggled ? chip._colPrimary : chip._colSub
 
         Rectangle {
             id: chipBg
@@ -607,24 +610,61 @@ Item {
                 ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
             }
 
+            MouseArea {
+                id: chipMA
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: chip.clicked()
+            }
+
             RowLayout {
                 anchors.fill: parent
                 anchors.leftMargin: 8
                 anchors.rightMargin: 10
                 spacing: 9
 
-                // Icon in accent-tinted circle
+                // Icon in accent-tinted or muted circle
                 Rectangle {
+                    id: iconCircle
                     Layout.preferredWidth: 32
                     Layout.preferredHeight: 32
                     radius: 16
-                    color: ColorUtils.transparentize(chip._colPrimary, 0.84)
+                    color: {
+                        if (chip.iconAction && iconMA.containsPress)
+                            return ColorUtils.transparentize(chip._colAccent, chip.toggled ? 0.60 : 0.70)
+                        if (chip.iconAction && iconMA.containsMouse)
+                            return ColorUtils.transparentize(chip._colAccent, chip.toggled ? 0.72 : 0.80)
+                        return ColorUtils.transparentize(chip._colAccent, chip.toggled ? 0.84 : 0.90)
+                    }
+
+                    Behavior on color {
+                        enabled: Appearance.animationsEnabled
+                        ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
+                    }
 
                     MaterialSymbol {
                         anchors.centerIn: parent
                         iconSize: 17
                         text: chip.chipIcon
-                        color: chip._colPrimary
+                        color: chip._colAccent
+
+                        Behavior on color {
+                            enabled: Appearance.animationsEnabled
+                            ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
+                        }
+                    }
+
+                    MouseArea {
+                        id: iconMA
+                        enabled: chip.iconAction !== null
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            if (chip.iconAction)
+                                chip.iconAction()
+                        }
                     }
                 }
 
@@ -666,18 +706,10 @@ Item {
                     }
                 }
             }
-
-            MouseArea {
-                id: chipMA
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onClicked: chip.clicked()
-            }
         }
 
         BubbleToolTip {
-            visible: chipMA.containsMouse
+            visible: chipMA.containsMouse && !iconMA.containsMouse
             position: "left"
             text: chip.chipLabel
         }
@@ -1640,8 +1672,48 @@ Item {
 
                                         ControlChipButton { Layout.fillWidth: true; chipIcon: "media_output"; chipLabel: Translation.tr("Output"); value: Audio.sink?.description ?? ""; onClicked: root.showAudioOutputDialog = true }
                                         ControlChipButton { Layout.fillWidth: true; chipIcon: "mic_external_on"; chipLabel: Translation.tr("Input"); value: Audio.source?.description ?? ""; onClicked: root.showAudioInputDialog = true }
-                                        ControlChipButton { Layout.fillWidth: true; chipIcon: "bluetooth"; chipLabel: Translation.tr("Bluetooth"); value: Bluetooth.defaultAdapter?.enabled ? Translation.tr("On") : Translation.tr("Off"); onClicked: root.showBluetoothDialog = true }
-                                        ControlChipButton { Layout.fillWidth: true; chipIcon: Network.materialSymbol; chipLabel: Translation.tr("Wi-Fi"); value: Network.networkName ?? ""; onClicked: root.showWifiDialog = true }
+                                        ControlChipButton {
+                                            Layout.fillWidth: true
+                                            chipIcon: BluetoothStatus.activeIcon
+                                            chipLabel: Translation.tr("Bluetooth")
+                                            value: {
+                                                if (!BluetoothStatus.enabled)
+                                                    return Translation.tr("Off")
+                                                if (BluetoothStatus.firstActiveDevice) {
+                                                    const devName = BluetoothStatus.firstActiveDevice.name || BluetoothStatus.firstActiveDevice.deviceName || Translation.tr("Connected")
+                                                    const extra = BluetoothStatus.activeDeviceCount > 1 ? ` (+${BluetoothStatus.activeDeviceCount - 1})` : ""
+                                                    return devName + extra
+                                                }
+                                                return Translation.tr("Not connected")
+                                            }
+                                            toggled: BluetoothStatus.enabled
+                                            iconAction: () => {
+                                                if (Bluetooth.defaultAdapter)
+                                                    Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter.enabled
+                                            }
+                                            onClicked: root.showBluetoothDialog = true
+                                        }
+                                        ControlChipButton {
+                                            Layout.fillWidth: true
+                                            chipIcon: Network.wifiMaterialSymbol
+                                            chipLabel: Translation.tr("Wi-Fi")
+                                            value: {
+                                                if (!Network.wifiEnabled && !Network.wifiScanning)
+                                                    return Translation.tr("Off")
+                                                if (Network.active?.ssid)
+                                                    return Network.active.ssid
+                                                if (Network.wifiStatus === "connecting")
+                                                    return Translation.tr("Connecting")
+                                                if (Network.wifiScanning)
+                                                    return Translation.tr("Searching networks…")
+                                                return Translation.tr("Not connected")
+                                            }
+                                            toggled: Network.wifiEnabled
+                                            iconAction: () => {
+                                                Network.toggleWifi()
+                                            }
+                                            onClicked: root.showWifiDialog = true
+                                        }
                                     }
                                 }
                             }
@@ -1742,8 +1814,7 @@ Item {
             if (!Bluetooth.defaultAdapter) return
             if (!shown) {
                 Bluetooth.defaultAdapter.discovering = false
-            } else {
-                Bluetooth.defaultAdapter.enabled = true
+            } else if (Bluetooth.defaultAdapter.enabled) {
                 Bluetooth.defaultAdapter.discovering = true
             }
         }
@@ -1761,8 +1832,8 @@ Item {
         dialog: WifiDialog {}
         onShownChanged: {
             if (!shown) return
-            Network.enableWifi()
-            Network.rescanWifi()
+            if (Network.wifiEnabled)
+                Network.rescanWifi()
         }
     }
 

--- a/modules/sidebarRight/SidebarRightContent.qml
+++ b/modules/sidebarRight/SidebarRightContent.qml
@@ -927,8 +927,7 @@ Item {
             if (!Bluetooth.defaultAdapter) return
             if (!shown) {
                 Bluetooth.defaultAdapter.discovering = false;
-            } else {
-                Bluetooth.defaultAdapter.enabled = true;
+            } else if (Bluetooth.defaultAdapter.enabled) {
                 Bluetooth.defaultAdapter.discovering = true;
             }
         }
@@ -949,8 +948,8 @@ Item {
         dialog: WifiDialog {}
         onShownChanged: {
             if (!shown) return;
-            Network.enableWifi();
-            Network.rescanWifi();
+            if (Network.wifiEnabled)
+                Network.rescanWifi();
         }
     }
 

--- a/modules/sidebarRight/bluetoothDevices/BluetoothDialog.qml
+++ b/modules/sidebarRight/bluetoothDevices/BluetoothDialog.qml
@@ -15,6 +15,7 @@ import Quickshell.Wayland
 WindowDialog {
     id: root
     backgroundHeight: 450
+    readonly property bool bluetoothOn: Bluetooth.defaultAdapter?.enabled ?? false
 
     WindowDialogTitle {
         text: Translation.tr("Bluetooth devices")
@@ -45,9 +46,11 @@ WindowDialog {
         clip: true
         spacing: 4
         animateAppearance: false
+        enabled: root.bluetoothOn
+        opacity: root.bluetoothOn ? 1 : 0.45
 
         model: ScriptModel {
-            values: [...Bluetooth.devices.values].sort((a, b) => {
+            values: root.bluetoothOn ? [...Bluetooth.devices.values].sort((a, b) => {
                 // Connected -> paired -> others
                 let conn = (b.connected - a.connected) || (b.paired - a.paired);
                 if (conn !== 0) return conn;
@@ -60,7 +63,7 @@ WindowDialog {
 
                 // Alphabetical by name
                 return a.name.localeCompare(b.name);
-            })
+            }) : []
         }
         delegate: BluetoothDeviceItem {
             required property BluetoothDevice modelData
@@ -70,6 +73,32 @@ WindowDialog {
                 right: parent?.right
                 leftMargin: 8
                 rightMargin: 8
+            }
+        }
+
+        // Empty state: no devices or bluetooth off
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 6
+            visible: Bluetooth.devices.values.length === 0 || (!root.bluetoothOn && !(Bluetooth.defaultAdapter?.discovering ?? false))
+
+            MaterialSymbol {
+                Layout.alignment: Qt.AlignHCenter
+                iconSize: 48
+                text: !root.bluetoothOn ? "bluetooth_disabled" : "bluetooth_searching"
+                color: Appearance.colors.colSubtext
+            }
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: {
+                    if (!root.bluetoothOn)
+                        return Translation.tr("Bluetooth is off")
+                    if (Bluetooth.defaultAdapter?.discovering)
+                        return Translation.tr("Searching devices…")
+                    return Translation.tr("No devices found")
+                }
+                font.pixelSize: Appearance.font.pixelSize.small
+                color: Appearance.colors.colSubtext
             }
         }
     }

--- a/modules/sidebarRight/wifiNetworks/WifiDialog.qml
+++ b/modules/sidebarRight/wifiNetworks/WifiDialog.qml
@@ -11,10 +11,12 @@ import Quickshell
 WindowDialog {
     id: root
     backgroundHeight: 450
+    readonly property bool wifiOn: Network.wifiEnabled
 
     WindowDialogTitle {
         text: Translation.tr("Connect to Wi-Fi")
     }
+
     WindowDialogSeparator {
         opacity: !Network.wifiScanning ? 1 : 0
         visible: opacity > 0
@@ -51,15 +53,17 @@ WindowDialog {
         clip: true
         spacing: 4
         animateAppearance: false
+        enabled: root.wifiOn
+        opacity: root.wifiOn ? 1 : 0.45
 
         model: ScriptModel {
-            values: [...Network.wifiNetworks].sort((a, b) => {
+            values: root.wifiOn ? [...Network.wifiNetworks].sort((a, b) => {
                 if (a.active && !b.active)
                     return -1;
                 if (!a.active && b.active)
                     return 1;
                 return b.strength - a.strength;
-            })
+            }) : []
         }
         delegate: WifiNetworkItem {
             required property WifiAccessPoint modelData
@@ -76,19 +80,23 @@ WindowDialog {
         ColumnLayout {
             anchors.centerIn: parent
             spacing: 6
-            visible: Network.wifiNetworks.length === 0 && !Network.wifiScanning
+            visible: Network.wifiNetworks.length === 0 || (!root.wifiOn && !Network.wifiScanning)
 
-            MascotImage {
+            MaterialSymbol {
                 Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 100
-                Layout.preferredHeight: 100
-                pose: "network-offline"
-                surface: "wifi"
-                fallbackSurface: "emptyStates"
+                iconSize: 48
+                text: !root.wifiOn && !Network.wifiScanning ? "signal_wifi_off" : "wifi_find"
+                color: Appearance.colors.colSubtext
             }
             StyledText {
                 Layout.alignment: Qt.AlignHCenter
-                text: Translation.tr("No networks found")
+                text: {
+                    if (!root.wifiOn && !Network.wifiScanning)
+                        return Translation.tr("Wi-Fi is off")
+                    if (Network.wifiScanning)
+                        return Translation.tr("Searching networks…")
+                    return Translation.tr("No networks found")
+                }
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colSubtext
             }

--- a/services/Network.qml
+++ b/services/Network.qml
@@ -33,30 +33,34 @@ Singleton {
     // wifiEnabled is true — so keying the strength icons off wifiEnabled both
     // rendered a stale full-strength icon after disconnecting and left the
     // "not_connected"/"wifi_find" branches permanently unreachable.
-    property string materialSymbol: root.ethernet
-        ? "lan"
-        : !root.wifiEnabled
+    property int wifiSignal: root.active?.strength || root.networkStrength
+    property string wifiMaterialSymbol: root.active
+        ? (
+            root.wifiSignal > 83 ? "signal_wifi_4_bar" :
+            root.wifiSignal > 67 ? "network_wifi" :
+            root.wifiSignal > 50 ? "network_wifi_3_bar" :
+            root.wifiSignal > 33 ? "network_wifi_2_bar" :
+            root.wifiSignal > 17 ? "network_wifi_1_bar" :
+            "signal_wifi_0_bar"
+        )
+        : (!root.wifiEnabled && !root.wifiScanning)
             ? "signal_wifi_off"
-            : (root.wifiStatus === "connected" || root.wifiStatus === "limited")
-                ? (
-                    Network.networkStrength > 83 ? "signal_wifi_4_bar" :
-                    Network.networkStrength > 67 ? "network_wifi" :
-                    Network.networkStrength > 50 ? "network_wifi_3_bar" :
-                    Network.networkStrength > 33 ? "network_wifi_2_bar" :
-                    Network.networkStrength > 17 ? "network_wifi_1_bar" :
-                    "signal_wifi_0_bar"
-                )
-                : (root.wifiStatus === "connecting")
-                    ? "signal_wifi_statusbar_not_connected"
-                    : (root.wifiStatus === "disconnected")
-                        ? "wifi_find"
-                        : (root.wifiStatus === "disabled")
-                            ? "signal_wifi_off"
-                            : "signal_wifi_bad"
+            : (root.wifiStatus === "connecting")
+                ? "signal_wifi_statusbar_not_connected"
+                : (root.wifiStatus === "disconnected" || root.wifiScanning)
+                    ? "wifi_find"
+                    : (root.wifiStatus === "disabled")
+                        ? "signal_wifi_off"
+                        : "signal_wifi_bad"
+    property string materialSymbol: root.ethernet ? "lan" : root.wifiMaterialSymbol
 
     // Control
     function enableWifi(enabled = true): void {
         const cmd = enabled ? "on" : "off";
+        if (!enabled) {
+            root.wifiScanning = false;
+            _scanPoll.stop();
+        }
         enableWifiProc.exec(["nmcli", "radio", "wifi", cmd]);
     }
 
@@ -64,8 +68,13 @@ Singleton {
         enableWifi(!wifiEnabled);
     }
 
+    property int _scanPolls: 0
+
     function rescanWifi(): void {
-        wifiScanning = true;
+        if (!root.active)
+            root.wifiScanning = true;
+        getNetworks.running = true;
+        rescanProcess.running = false;
         rescanProcess.running = true;
     }
 
@@ -129,6 +138,12 @@ Singleton {
 
     Process {
         id: enableWifiProc
+        onExited: exitCode => {
+            wifiStatusProcess.running = true;
+            if (exitCode === 0 && root.wifiEnabled) {
+                root.rescanWifi();
+            }
+        }
     }
 
     Process {
@@ -177,11 +192,28 @@ Singleton {
 
     Process {
         id: rescanProcess
-        command: ["nmcli", "dev", "wifi", "list", "--rescan", "yes"]
-        stdout: SplitParser {
-            onRead: {
-                wifiScanning = false;
-                getNetworks.running = true;
+        command: ["nmcli", "device", "wifi", "rescan"]
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        onExited: {
+            getNetworks.running = true;
+            root._scanPolls = 0;
+            _scanPoll.restart();
+        }
+    }
+
+    Timer {
+        id: _scanPoll
+        interval: 500
+        repeat: true
+        onTriggered: {
+            getNetworks.running = true;
+            root._scanPolls += 1;
+            if (root._scanPolls >= 12) {
+                stop();
+                root.wifiScanning = false;
             }
         }
     }
@@ -219,6 +251,7 @@ Singleton {
 
     Component.onDestruction: {
         root._destroying = true;
+        _scanPoll.stop();
         subscriber.running = false;
     }
 
@@ -342,7 +375,7 @@ Singleton {
     Process {
         id: getNetworks
         running: false
-        command: ["nmcli", "-g", "ACTIVE,SIGNAL,FREQ,SSID,BSSID,SECURITY,RATE", "d", "w"]
+        command: ["nmcli", "-g", "ACTIVE,SIGNAL,FREQ,SSID,BSSID,SECURITY,RATE", "device", "wifi", "list", "--rescan", "no"]
         environment: ({
             LANG: "C",
             LC_ALL: "C"
@@ -387,9 +420,16 @@ Singleton {
                 }
 
                 const wifiNetworks = Array.from(networkMap.values());
+                const activeNet = wifiNetworks.find(n => n.active);
+                if (activeNet?.ssid) {
+                    root.wifi = true;
+                    if (root.wifiStatus !== "limited")
+                        root.wifiStatus = "connected";
+                }
+                if (wifiNetworks.length > 0)
+                    root.wifiScanning = false;
 
                 const rNetworks = root.wifiNetworks;
-
                 const destroyed = rNetworks.filter(rn => !wifiNetworks.find(n => n.frequency === rn.frequency && n.ssid === rn.ssid && n.bssid === rn.bssid));
                 for (const network of destroyed)
                     rNetworks.splice(rNetworks.indexOf(network), 1).forEach(n => n.destroy());


### PR DESCRIPTION
## Summary

Enhances the Wi-Fi and Bluetooth control chips and modal dialogs in the sidebar with split-toggle interactions, live connection/device status, disabled empty states, and non-blocking background Wi-Fi scanning with instant AP caching.

## Key Changes

### 1. Split-Toggle Control Chips (`CompactSidebarRightContent.qml`)
- **Icon action:** Clicking the circular icon directly toggles the hardware radio (Wi-Fi via `Network.toggleWifi()`, Bluetooth via `Bluetooth.defaultAdapter.enabled`).
- **Body action:** Clicking the chip body or chevron opens the corresponding configuration dialog.
- **Visual hierarchy:** Active controls display illuminated primary accent colors when ON, transitioning smoothly to dimmed/muted states when OFF.

### 2. Live Device & Connection Status
- **Bluetooth:** Displays the active connected device name (e.g. headphones, controllers) and device count `(+N)` instead of static text, with dynamic device-type glyphs (`BluetoothStatus.activeIcon`).
- **Wi-Fi:** Displays active SSID, connecting/scanning status, and signal strength bars on the chip.

### 3. Dialog Consistency & Disabled States (`WifiDialog.qml`, `BluetoothDialog.qml`, `SidebarRightContent.qml`)
- Dialogs maintain a clean list-focused interface without redundant switches.
- When radios are OFF, dialogs smoothly disable their list view and present a clear empty state (`Wi-Fi is off` / `Bluetooth is off`).
- Opening dialogs no longer forces radios ON; discovery/rescanning triggers conditionally only when radios are already enabled.

### 4. Background Wi-Fi Scanning & AP Caching (`Network.qml`)
- Queries cached access points immediately with `nmcli ... --rescan no` to eliminate the 2–5s initial freeze when opening Wi-Fi.
- Performs asynchronous hardware scans (`nmcli device wifi rescan`) with non-blocking polling, allowing NetworkManager to handle network discovery and native auto-connection seamlessly.

## Testing

- [x] Toggled Wi-Fi via icon circle: radio toggles instantly without opening the dialog.
- [x] Toggled Bluetooth via icon circle: adapter toggles instantly; icon transitions between active and muted states.
- [x] Clicked chip body: opens respective selection dialog.
- [x] Opened dialogs while radios were OFF: verified empty state text and icons; verified radios were not forcibly turned on.
- [x] Background Wi-Fi scan: verified known networks render immediately on dialog open while background scan refreshes signal levels smoothly.
- [x] Connected Bluetooth device: verified device name and device-specific icon update in real time.