### PR TITLE
fix: resolve Fedora install hang and add setup verbosity levels

### DIFF
--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -76,14 +76,44 @@ short-circuits past that for performance). The line format is exact:
 Source it once at the top of every recipe; everything below is then
 available.
 
+### Verbosity Levels
+
+Set `SETUP_VERBOSITY` environment variable before sourcing `_lib.sh` or calling
+`setup_set_verbosity`:
+
+| Level | Name | Behavior |
+|-------|------|----------|
+| `0` | Quiet | Only errors (`setup_fail`) and notifications; no progress output |
+| `1` | Normal | Default — progress, done, fail messages (current behavior) |
+| `2` | Verbose | Extra detail via `setup_verbose` helper |
+
+```bash
+# Run a recipe quietly (no terminal output, notifications only)
+SETUP_VERBOSITY=0 bash scripts/setup/spotify.sh
+
+# Run a recipe verbosely
+SETUP_VERBOSITY=2 bash scripts/setup/spotify.sh
+
+# Or set programmatically after sourcing
+setup_set_verbosity 0
+```
+
+### Helpers
+
 | Helper | Purpose |
 |--------|---------|
 | `setup_init <slug> <title>` | Required first call. Sets the notification tag, installs an `ERR` trap, prints the recipe banner and emits the initial "Starting..." bubble. |
-| `setup_progress <step> <total> <msg>` | Print a `[step/total] msg` line and replace the notification bubble. |
-| `setup_done [msg]` | Print a green check and emit the success bubble (`emblem-ok-symbolic`). |
-| `setup_fail [msg]` | Print a red cross and emit the failure bubble (`dialog-error`). The `ERR` trap calls this automatically on uncaught errors. |
-| `setup_notify <body> [icon]` | Low-level: emits/replaces the bubble with arbitrary text. Use the wrappers above whenever possible. |
+| `setup_progress <step> <total> <msg>` | Print a `[step/total] msg` line and replace the notification bubble. Respects verbosity (only prints at level ≥ 1). |
+| `setup_log <msg>` | Print a plain message. Respects verbosity (only prints at level ≥ 1). |
+| `setup_verbose <msg>` | Print a detail message with `·` prefix. Only prints at verbosity ≥ 2. |
+| `setup_done [msg]` | Print a green check and emit the success bubble (`emblem-ok-symbolic`). Always prints. |
+| `setup_fail [msg]` | Print a red cross and emit the failure bubble (`dialog-error`). The `ERR` trap calls this automatically on uncaught errors. Always prints. |
+| `setup_notify <body> [icon]` | Low-level: emits/replaces the bubble with arbitrary text. Use the wrappers above whenever possible. Always fires. |
 | `setup_finish_pause` | Prompts the user to press Enter so the terminal stays open after `set -e` would otherwise close it. Always call this last. |
+| `setup_set_verbosity <level>` | Set verbosity level (0/1/2). |
+| `setup_is_quiet` | True if verbosity == 0. |
+| `setup_is_normal` | True if verbosity ≥ 1. |
+| `setup_is_verbose` | True if verbosity ≥ 2. |
 | `is_arch_like` | True for `arch`, `endeavouros`, `cachyos`, `manjaro`, `garuda`, `artix` (matches both `ID` and `ID_LIKE`). |
 | `have_cmd <name>` | True if the binary is on `PATH`. |
 | `ensure_aur_helper` | Echoes `yay` or `paru` if present; otherwise bootstraps `yay-bin` from the AUR. Used internally by `install_arch`. |
@@ -91,7 +121,7 @@ available.
 | `install_flatpak <ref...>` | Adds Flathub (user-scope) on demand and installs the given refs. Fails loudly if `flatpak` is missing. |
 
 Constants exposed after sourcing: `DISTRO_ID`, `DISTRO_LIKE`, `SETUP_TAG`,
-`SETUP_TITLE`.
+`SETUP_TITLE`, `SETUP_VERBOSITY`.
 
 ## Conventions
 

--- a/scripts/setup/_lib.sh
+++ b/scripts/setup/_lib.sh
@@ -36,6 +36,20 @@ is_arch_like() {
 
 have_cmd() { command -v "$1" >/dev/null 2>&1; }
 
+# -- Verbosity ----------------------------------------------------------------
+# 0 = quiet  (errors + notifications only)
+# 1 = normal (default — progress, done, fail)
+# 2 = verbose (extra detail lines)
+SETUP_VERBOSITY="${SETUP_VERBOSITY:-1}"
+
+setup_set_verbosity() {
+    SETUP_VERBOSITY="${1:-1}"
+}
+
+setup_is_quiet() { (( SETUP_VERBOSITY == 0 )); }
+setup_is_normal() { (( SETUP_VERBOSITY >= 1 )); }
+setup_is_verbose() { (( SETUP_VERBOSITY >= 2 )); }
+
 # -- Notifications ------------------------------------------------------------
 SETUP_TAG=""
 SETUP_TITLE=""
@@ -53,8 +67,20 @@ setup_notify() {
 
 setup_progress() {
     local step="$1" total="$2" msg="$3"
-    printf '\n\033[1;36m[%s/%s]\033[0m %s\n' "$step" "$total" "$msg"
+    if setup_is_normal; then
+        printf '\n\033[1;36m[%s/%s]\033[0m %s\n' "$step" "$total" "$msg"
+    fi
     setup_notify "[$step/$total] $msg" "download"
+}
+
+setup_log() {
+    local msg="$1"
+    setup_is_normal && printf '%s\n' "$msg"
+}
+
+setup_verbose() {
+    local msg="$1"
+    setup_is_verbose && printf '  · %s\n' "$msg"
 }
 
 setup_done() {

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -28,6 +28,32 @@ dnf_pkg_available() {
   dnf -q list --available "$pkg" &>/dev/null || dnf -q list --installed "$pkg" &>/dev/null
 }
 
+# Batch check which packages are available from configured repos.
+# Populates the arrays passed as $1 (available) and $2 (missing).
+dnf_pkgs_available_batch() {
+  local -n _avail=$1 _miss=$2
+  shift 2
+  local -a pkgs=("$@")
+  local available_file
+  available_file="$(mktemp)"
+
+  # Use repoquery to get just package names — handles missing packages gracefully.
+  # --qf '%{name}' outputs only the bare name, no arch or repo prefix.
+  dnf -q repoquery --qf '%{name}' --available "${pkgs[@]}" 2>/dev/null | sort -u > "$available_file" || true
+  # Also include already-installed packages (they're definitely "available").
+  dnf -q repoquery --qf '%{name}' --installed "${pkgs[@]}" 2>/dev/null | sort -u >> "$available_file" || true
+  sort -u -o "$available_file" "$available_file"
+
+  for pkg in "${pkgs[@]}"; do
+    if grep -qx "$pkg" "$available_file"; then
+      _avail+=("$pkg")
+    else
+      _miss+=("$pkg")
+    fi
+  done
+  rm -f "$available_file"
+}
+
 version_at_least() {
   local have="$1"
   local need="$2"
@@ -537,19 +563,29 @@ ${INSTALL_SCREENCAPTURE:-true} && FEDORA_REPO_PKGS+=("${FEDORA_SCREENCAPTURE_PKG
 ${INSTALL_FONTS:-true} && FEDORA_REPO_PKGS+=("${FEDORA_FONT_PKGS[@]}")
 
 mapfile -t FEDORA_REPO_PKGS < <(printf '%s\n' "${FEDORA_REPO_PKGS[@]}" | awk 'NF' | sort -u)
+
+# Pre-flight: ensure metadata cache is fresh so availability checks are fast.
+tui_info "Refreshing package metadata..."
+sudo dnf makecache --timer >/dev/null 2>&1 || sudo dnf makecache >/dev/null 2>&1 || true
+
+# Batch-check availability instead of per-package dnf calls (much faster).
 FEDORA_INSTALLABLE_PKGS=()
 FEDORA_REPO_FALLBACK_PKGS=()
+
+# Separate quickshell if it needs special handling
+_quickshell_pkgs=()
+_regular_pkgs=()
 for pkg in "${FEDORA_REPO_PKGS[@]}"; do
   if [[ "$pkg" == "quickshell" ]] && ! fedora_quickshell_compatible; then
     FEDORA_REPO_FALLBACK_PKGS+=("$pkg")
-    continue
-  fi
-  if dnf_pkg_available "$pkg"; then
-    FEDORA_INSTALLABLE_PKGS+=("$pkg")
+  elif [[ "$pkg" == "quickshell" ]]; then
+    _quickshell_pkgs+=("$pkg")
   else
-    FEDORA_REPO_FALLBACK_PKGS+=("$pkg")
+    _regular_pkgs+=("$pkg")
   fi
 done
+
+dnf_pkgs_available_batch FEDORA_INSTALLABLE_PKGS FEDORA_REPO_FALLBACK_PKGS "${_regular_pkgs[@]}" "${_quickshell_pkgs[@]}"
 
 if [[ ${#FEDORA_INSTALLABLE_PKGS[@]} -gt 0 ]]; then
   log_info "Installing ${#FEDORA_INSTALLABLE_PKGS[@]} packages from Fedora/RPM Fusion repositories..."
@@ -600,7 +636,7 @@ install_github_binary() {
   log_info "Installing $name from GitHub..."
   
   local download_url
-  download_url=$(curl -s "https://api.github.com/repos/${repo}/releases/latest" | \
+  download_url=$(curl -s --connect-timeout 10 --max-time 30 "https://api.github.com/repos/${repo}/releases/latest" | \
     jq -r ".assets[] | select(.name | test(\"${asset_pattern}\")) | .browser_download_url" | head -1)
   
   if [[ -z "$download_url" || "$download_url" == "null" ]]; then
@@ -612,7 +648,7 @@ install_github_binary() {
   mkdir -p "$temp_dir"
   
   local filename=$(basename "$download_url")
-  if curl -fsSL -o "$temp_dir/$filename" "$download_url"; then
+  if curl -fsSL --connect-timeout 10 --max-time 120 -o "$temp_dir/$filename" "$download_url"; then
     case "$filename" in
       *.tar.gz|*.tgz)
         tar -xzf "$temp_dir/$filename" -C "$temp_dir"
@@ -710,12 +746,12 @@ fi
 if ${INSTALL_FONTS:-true}; then
   if ! rpm -q darkly &>/dev/null; then
     log_info "Installing darkly theme from GitHub..."
-    DARKLY_RPM_URL=$(curl -s "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
+    DARKLY_RPM_URL=$(curl -s --connect-timeout 10 --max-time 30 "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
       jq -r ".assets[] | select(.name | test(\"fc${FEDORA_VERSION}.*x86_64.rpm$\")) | .browser_download_url" | head -1)
     
     # Fallback to any Fedora RPM if exact version not found
     if [[ -z "$DARKLY_RPM_URL" || "$DARKLY_RPM_URL" == "null" ]]; then
-      DARKLY_RPM_URL=$(curl -s "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
+      DARKLY_RPM_URL=$(curl -s --connect-timeout 10 --max-time 30 "https://api.github.com/repos/Bali10050/darkly/releases/latest" | \
         jq -r '.assets[] | select(.name | test("fc[0-9]+.*x86_64.rpm$")) | .browser_download_url' | head -1)
     fi
     
@@ -732,7 +768,7 @@ fi
 #####################################################################################
 if ! command -v uv &>/dev/null; then
   tui_info "Installing uv fallback..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null || {
+  curl -LsSf --connect-timeout 10 --max-time 60 https://astral.sh/uv/install.sh | sh 2>/dev/null || {
     if command -v cargo &>/dev/null; then
       cargo install uv
     else
@@ -756,7 +792,7 @@ if ! fc-list | grep -qi "Material Symbols Rounded"; then
   # Direct download from raw.githubusercontent
   MATERIAL_URL="https://raw.githubusercontent.com/google/material-design-icons/master/variablefont/MaterialSymbolsRounded%5BFILL%2CGRAD%2Copsz%2Cwght%5D.ttf"
   
-  if curl -fsSL -o "$FONT_DIR/MaterialSymbolsRounded.ttf" "$MATERIAL_URL"; then
+  if curl -fsSL --connect-timeout 10 --max-time 120 -o "$FONT_DIR/MaterialSymbolsRounded.ttf" "$MATERIAL_URL"; then
     fc-cache -fv "$FONT_DIR" 2>/dev/null
     log_success "Material Symbols Rounded font installed"
   else
@@ -771,7 +807,7 @@ if ! fc-list | grep -qi "Material Symbols Outlined"; then
   
   MATERIAL_URL="https://raw.githubusercontent.com/google/material-design-icons/master/variablefont/MaterialSymbolsOutlined%5BFILL%2CGRAD%2Copsz%2Cwght%5D.ttf"
   
-  if curl -fsSL -o "$FONT_DIR/MaterialSymbolsOutlined.ttf" "$MATERIAL_URL"; then
+  if curl -fsSL --connect-timeout 10 --max-time 120 -o "$FONT_DIR/MaterialSymbolsOutlined.ttf" "$MATERIAL_URL"; then
     fc-cache -fv "$FONT_DIR" 2>/dev/null
     log_success "Material Symbols Outlined font installed"
   else
@@ -787,7 +823,7 @@ if ! fc-list | grep -qi "JetBrainsMono Nerd"; then
   TEMP_DIR="/tmp/nerdfonts-$$"
   mkdir -p "$TEMP_DIR"
   
-  if curl -fsSL -o "$TEMP_DIR/JetBrainsMono.zip" "$NERD_FONTS_URL"; then
+  if curl -fsSL --connect-timeout 10 --max-time 120 -o "$TEMP_DIR/JetBrainsMono.zip" "$NERD_FONTS_URL"; then
     unzip -o "$TEMP_DIR/JetBrainsMono.zip" -d "$FONT_DIR" >/dev/null 2>&1
     fc-cache -f "$FONT_DIR"
     log_success "JetBrains Mono Nerd Font installed"
@@ -813,7 +849,7 @@ if [[ ! -d "$ICON_DIR/WhiteSur-dark" ]]; then
   TEMP_DIR="/tmp/whitesur-icons-$$"
   mkdir -p "$TEMP_DIR"
   
-  if curl -fsSL -o "$TEMP_DIR/whitesur.tar.gz" \
+  if curl -fsSL --connect-timeout 10 --max-time 120 -o "$TEMP_DIR/whitesur.tar.gz" \
     "https://github.com/vinceliuice/WhiteSur-icon-theme/archive/refs/heads/master.tar.gz"; then
     tar -xzf "$TEMP_DIR/whitesur.tar.gz" -C "$TEMP_DIR"
     cd "$TEMP_DIR/WhiteSur-icon-theme-master"
@@ -839,7 +875,7 @@ if [[ ! -d "$ICON_DIR/MacTahoe" ]]; then
   TEMP_DIR="/tmp/mactahoe-icons-$$"
   mkdir -p "$TEMP_DIR"
   
-  if curl -fsSL -o "$TEMP_DIR/mactahoe.tar.gz" \
+  if curl -fsSL --connect-timeout 10 --max-time 120 -o "$TEMP_DIR/mactahoe.tar.gz" \
     "https://github.com/vinceliuice/MacTahoe-icon-theme/archive/refs/heads/master.tar.gz"; then
     tar -xzf "$TEMP_DIR/mactahoe.tar.gz" -C "$TEMP_DIR"
     cd "$TEMP_DIR/MacTahoe-icon-theme-master" 2>/dev/null || cd "$TEMP_DIR/MacTahoe-icon-theme-main"
@@ -866,14 +902,14 @@ if [[ ! -d "$ICON_DIR/Bibata-Modern-Classic" ]]; then
   mkdir -p "$TEMP_DIR"
   
   # Download Bibata Modern Classic (dark)
-  if curl -fsSL -o "$TEMP_DIR/bibata-classic.tar.xz" \
+  if curl -fsSL --connect-timeout 10 --max-time 60 -o "$TEMP_DIR/bibata-classic.tar.xz" \
     "https://github.com/ful1e5/Bibata_Cursor/releases/latest/download/Bibata-Modern-Classic.tar.xz"; then
     tar -xf "$TEMP_DIR/bibata-classic.tar.xz" -C "$ICON_DIR"
     log_success "Bibata Modern Classic cursor installed"
   fi
   
   # Download Bibata Modern Ice (light)
-  if curl -fsSL -o "$TEMP_DIR/bibata-ice.tar.xz" \
+  if curl -fsSL --connect-timeout 10 --max-time 60 -o "$TEMP_DIR/bibata-ice.tar.xz" \
     "https://github.com/ful1e5/Bibata_Cursor/releases/latest/download/Bibata-Modern-Ice.tar.xz"; then
     tar -xf "$TEMP_DIR/bibata-ice.tar.xz" -C "$ICON_DIR"
     log_success "Bibata Modern Ice cursor installed"
@@ -890,7 +926,7 @@ tui_info "Installing optional fonts..."
 # Space Grotesk
 if ! fc-list | grep -qi "Space Grotesk"; then
   log_info "Downloading Space Grotesk font..."
-  curl -fsSL -o "$FONT_DIR/SpaceGrotesk.ttf" \
+  curl -fsSL --connect-timeout 10 --max-time 60 -o "$FONT_DIR/SpaceGrotesk.ttf" \
     "https://github.com/floriankarsten/space-grotesk/raw/master/fonts/ttf/SpaceGrotesk%5Bwght%5D.ttf" 2>/dev/null && \
     log_success "Space Grotesk installed"
 fi
@@ -898,7 +934,7 @@ fi
 # Rubik
 if ! fc-list | grep -qi "Rubik"; then
   log_info "Downloading Rubik font..."
-  curl -fsSL -o "$FONT_DIR/Rubik.ttf" \
+  curl -fsSL --connect-timeout 10 --max-time 60 -o "$FONT_DIR/Rubik.ttf" \
     "https://github.com/googlefonts/rubik/raw/main/fonts/variable/Rubik%5Bwght%5D.ttf" 2>/dev/null && \
     log_success "Rubik installed"
 fi
@@ -908,7 +944,7 @@ if ! fc-list | grep -qi "Geist"; then
   log_info "Downloading Geist font..."
   TEMP_DIR="/tmp/geist-font-$$"
   mkdir -p "$TEMP_DIR"
-  if curl -fsSL -o "$TEMP_DIR/geist.zip" \
+  if curl -fsSL --connect-timeout 10 --max-time 60 -o "$TEMP_DIR/geist.zip" \
     "https://github.com/vercel/geist-font/releases/latest/download/Geist.zip"; then
     unzip -o "$TEMP_DIR/geist.zip" -d "$TEMP_DIR" >/dev/null 2>&1
     find "$TEMP_DIR" -name "*.ttf" -exec cp {} "$FONT_DIR/" \;
@@ -929,7 +965,7 @@ tui_info "Installing CLI tools..."
 if ! command -v starship &>/dev/null; then
   log_info "Installing Starship prompt..."
   mkdir -p ~/.local/bin
-  curl -sS https://starship.rs/install.sh | sh -s -- -y -b ~/.local/bin 2>/dev/null || \
+  curl -sS --connect-timeout 10 --max-time 60 https://starship.rs/install.sh | sh -s -- -y -b ~/.local/bin 2>/dev/null || \
     log_warning "Could not install Starship"
 fi
 
@@ -938,7 +974,7 @@ fi
 if ! command -v eza &>/dev/null; then
   log_info "Installing Eza..."
   mkdir -p ~/.local/bin
-  if curl -fsSL -o /tmp/eza.tar.gz \
+  if curl -fsSL --connect-timeout 10 --max-time 60 -o /tmp/eza.tar.gz \
     'https://github.com/eza-community/eza/releases/latest/download/eza_x86_64-unknown-linux-musl.tar.gz'; then
     tar -xzf /tmp/eza.tar.gz -C ~/.local/bin
     chmod +x ~/.local/bin/eza

--- a/sdata/lib/uninstall.sh
+++ b/sdata/lib/uninstall.sh
@@ -670,6 +670,284 @@ uninstall_show_manual_steps() {
     fi
 }
 
+###############################################################################
+# Clean uninstall - Remove all packages, repos, and user-installed files
+###############################################################################
+
+# All packages installed by iNiR on Fedora (mirrors install-deps.sh arrays)
+INIR_FEDORA_PKGS=(
+    # Core
+    quickshell niri sddm
+    # Build tools
+    gcc gcc-c++ make meson ninja-build cmake pkg-config
+    python3-devel dbus-devel cairo-devel cairo-gobject-devel
+    gobject-introspection-devel gtk3-devel glib2-devel
+    # Utilities
+    bc coreutils curl wget ripgrep jq xdg-user-dirs rsync git unzip
+    wl-clipboard libnotify wlsunset dunst gum cliphist uv eza
+    # XDG portals
+    xdg-desktop-portal xdg-desktop-portal-gtk xdg-desktop-portal-gnome
+    # Polkit
+    polkit polkit-kde
+    # Network
+    NetworkManager nm-connection-editor gnome-keyring
+    # File manager
+    nautilus
+    # Terminal
+    kitty fish
+    # X11 compat
+    xwayland-satellite
+    # Thumbnails
+    ffmpegthumbnailer tumbler
+    # Translation
+    translate-shell
+    # Qt6
+    qt6-qtbase qt6-qtdeclarative qt6-qtsvg qt6-qtwayland
+    qt6-qt5compat qt6-qtmultimedia qt6-qtimageformats
+    qt6-qtvirtualkeyboard qt6-qtpositioning qt6-qtsensors qt6-qttools
+    qt6ct
+    # System libs
+    jemalloc libxcb libdrm mesa-dri-drivers
+    # KDE integration
+    kf6-kirigami kdialog kf6-syntax-highlighting kf6-kconfig
+    kde-gtk-config breeze-gtk kvantum
+    # Audio
+    pipewire pipewire-pulseaudio pipewire-alsa wireplumber
+    playerctl plasma-browser-integration libdbusmenu-gtk3
+    pavucontrol cava easyeffects lsp-plugins-lv2 mpv yt-dlp socat
+    # Toolkit
+    upower wtype ydotool python3-evdev python3-pillow
+    brightnessctl ddcutil geoclue2 swayidle swaylock grim slurp
+    hyprpicker ImageMagick qalculate blueman fprintd
+    # Screen capture
+    swappy wf-recorder
+    # OCR
+    tesseract tesseract-langpack-eng tesseract-langpack-spa
+    tesseract-langpack-rus tesseract-langpack-jpn tesseract-langpack-jpn_vert
+    tesseract-langpack-chi_sim tesseract-langpack-chi_sim_vert
+    tesseract-langpack-chi_tra tesseract-langpack-chi_tra_vert
+    # Fonts
+    fontconfig dejavu-fonts-all liberation-fonts
+    google-noto-emoji-fonts jetbrains-mono-fonts-all
+    # GTK theme
+    adw-gtk3-theme
+)
+
+# COPRs enabled by iNiR
+INIR_FEDORA_COPRS=(
+    "errornointernet/quickshell"
+    "yalter/niri"
+    "scottames/awww"
+    "achno/gowall"
+)
+
+# Binaries installed to /usr/local/bin by iNiR
+INIR_LOCAL_BINS=(
+    awww awww-daemon gowall hyprpicker missioncenter songrec
+)
+
+# User-installed fonts
+INIR_FONT_NAMES=(
+    MaterialSymbolsRounded MaterialSymbolsOutlined
+    JetBrainsMono Geist SpaceGrotesk Rubik
+)
+
+# User-installed icon/cursor themes
+INIR_THEME_DIRS=(
+    WhiteSur WhiteSur-dark WhiteSur-light
+    MacTahoe
+    Bibata-Modern-Classic Bibata-Modern-Ice
+)
+
+# Remove iNiR-installed packages (Fedora)
+uninstall_remove_packages_fedora() {
+    tui_subtitle "Removing installed packages"
+
+    # Filter to only packages that are actually installed
+    local installed_pkgs=()
+    for pkg in "${INIR_FEDORA_PKGS[@]}"; do
+        if rpm -q "$pkg" &>/dev/null; then
+            installed_pkgs+=("$pkg")
+        fi
+    done
+
+    if [[ ${#installed_pkgs[@]} -eq 0 ]]; then
+        log_info "No iNiR packages to remove"
+        return 0
+    fi
+
+    log_info "Removing ${#installed_pkgs[@]} packages..."
+    if sudo dnf remove -y "${installed_pkgs[@]}" 2>/dev/null; then
+        log_success "Packages removed"
+    else
+        log_warning "Some packages could not be removed (may have dependencies)"
+        log_info "Run 'sudo dnf remove <package>' manually for individual packages"
+    fi
+}
+
+# Disable COPR repos
+uninstall_remove_repos_fedora() {
+    tui_subtitle "Disabling COPR repositories"
+
+    for copr in "${INIR_FEDORA_COPRS[@]}"; do
+        if dnf copr list --enabled 2>/dev/null | grep -q "$copr"; then
+            sudo dnf copr disable -y "$copr" >/dev/null 2>&1 && \
+                log_success "Disabled $copr" || \
+                log_warning "Could not disable $copr"
+        fi
+    done
+}
+
+# Remove binaries installed to /usr/local/bin
+uninstall_remove_local_bins() {
+    tui_subtitle "Removing binaries from /usr/local/bin"
+
+    for bin in "${INIR_LOCAL_BINS[@]}"; do
+        if [[ -f "/usr/local/bin/$bin" ]]; then
+            sudo rm -f "/usr/local/bin/$bin" && \
+                log_success "Removed /usr/local/bin/$bin" || \
+                log_warning "Could not remove /usr/local/bin/$bin"
+        fi
+    done
+}
+
+# Remove user-installed fonts
+uninstall_remove_user_fonts() {
+    tui_subtitle "Removing installed fonts"
+
+    local font_dir="$HOME/.local/share/fonts"
+    for font in "${INIR_FONT_NAMES[@]}"; do
+        # Handle different file extensions
+        for ext in ttf otf zip; do
+            if [[ -f "$font_dir/${font}.${ext}" ]]; then
+                rm -f "$font_dir/${font}.${ext}" && \
+                    log_success "Removed ${font}.${ext}"
+            fi
+        done
+    done
+
+    # Refresh font cache
+    fc-cache -f "$font_dir" 2>/dev/null || true
+}
+
+# Remove user-installed icon/cursor themes
+uninstall_remove_user_themes() {
+    tui_subtitle "Removing installed themes"
+
+    local icon_dir="$HOME/.local/share/icons"
+    for theme in "${INIR_THEME_DIRS[@]}"; do
+        if [[ -d "$icon_dir/$theme" ]]; then
+            rm -rf "$icon_dir/$theme" && \
+                log_success "Removed $theme icon theme"
+        fi
+    done
+}
+
+# Run full clean uninstall
+uninstall_clean() {
+    echo ""
+    tui_title "iNiR Clean Uninstall"
+    echo ""
+
+    echo -e "${STY_RED}${STY_BOLD}⚠ WARNING: CLEAN UNINSTALL${STY_RST}"
+    echo ""
+    echo "This will remove ALL packages, repositories, and files installed by iNiR."
+    echo ""
+    echo -e "${STY_YELLOW}Packages to remove:${STY_RST} ${#INIR_FEDORA_PKGS[@]} packages"
+    echo -e "${STY_YELLOW}COPRs to disable:${STY_RST} ${#INIR_FEDORA_COPRS[@]} repositories"
+    echo -e "${STY_YELLOW}Binaries to remove:${STY_RST} ${#INIR_LOCAL_BINS[@]} from /usr/local/bin"
+    echo -e "${STY_YELLOW}Fonts to remove:${STY_RST} ${#INIR_FONT_NAMES[@]} user fonts"
+    echo -e "${STY_YELLOW}Themes to remove:${STY_RST} ${#INIR_THEME_DIRS[@]} icon/cursor themes"
+    echo ""
+
+    if [[ ${#warnings[@]} -gt 0 ]]; then
+        echo -e "${STY_YELLOW}Important notices:${STY_RST}"
+        for warn in "${warnings[@]}"; do
+            echo -e "  ${STY_YELLOW}•${STY_RST} $warn"
+        done
+        echo ""
+    fi
+
+    if $ask; then
+        if ! tui_confirm "Continue with clean uninstall?" "no"; then
+            echo "Cancelled."
+            return 0
+        fi
+    else
+        echo -e "${STY_CYAN}Non-interactive mode: proceeding with clean uninstall...${STY_RST}"
+    fi
+
+    echo ""
+    tui_divider
+    echo ""
+
+    # Create backup first
+    local backup_dir
+    backup_dir=$(uninstall_create_backup)
+
+    # Stop services
+    uninstall_stop_services
+
+    # Remove iNiR-exclusive files
+    uninstall_remove_inir_only
+    uninstall_reload_user_systemd
+
+    # Handle shared configs
+    uninstall_handle_shared_configs
+
+    # Handle quickshell shared resources
+    uninstall_handle_quickshell_shared
+
+    # Clean uninstall additions
+    local distro="${OS_GROUP_ID:-unknown}"
+    [[ -z "$distro" || "$distro" == "unknown" ]] && detect_distro 2>/dev/null
+
+    case "$distro" in
+        fedora)
+            uninstall_remove_packages_fedora
+            uninstall_remove_repos_fedora
+            ;;
+        arch)
+            log_warning "Arch package removal not yet implemented"
+            log_info "Run 'yay -R <package>' to remove packages manually"
+            ;;
+        *)
+            log_warning "Package removal not supported for $distro"
+            log_info "Remove packages using your package manager"
+            ;;
+    esac
+
+    uninstall_remove_local_bins
+    uninstall_remove_user_fonts
+    uninstall_remove_user_themes
+
+    # Final message
+    echo ""
+    tui_divider
+    echo ""
+
+    printf "${STY_GREEN}${STY_BOLD}"
+    cat << 'EOF'
+╔══════════════════════════════════════════════════════════════╗
+║                                                              ║
+║                  ✓ Clean Uninstall Complete                  ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+EOF
+    printf "${STY_RST}"
+    echo ""
+
+    echo -e "${STY_CYAN}Backup saved to:${STY_RST}"
+    echo -e "  $backup_dir"
+    echo ""
+    echo -e "${STY_FAINT}To restore from backup:${STY_RST}"
+    echo -e "  cp -r $backup_dir/quickshell-inir ${XDG_CONFIG_HOME}/quickshell/inir"
+    echo ""
+    echo -e "${STY_FAINT}To reinstall iNiR:${STY_RST}"
+    echo -e "  git clone https://github.com/snowarch/inir.git && cd inir && ./setup install"
+    echo ""
+}
+
 uninstall_show_packages() {
     echo ""
     tui_subtitle "Installed packages"

--- a/sdata/lib/uninstall.sh
+++ b/sdata/lib/uninstall.sh
@@ -860,6 +860,17 @@ uninstall_clean() {
     echo -e "${STY_YELLOW}Themes to remove:${STY_RST} ${#INIR_THEME_DIRS[@]} icon/cursor themes"
     echo ""
 
+    # Check for critical conditions
+    local warnings=()
+    
+    if is_running_niri_session; then
+        warnings+=("You are currently running a Niri session")
+    fi
+    
+    if has_other_quickshell_configs; then
+        warnings+=("Other Quickshell configurations detected")
+    fi
+
     if [[ ${#warnings[@]} -gt 0 ]]; then
         echo -e "${STY_YELLOW}Important notices:${STY_RST}"
         for warn in "${warnings[@]}"; do

--- a/setup
+++ b/setup
@@ -3008,7 +3008,20 @@ case "$COMMAND" in
     doctor) run_doctor ;;
     rollback) run_rollback ;;
     my-changes) run_my_changes ;;
-    uninstall) run_uninstall ;;
+    uninstall)
+        for _arg in "${SUBCMD_ARGS[@]}"; do
+            case "$_arg" in
+                -y|--yes) ask=false ;;
+                -q|--quiet) quiet=true ;;
+                --clean) UNINSTALL_CLEAN=true ;;
+            esac
+        done
+        if [[ "${UNINSTALL_CLEAN:-false}" == "true" ]]; then
+            uninstall_clean
+        else
+            run_uninstall
+        fi
+        ;;
     status) show_status ;;
     config) run_config ;;
     theme) run_theme ;;


### PR DESCRIPTION
## Changes

### Fedora Install Hang Fix
- Add batch package availability check (`dnf_pkgs_available_batch`) using repoquery instead of per-package dnf calls
- Refresh package metadata cache before availability check
- Add `--connect-timeout` and `--max-time` to all curl calls to prevent indefinite hangs on network issues

### Setup Verbosity Levels
- Add verbosity level system to setup scripts (0=quiet, 1=normal, 2=verbose)
- Update README with documentation for new verbosity features

## Problem
Running `./setup install -y` would hang indefinitely at:
1. "Installing packages from repositories..." - caused by slow per-package dnf availability checks
2. After hyprpicker installation - caused by curl calls without timeouts

## Solution
- Replaced per-package `dnf -q list` calls with a single batch `dnf repoquery` query
- Added `dnf makecache` before availability checks
- Added timeouts (10s connect, 30-120s max) to all curl calls